### PR TITLE
Add Linux SDK & cross compilation support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     # We want to run on external PRs, but not on our own internal PRs as they'll be run by the push
     # to the branch.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    env:
+      DISPLAY: ':99.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,6 +27,8 @@ jobs:
           AGREE: true
       - name: x86_64-linux -> x86_64-windows
         run: zig build test -Dtarget=x86_64-windows
+      - name: launch xvfb
+        run: Xvfb :99 -screen 0 1680x720x24 > /dev/null 2>&1 &
       - name: mach::test
         run: |
           sudo add-apt-repository -y ppa:kisak/kisak-mesa

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,14 @@ jobs:
           AGREE: true
       - name: x86_64-linux -> x86_64-windows
         run: zig build test -Dtarget=x86_64-windows
-      - name: mach::test (xvfb)
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: zig build test
-      - name: webgpu::test (xvfb)
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: cd webgpu && zig build test
+      - name: mach::test
+        run: |
+          sudo add-apt-repository -y ppa:kisak/kisak-mesa
+          sudo apt-get update
+          sudo apt-get install mesa-utils mesa-utils-extra mesa-va-drivers mesa-vdpau-drivers mesa-vulkan-drivers xvfb
+          zig build test
+      - name: webgpu::test
+        run: cd webgpu && zig build test
   x86_64-windows:
     runs-on: windows-latest
     # We want to run on external PRs, but not on our own internal PRs as they'll be run by the push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,8 @@ jobs:
           AGREE: true
       - name: x86_64-linux -> x86_64-windows
         run: zig build test -Dtarget=x86_64-windows
-      # Disabled for now, see https://github.com/hexops/mach/issues/4
-      # - name: mach::test
-      #   run: zig build test
+      - name: mach::test
+        run: zig build test
       - name: webgpu::test
         run: cd webgpu && zig build test
   x86_64-windows:
@@ -58,6 +57,8 @@ jobs:
         run: zig build install -Dtarget=aarch64-macos
         env:
           AGREE: true
+      - name: x86_64-windows -> x86_64-linux
+        run: zig build test -Dtarget=x86_64-linux
       - name: mach::test
         run: zig build test
       - name: webgpu::test
@@ -84,5 +85,7 @@ jobs:
           AGREE: true
       - name: x86_64-macos -> x86_64-windows
         run: zig build test -Dtarget=x86_64-windows
+      - name: x86_64-macos -> x86_64-linux
+        run: zig build test -Dtarget=x86_64-linux
       - name: webgpu::test
         run: cd webgpu && zig build test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,14 @@ jobs:
           AGREE: true
       - name: x86_64-linux -> x86_64-windows
         run: zig build test -Dtarget=x86_64-windows
-      - name: mach::test
-        run: zig build test
-      - name: webgpu::test
-        run: cd webgpu && zig build test
+      - name: mach::test (xvfb)
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: zig build test
+      - name: webgpu::test (xvfb)
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: cd webgpu && zig build test
   x86_64-windows:
     runs-on: windows-latest
     # We want to run on external PRs, but not on our own internal PRs as they'll be run by the push

--- a/.github/workflows/m1_ci.yml
+++ b/.github/workflows/m1_ci.yml
@@ -29,5 +29,7 @@ jobs:
           AGREE: true
       - name: aarch64-macos -> x86_64-windows
         run: zig build test -Dtarget=x86_64-windows
+      - name: aarch64-macos -> x86_64-linux
+        run: zig build test -Dtarget=x86_64-linux
       - name: webgpu::test
         run: cd webgpu && zig build test


### PR DESCRIPTION
Adds full cross compilation support, via a small Linux SDK (~27M) that is `git clone`d in `build.zig`:

https://github.com/hexops/sdk-linux-x86_64

Enables cross compilation from any OS to Linux, and removes the need to install any dependencies other than `zig` and `git` to build on Linux.