### PR TITLE
fix key.press being set to release

### DIFF
--- a/glfw/src/action.zig
+++ b/glfw/src/action.zig
@@ -6,7 +6,7 @@ const c = @import("c.zig").c;
 pub const release = c.GLFW_RELEASE;
 
 /// The key or mouse button was pressed.
-pub const press = c.GLFW_RELEASE;
+pub const press = c.GLFW_PRESS;
 
 /// The key was held down until it repeated.
 pub const repeat = c.GLFW_REPEAT;


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

A very minor fix to correct ``key.press`` being set to ``GLFW_RELEASE``  instead of ``GLFW_PRESS``