### PR TITLE
glfw: fix getWindowPos

### DIFF
--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -366,8 +366,8 @@ pub inline fn setIcon(self: Window, allocator: *mem.Allocator, images: ?[]Image)
 }
 
 const Pos = struct {
-    x: usize,
-    y: usize,
+    x: isize,
+    y: isize,
 };
 
 /// Retrieves the position of the content area of the specified window.
@@ -388,7 +388,7 @@ pub inline fn getPos(self: Window) Error!Pos {
     var y: c_int = 0;
     c.glfwGetWindowPos(self.handle, &x, &y);
     try getError();
-    return Pos{ .x = @intCast(usize, x), .y = @intCast(usize, y) };
+    return Pos{ .x = @intCast(isize, x), .y = @intCast(isize, y) };
 }
 
 /// Sets the position of the content area of the specified window.


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

getWindowPos can return negative numbers on mac because (0, 0) is relative to the main screen

![image](https://user-images.githubusercontent.com/6010774/137972374-2cbbb189-66d7-491c-a465-385317addbba.png)