### PR TITLE
glfw: do not set sysroot (prevents linking libs not in our system SDKs)

### DIFF
--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -216,10 +216,13 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
                 step.linkFramework("OpenGL");
             }
 
+            // These are dependencies of the above frameworks, but are not properly picked by zld
+            // when cross-compiling Windows/Linux -> MacOS unless linked explicitly here.
             step.linkFramework("CoreGraphics");
             step.linkFramework("CoreServices");
-            step.linkFramework("ObjC");
             step.linkFramework("AppKit");
+            step.linkFramework("Foundation");
+            step.linkSystemLibrary("objc");
         },
         else => {
             // Assume Linux-like


### PR DESCRIPTION
Fixes hexops/mach#40

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.