### PR TITLE
update to Zig nightly 1444+e2a2e6c14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Zig
         run: |
           sudo apt install xz-utils
-          sudo sh -c 'wget -c https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.959+f011f1393.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.1444+e2a2e6c14.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: x86_64-linux -> x86_64-macos
         run: cd ${{ matrix.project }} && zig build test -Dtarget=x86_64-macos
         env:
@@ -53,10 +53,10 @@ jobs:
         run: choco install git
       - name: Setup Zig
         run: |
-          Invoke-WebRequest -Uri "https://ziglang.org/builds/zig-windows-x86_64-0.9.0-dev.959+f011f1393.zip" -OutFile "C:\zig.zip"
+          Invoke-WebRequest -Uri "https://ziglang.org/builds/zig-windows-x86_64-0.9.0-dev.1444+e2a2e6c14.zip" -OutFile "C:\zig.zip"
           cd C:\
           7z x zig.zip
-          Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.9.0-dev.959+f011f1393\"
+          Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.9.0-dev.1444+e2a2e6c14\"
       - name: x86_64-windows -> x86_64-macos
         run: cd ${{ matrix.project }} && zig build test -Dtarget=x86_64-macos
         env:
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Zig
         run: |
           brew install xz
-          sudo sh -c 'wget -c https://ziglang.org/builds/zig-macos-x86_64-0.9.0-dev.959+f011f1393.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-macos-x86_64-0.9.0-dev.1444+e2a2e6c14.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: test
         run: cd ${{ matrix.project }} && zig build test
         env:

--- a/glfw/.github/workflows/ci.yml
+++ b/glfw/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Zig
         run: |
           sudo apt install xz-utils
-          sudo sh -c 'wget -c https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.959+f011f1393.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.1444+e2a2e6c14.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: x86_64-linux -> x86_64-macos
         run: zig build test -Dtarget=x86_64-macos
         env:
@@ -47,10 +47,10 @@ jobs:
         run: choco install git
       - name: Setup Zig
         run: |
-          Invoke-WebRequest -Uri "https://ziglang.org/builds/zig-windows-x86_64-0.9.0-dev.959+f011f1393.zip" -OutFile "C:\zig.zip"
+          Invoke-WebRequest -Uri "https://ziglang.org/builds/zig-windows-x86_64-0.9.0-dev.1444+e2a2e6c14.zip" -OutFile "C:\zig.zip"
           cd C:\
           7z x zig.zip
-          Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.9.0-dev.959+f011f1393\"
+          Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.9.0-dev.1444+e2a2e6c14\"
       - name: x86_64-windows -> x86_64-macos
         run: zig build test -Dtarget=x86_64-macos
         env:
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Zig
         run: |
           brew install xz
-          sudo sh -c 'wget -c https://ziglang.org/builds/zig-macos-x86_64-0.9.0-dev.959+f011f1393.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-macos-x86_64-0.9.0-dev.1444+e2a2e6c14.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: test
         run: zig build test
         env:

--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -217,12 +217,17 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
             }
 
             // These are dependencies of the above frameworks, but are not properly picked by zld
-            // when cross-compiling Windows/Linux -> MacOS unless linked explicitly here.
-            step.linkFramework("CoreGraphics");
-            step.linkFramework("CoreServices");
-            step.linkFramework("AppKit");
-            step.linkFramework("Foundation");
-            step.linkSystemLibrary("objc");
+            // when cross-compiling Windows/Linux -> MacOS, or on MacOS (no XCode) with `zig build test -Dtarget=aarch64-macos`
+            // unless linked explicitly here.
+            //
+            // If b.sysroot is set, however, these must NOT be specified. This is a bug in zld.
+            if (b.sysroot == null) {
+                step.linkFramework("CoreGraphics");
+                step.linkFramework("CoreServices");
+                step.linkFramework("AppKit");
+                step.linkFramework("Foundation");
+                step.linkSystemLibrary("objc");
+            }
         },
         else => {
             // Assume Linux-like


### PR DESCRIPTION
Brings us up-to-date with latest Zig and works around an issue. Introduces #48

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.