### PR TITLE
glfw: make glfw.getProcAddress conform to GLFW C ABI 

### DIFF
--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -104,7 +104,7 @@ pub const VKProc = fn () callconv(.C) void;
 /// @thread_safety This function may be called from any thread.
 pub fn getInstanceProcAddress(vk_instance: ?*opaque {}, proc_name: [*c]const u8) callconv(.C) ?VKProc {
     const proc_address = c.glfwGetInstanceProcAddress(if (vk_instance) |v| @ptrCast(c.VkInstance, v) else null, proc_name);
-    getError() catch @panic("glfw.getInstanceProcAddress failed, not initialized or Vulkan API unavailable");
+    getError() catch |err| @panic(@errorName(err));
     if (proc_address) |addr| return addr;
     return null;
 }


### PR DESCRIPTION
Having `glfw.getProcAddress` conform to the GLFW C ABI is important as it is often
likely to be passed into libraries which expect exactly that ABI for OpenGL function
loading.

Fixes #52

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.