### PR TITLE
glfw: ziggify all Action enums

### DIFF
--- a/glfw/src/Joystick.zig
+++ b/glfw/src/Joystick.zig
@@ -42,7 +42,7 @@ pub const last = c.GLFW_JOYSTICK_LAST;
 ///
 /// see also: gamepad, glfwGetGamepadState
 const GamepadState = extern struct {
-    /// The states of each gamepad button (see gamepad_buttons), `glfw.press` or `glfw.release`.
+    /// The states of each gamepad button (see gamepad_buttons), `glfw.Action.press` or `glfw.Action.release`.
     buttons: [15]u8,
 
     /// The states of each gamepad axis (see gamepad_axes), in the range -1.0 to 1.0 inclusive.
@@ -100,7 +100,7 @@ pub inline fn getAxes(self: Joystick) Error!?[]const f32 {
 /// Returns the state of all buttons of the specified joystick.
 ///
 /// This function returns the state of all buttons of the specified joystick. Each element in the
-/// array is either `glfw.press` or `glfw.release`.
+/// array is either `glfw.Action.press` or `glfw.Action.release`.
 ///
 /// For backward compatibility with earlier versions that did not have glfw.Joystick.getHats, the
 /// button array also includes all hats, each represented as four buttons. The hats are in the same
@@ -396,7 +396,7 @@ pub inline fn getGamepadName(self: Joystick) Error!?[*c]const u8 {
 /// Steam client.
 ///
 /// Not all devices have all the buttons or axes provided by GamepadState. Unavailable buttons
-/// and axes will always report `glfw.release` and 0.0 respectively.
+/// and axes will always report `glfw.Action.release` and 0.0 respectively.
 ///
 /// @param[in] jid The joystick (see joysticks) to query.
 /// @param[out] state The gamepad input state of the joystick.

--- a/glfw/src/action.zig
+++ b/glfw/src/action.zig
@@ -2,11 +2,14 @@
 
 const c = @import("c.zig").c;
 
-/// The key or mouse button was released.
-pub const release = c.GLFW_RELEASE;
+/// Holds all GLFW C action enumerations in their raw form.
+pub const Action = enum(c_int) {
+    /// The key or mouse button was released.
+    release = c.GLFW_RELEASE,
 
-/// The key or mouse button was pressed.
-pub const press = c.GLFW_PRESS;
+    /// The key or mouse button was pressed.
+    press = c.GLFW_PRESS,
 
-/// The key was held down until it repeated.
-pub const repeat = c.GLFW_REPEAT;
+    /// The key was held down until it repeated.
+    repeat = c.GLFW_REPEAT,
+};

--- a/glfw/src/key.zig
+++ b/glfw/src/key.zig
@@ -23,10 +23,10 @@ const getError = @import("errors.zig").getError;
 /// enum containing all glfw keys
 pub const Key = enum(c_int) {
     /// The unknown key
-    unknown = cc.GLFW_KEY_UNKNOWN, 
+    unknown = cc.GLFW_KEY_UNKNOWN,
 
     /// Printable keys
-    space = cc.GLFW_KEY_SPACE, 
+    space = cc.GLFW_KEY_SPACE,
     apostrophe = cc.GLFW_KEY_APOSTROPHE,
     comma = cc.GLFW_KEY_COMMA,
     minus = cc.GLFW_KEY_MINUS,
@@ -78,7 +78,7 @@ pub const Key = enum(c_int) {
     world_2 = cc.GLFW_KEY_WORLD_2, // non-US #2
 
     // Function keys
-    escape = cc.GLFW_KEY_ESCAPE, 
+    escape = cc.GLFW_KEY_ESCAPE,
     enter = cc.GLFW_KEY_ENTER,
     tab = cc.GLFW_KEY_TAB,
     backspace = cc.GLFW_KEY_BACKSPACE,
@@ -153,7 +153,6 @@ pub const Key = enum(c_int) {
         return @intToEnum(Key, cc.GLFW_KEY_LAST);
     }
 
-    
     /// Returns the layout-specific name of the specified printable key.
     ///
     /// This function returns the name of the specified printable key, encoded as UTF-8. This is
@@ -238,9 +237,8 @@ pub const Key = enum(c_int) {
     }
 };
 
-
 test "getName" {
-    const glfw = @import("main.zig");  
+    const glfw = @import("main.zig");
     try glfw.init();
     defer glfw.terminate();
 

--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -9,7 +9,7 @@ pub usingnamespace @import("consts.zig");
 pub const Error = @import("errors.zig").Error;
 const getError = @import("errors.zig").getError;
 
-pub const action = @import("action.zig");
+pub const Action = @import("action.zig").Action;
 pub const gamepad_axis = @import("gamepad_axis.zig");
 pub const gamepad_button = @import("gamepad_button.zig");
 pub const GammaRamp = @import("GammaRamp.zig");

--- a/glfw/src/mod.zig
+++ b/glfw/src/mod.zig
@@ -7,7 +7,7 @@ const c = @import("c.zig").c;
 // must be in sync with https://www.glfw.org/docs/3.3/group__mods.html
 /// A bitmask of all key modifiers
 pub const Mods = packed struct {
-    shift: bool align(@alignOf(c_int)) = false, 
+    shift: bool align(@alignOf(c_int)) = false,
     control: bool = false,
     alt: bool = false,
     super: bool = false,
@@ -34,7 +34,7 @@ pub const Mods = packed struct {
     }
 };
 
-/// Hold all glfw values as is
+/// Holds all GLFW mod values in their raw form.
 pub const RawMods = struct {
     /// If this bit is set one or more Shift keys were held down.
     pub const shift = c.GLFW_MOD_SHIFT;
@@ -54,7 +54,6 @@ pub const RawMods = struct {
     /// If this bit is set the Num Lock key is enabled and the glfw.lock_key_mods input mode is set.
     pub const num_lock = c.GLFW_MOD_NUM_LOCK;
 };
-
 
 test "shift int to bitmask" {
     const std = @import("std");
@@ -112,13 +111,12 @@ test "num lock int to bitmask" {
     std.testing.expect(mod.num_lock == true);
 }
 
-
 test "all int to bitmask" {
     const std = @import("std");
 
-    const int_mod = RawMods.shift | RawMods.control | 
-                    RawMods.alt | RawMods.super | 
-                    RawMods.caps_lock | RawMods.num_lock;
+    const int_mod = RawMods.shift | RawMods.control |
+        RawMods.alt | RawMods.super |
+        RawMods.caps_lock | RawMods.num_lock;
     const mod = Mods.fromInt(int_mod);
 
     std.testing.expect(mod.shift == true);
@@ -150,7 +148,7 @@ test "shift and alt bitmask to int" {
 test "all bitmask to int" {
     const std = @import("std");
 
-    const mod = Mods{ 
+    const mod = Mods{
         .shift = true,
         .control = true,
         .alt = true,
@@ -160,9 +158,9 @@ test "all bitmask to int" {
     };
     const int_mod = mod.toInt(c_int);
 
-    const expected = RawMods.shift | RawMods.control | 
-                    RawMods.alt | RawMods.super | 
-                    RawMods.caps_lock | RawMods.num_lock;
+    const expected = RawMods.shift | RawMods.control |
+        RawMods.alt | RawMods.super |
+        RawMods.caps_lock | RawMods.num_lock;
 
     std.testing.expectEqual(int_mod, expected);
 }


### PR DESCRIPTION
Make the GLFW action enumerations proper Zig enums so one can use `.Name` syntax, etc.

Helps #37

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.