### PR TITLE
glfw: fix linking difference between sysroot and non-sysroot

### DIFF
--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -218,6 +218,16 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
             }
             step.linkSystemLibrary("objc");
             step.linkFramework("AppKit");
+
+            // TODO(system_sdk): update MacOS system SDK so we can remove this, see:
+            // https://github.com/hexops/mach/pull/63#issuecomment-962141088
+            switch (std.Target.current.os.tag) {
+                .macos => {},
+                else => {
+                    step.linkFramework("CoreGraphics");
+                    step.linkFramework("Foundation");
+                },
+            };
         },
         else => {
             // Assume Linux-like

--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -224,6 +224,7 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
             switch (@import("builtin").target.os.tag) {
                 .macos => {},
                 else => {
+                    step.linkFramework("CoreServices");
                     step.linkFramework("CoreGraphics");
                     step.linkFramework("Foundation");
                 },

--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -208,7 +208,6 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
             }
         },
         .macos => {
-            step.linkFramework("Cocoa");
             step.linkFramework("IOKit");
             step.linkFramework("CoreFoundation");
             if (options.metal) {
@@ -217,19 +216,8 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
             if (options.opengl) {
                 step.linkFramework("OpenGL");
             }
-
-            // These are dependencies of the above frameworks, but are not properly picked by zld
-            // when cross-compiling Windows/Linux -> MacOS, or on MacOS (no XCode) with `zig build test -Dtarget=aarch64-macos`
-            // unless linked explicitly here.
-            //
-            // If b.sysroot is set, however, these must NOT be specified. This is a bug in zld.
-            if (b.sysroot == null) {
-                step.linkFramework("CoreGraphics");
-                step.linkFramework("CoreServices");
-                step.linkFramework("AppKit");
-                step.linkFramework("Foundation");
-                step.linkSystemLibrary("objc");
-            }
+            step.linkSystemLibrary("objc");
+            step.linkFramework("AppKit");
         },
         else => {
             // Assume Linux-like
@@ -253,3 +241,4 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
         },
     }
 }
+

--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -221,13 +221,13 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
 
             // TODO(system_sdk): update MacOS system SDK so we can remove this, see:
             // https://github.com/hexops/mach/pull/63#issuecomment-962141088
-            switch (std.Target.current.os.tag) {
+            switch (@import("builtin").target.os.tag) {
                 .macos => {},
                 else => {
                     step.linkFramework("CoreGraphics");
                     step.linkFramework("Foundation");
                 },
-            };
+            }
         },
         else => {
             // Assume Linux-like


### PR DESCRIPTION
This effectively gives us the dependencies we need in any case, and works around ziglang/zig#10103

Importantly, this removes a blocker for landing WebGPU support in hexops/mach#62

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.