### PR TITLE
glfw: send pull requests to the main repository to avoid merge conflicts

### DIFF
--- a/glfw/README.md
+++ b/glfw/README.md
@@ -2,7 +2,7 @@
 
 Ziggified GLFW bindings that [Mach engine](https://github.com/hexops/mach) uses, with 100% API coverage, zero-fuss installation, cross compilation, and more.
 
-The [main Mach repository](https://github.com/hexops/mach) includes [this one](https://github.com/hexops/mach-glfw) as a `git subtree`. This is a separate repo so that anyone can use this library in their own project / engine if they like!
+This repository is a separate copy of the same library in the [main Mach repository](https://github.com/hexops/mach), and is automatically kept in sync, so that anyone can use this library in their own project / engine if they like!
 
 ## Zero fuss installation, cross compilation, and more
 
@@ -110,6 +110,6 @@ Issues are tracked in the [main Mach repository](https://github.com/hexops/mach/
 
 ## Contributing
 
-Contributions are very welcome. If possible, please send pull requests to [the main repository](https://github.com/hexops/mach/tree/main/glfw) and once merged the change will get sync'd here.
+Contributions are very welcome, but pull requests must be sent to [the main repository](https://github.com/hexops/mach/tree/main/glfw) to avoid some complex merge conflicts we'd get by accepting contributions in both repositories. Once the changes are merged there, they'll get sync'd to this repository automatically.
 
 We track the latest stable release of GLFW, if you need a newer version we can start a development branch / figure that out - just open an issue.


### PR DESCRIPTION
When changes are merged to both hexops/mach and hexops/mach-glfw, we get a conflict
which is difficult to resolve with `git subtree`, particularly because we don't want
to squash commits for either repository (we prefer to maintain the full commit history
in both repos.)

Instead, require that all pull requests be sent to the main hexops/mach repository.
That's not as nice, I admit, but should be pretty easy to handle (literally just copy
changes over) and will ensure we can always keep both repos in sync easily and without
conflict.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.