### PR TITLE
Friendlier GLFW API initialization

### DIFF
--- a/glfw/README.md
+++ b/glfw/README.md
@@ -67,7 +67,7 @@ Now in your code you may import and use GLFW:
 const glfw = @import("glfw");
 
 pub fn main() !void {
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     // Create our window

--- a/glfw/src/Cursor.zig
+++ b/glfw/src/Cursor.zig
@@ -104,7 +104,7 @@ test "create" {
     const allocator = testing.allocator;
 
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const image = try Image.init(allocator, 32, 32, 32 * 32 * 4);
@@ -119,7 +119,7 @@ test "create" {
 
 test "createStandard" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const cursor = glfw.Cursor.createStandard(.ibeam) catch |err| {

--- a/glfw/src/Joystick.zig
+++ b/glfw/src/Joystick.zig
@@ -446,7 +446,7 @@ pub inline fn getGamepadState(self: Joystick) Error!?GamepadState {
 
 test "present" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -456,7 +456,7 @@ test "present" {
 
 test "getAxes" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -466,7 +466,7 @@ test "getAxes" {
 
 test "getButtons" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -476,7 +476,7 @@ test "getButtons" {
 
 test "getHats" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -490,7 +490,7 @@ test "getHats" {
 
 test "getName" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -500,7 +500,7 @@ test "getName" {
 
 test "getGUID" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -510,7 +510,7 @@ test "getGUID" {
 
 test "setUserPointer_syntax" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -521,7 +521,7 @@ test "setUserPointer_syntax" {
 
 test "getUserPointer_syntax" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -532,7 +532,7 @@ test "getUserPointer_syntax" {
 
 test "setCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     glfw.Joystick.setCallback((struct {
@@ -550,7 +550,7 @@ test "updateGamepadMappings_syntax" {
 
 test "isGamepad" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -559,7 +559,7 @@ test "isGamepad" {
 
 test "getGamepadName" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };
@@ -568,7 +568,7 @@ test "getGamepadName" {
 
 test "getGamepadState" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = glfw.Joystick.one };

--- a/glfw/src/Monitor.zig
+++ b/glfw/src/Monitor.zig
@@ -403,7 +403,7 @@ pub inline fn setCallback(comptime Data: type, data: *Data, f: ?*const fn (monit
 
 test "getAll" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const allocator = testing.allocator;
@@ -413,7 +413,7 @@ test "getAll" {
 
 test "getPrimary" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = try getPrimary();
@@ -421,7 +421,7 @@ test "getPrimary" {
 
 test "getPos" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();
@@ -432,7 +432,7 @@ test "getPos" {
 
 test "getWorkarea" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();
@@ -443,7 +443,7 @@ test "getWorkarea" {
 
 test "getPhysicalSize" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();
@@ -454,7 +454,7 @@ test "getPhysicalSize" {
 
 test "getContentScale" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();
@@ -465,7 +465,7 @@ test "getContentScale" {
 
 test "getName" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();
@@ -476,7 +476,7 @@ test "getName" {
 
 test "userPointer" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();
@@ -492,7 +492,7 @@ test "userPointer" {
 
 test "setCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     var custom_data: u32 = 5;
@@ -507,7 +507,7 @@ test "setCallback" {
 
 test "getVideoModes" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();
@@ -520,7 +520,7 @@ test "getVideoModes" {
 
 test "getVideoMode" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();
@@ -532,7 +532,7 @@ test "getVideoMode" {
 test "set_getGammaRamp" {
     const allocator = testing.allocator;
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const monitor = try getPrimary();

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -2067,7 +2067,7 @@ pub inline fn setDropCallback(self: Window, callback: ?fn (window: Window, paths
 
 test "defaultHints" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     try defaultHints();
@@ -2075,7 +2075,7 @@ test "defaultHints" {
 
 test "hint comptime int" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     try hint(.focused, 1);
@@ -2084,7 +2084,7 @@ test "hint comptime int" {
 
 test "hint int" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     var focused: i32 = 1;
@@ -2095,7 +2095,7 @@ test "hint int" {
 
 test "hint bool" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     try hint(.focused, true);
@@ -2104,7 +2104,7 @@ test "hint bool" {
 
 test "hint enum(u1)" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const MyEnum = enum(u1) {
@@ -2118,7 +2118,7 @@ test "hint enum(u1)" {
 
 test "hint enum(i32)" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const MyEnum = enum(i32) {
@@ -2132,7 +2132,7 @@ test "hint enum(i32)" {
 
 test "hint array str" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const str_arr = [_]u8{ 'm', 'y', 'c', 'l', 'a', 's', 's' };
@@ -2143,7 +2143,7 @@ test "hint array str" {
 
 test "hint pointer str" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     try hint(.x11_class_name, "myclass");
@@ -2151,7 +2151,7 @@ test "hint pointer str" {
 
 test "createWindow" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2165,7 +2165,7 @@ test "createWindow" {
 
 test "setShouldClose" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2180,7 +2180,7 @@ test "setShouldClose" {
 
 test "setTitle" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2197,7 +2197,7 @@ test "setTitle" {
 test "setIcon" {
     const allocator = testing.allocator;
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2229,7 +2229,7 @@ test "setIcon" {
 
 test "getPos" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2245,7 +2245,7 @@ test "getPos" {
 
 test "setPos" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2261,7 +2261,7 @@ test "setPos" {
 
 test "getSize" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2277,7 +2277,7 @@ test "getSize" {
 
 test "setSize" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2293,7 +2293,7 @@ test "setSize" {
 
 test "setSizeLimits" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2312,7 +2312,7 @@ test "setSizeLimits" {
 
 test "setAspectRatio" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2328,7 +2328,7 @@ test "setAspectRatio" {
 
 test "getFramebufferSize" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2344,7 +2344,7 @@ test "getFramebufferSize" {
 
 test "getFrameSize" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2360,7 +2360,7 @@ test "getFrameSize" {
 
 test "getContentScale" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2376,7 +2376,7 @@ test "getContentScale" {
 
 test "getOpacity" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2392,7 +2392,7 @@ test "getOpacity" {
 
 test "iconify" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2408,7 +2408,7 @@ test "iconify" {
 
 test "restore" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2424,7 +2424,7 @@ test "restore" {
 
 test "maximize" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2440,7 +2440,7 @@ test "maximize" {
 
 test "show" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2456,7 +2456,7 @@ test "show" {
 
 test "hide" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2472,7 +2472,7 @@ test "hide" {
 
 test "focus" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2488,7 +2488,7 @@ test "focus" {
 
 test "requestAttention" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2504,7 +2504,7 @@ test "requestAttention" {
 
 test "swapBuffers" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2520,7 +2520,7 @@ test "swapBuffers" {
 
 test "getMonitor" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2536,7 +2536,7 @@ test "getMonitor" {
 
 test "setMonitor" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2552,7 +2552,7 @@ test "setMonitor" {
 
 test "getAttrib" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2568,7 +2568,7 @@ test "getAttrib" {
 
 test "setAttrib" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2584,7 +2584,7 @@ test "setAttrib" {
 
 test "setUserPointer" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2603,7 +2603,7 @@ test "setUserPointer" {
 
 test "getUserPointer" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2624,7 +2624,7 @@ test "getUserPointer" {
 
 test "setPosCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2646,7 +2646,7 @@ test "setPosCallback" {
 
 test "setSizeCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2668,7 +2668,7 @@ test "setSizeCallback" {
 
 test "setCloseCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2688,7 +2688,7 @@ test "setCloseCallback" {
 
 test "setRefreshCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2708,7 +2708,7 @@ test "setRefreshCallback" {
 
 test "setFocusCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2729,7 +2729,7 @@ test "setFocusCallback" {
 
 test "setIconifyCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2750,7 +2750,7 @@ test "setIconifyCallback" {
 
 test "setMaximizeCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2771,7 +2771,7 @@ test "setMaximizeCallback" {
 
 test "setFramebufferSizeCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2793,7 +2793,7 @@ test "setFramebufferSizeCallback" {
 
 test "setContentScaleCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2815,7 +2815,7 @@ test "setContentScaleCallback" {
 
 test "setDropCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2836,7 +2836,7 @@ test "setDropCallback" {
 
 test "getInputModeCursor" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2852,7 +2852,7 @@ test "getInputModeCursor" {
 
 test "setInputModeCursor" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2868,7 +2868,7 @@ test "setInputModeCursor" {
 
 test "getInputModeStickyKeys" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2884,7 +2884,7 @@ test "getInputModeStickyKeys" {
 
 test "setInputModeStickyKeys" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2900,7 +2900,7 @@ test "setInputModeStickyKeys" {
 
 test "getInputModeStickyMouseButtons" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2916,7 +2916,7 @@ test "getInputModeStickyMouseButtons" {
 
 test "setInputModeStickyMouseButtons" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2932,7 +2932,7 @@ test "setInputModeStickyMouseButtons" {
 
 test "getInputModeLockKeyMods" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2948,7 +2948,7 @@ test "getInputModeLockKeyMods" {
 
 test "setInputModeLockKeyMods" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2964,7 +2964,7 @@ test "setInputModeLockKeyMods" {
 
 test "getInputModeRawMouseMotion" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2980,7 +2980,7 @@ test "getInputModeRawMouseMotion" {
 
 test "setInputModeRawMouseMotion" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -2996,7 +2996,7 @@ test "setInputModeRawMouseMotion" {
 
 test "getInputMode" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3012,7 +3012,7 @@ test "getInputMode" {
 
 test "setInputMode" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3032,7 +3032,7 @@ test "setInputMode" {
 
 test "getKey" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3048,7 +3048,7 @@ test "getKey" {
 
 test "getMouseButton" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3064,7 +3064,7 @@ test "getMouseButton" {
 
 test "getCursorPos" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3080,7 +3080,7 @@ test "getCursorPos" {
 
 test "setCursorPos" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3096,7 +3096,7 @@ test "setCursorPos" {
 
 test "setCursor" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3118,7 +3118,7 @@ test "setCursor" {
 
 test "setKeyCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3142,7 +3142,7 @@ test "setKeyCallback" {
 
 test "setCharCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3163,7 +3163,7 @@ test "setCharCallback" {
 
 test "setMouseButtonCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3186,7 +3186,7 @@ test "setMouseButtonCallback" {
 
 test "setCursorPosCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3208,7 +3208,7 @@ test "setCursorPosCallback" {
 
 test "setCursorEnterCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -3229,7 +3229,7 @@ test "setCursorEnterCallback" {
 
 test "setScrollCallback" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {

--- a/glfw/src/clipboard.zig
+++ b/glfw/src/clipboard.zig
@@ -47,7 +47,7 @@ pub inline fn getClipboardString() Error![*c]const u8 {
 
 test "setClipboardString" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     try glfw.setClipboardString("hello mach");
@@ -55,7 +55,7 @@ test "setClipboardString" {
 
 test "getClipboardString" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = glfw.getClipboardString() catch |err| std.debug.print("can't get clipboard, not supported by OS? error={}\n", .{err});

--- a/glfw/src/key.zig
+++ b/glfw/src/key.zig
@@ -239,7 +239,7 @@ pub const Key = enum(c_int) {
 
 test "getName" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = glfw.Key.a.getName(0) catch |err| std.debug.print("failed to get key name, not supported? error={}\n", .{err});
@@ -247,7 +247,7 @@ test "getName" {
 
 test "getScancode" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = glfw.Key.a.getScancode() catch |err| std.debug.print("failed to get key scancode, not supported? error={}\n", .{err});

--- a/glfw/src/opengl.zig
+++ b/glfw/src/opengl.zig
@@ -168,7 +168,7 @@ pub inline fn getProcAddress(proc_name: [*c]const u8) ?GLProc {
 
 test "makeContextCurrent" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -184,7 +184,7 @@ test "makeContextCurrent" {
 
 test "getCurrentContext" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const current_context = glfw.getCurrentContext() catch |err| {
@@ -196,7 +196,7 @@ test "getCurrentContext" {
 
 test "swapInterval" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -213,7 +213,7 @@ test "swapInterval" {
 
 test "getProcAddress" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
@@ -230,7 +230,7 @@ test "getProcAddress" {
 
 test "extensionSupported" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {

--- a/glfw/src/time.zig
+++ b/glfw/src/time.zig
@@ -103,7 +103,7 @@ pub inline fn getTimerFrequency() u64 {
 
 test "getTime" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = getTime();
@@ -111,7 +111,7 @@ test "getTime" {
 
 test "setTime" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = try glfw.setTime(1234);
@@ -119,7 +119,7 @@ test "setTime" {
 
 test "getTimerValue" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = glfw.getTimerValue();
@@ -127,7 +127,7 @@ test "getTimerValue" {
 
 test "getTimerFrequency" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = glfw.getTimerFrequency();

--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -209,7 +209,7 @@ pub inline fn createWindowSurface(vk_instance: anytype, window: Window, vk_alloc
 
 test "vulkanSupported" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = try glfw.vulkanSupported();
@@ -217,7 +217,7 @@ test "vulkanSupported" {
 
 test "getRequiredInstanceExtensions" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     _ = glfw.getRequiredInstanceExtensions() catch |err| std.debug.print("failed to get vulkan instance extensions, error={}\n", .{err});
@@ -225,7 +225,7 @@ test "getRequiredInstanceExtensions" {
 
 test "getInstanceProcAddress" {
     const glfw = @import("main.zig");
-    try glfw.init();
+    try glfw.init(.{});
     defer glfw.terminate();
 
     // syntax check only, we don't have a real vulkan instance and so this function would panic.


### PR DESCRIPTION
Closes #66

What should be done with the original `InitHint` enum and `initHint` function could maybe be discussed. I didn't remove them, as they were useful for implementing the new interface, and make it so that new code behaves about the same way as old code which explicitly set all hints. They are also documentative, seeing as they more closely reflect the actual GLFW API than these changes. 

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.