### PR TITLE
glfw: remove [*c] pointers from api and return lengthed strings when possible

### DIFF
--- a/glfw/src/Joystick.zig
+++ b/glfw/src/Joystick.zig
@@ -217,10 +217,13 @@ pub inline fn getHats(self: Joystick) Error!?[]const Hat {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: joystick_name
-pub inline fn getName(self: Joystick) Error![*c]const u8 {
-    const name = c.glfwGetJoystickName(self.jid);
+pub inline fn getName(self: Joystick) Error!?[:0]const u8 {
+    const name_opt = c.glfwGetJoystickName(self.jid);
     try getError();
-    return name;
+    return if (name_opt) |name|
+        std.mem.span(name)
+    else
+        null;
 }
 
 /// Returns the SDL compatible GUID of the specified joystick.
@@ -250,10 +253,13 @@ pub inline fn getName(self: Joystick) Error![*c]const u8 {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: gamepad
-pub inline fn getGUID(self: Joystick) Error![*c]const u8 {
-    const guid = c.glfwGetJoystickGUID(self.jid);
+pub inline fn getGUID(self: Joystick) Error!?[:0]const u8 {
+    const guid_opt = c.glfwGetJoystickGUID(self.jid);
     try getError();
-    return guid;
+    return if (guid_opt) |guid|
+        std.mem.span(guid)
+    else
+        null;
 }
 
 /// Sets the user pointer of the specified joystick.
@@ -357,7 +363,7 @@ pub inline fn setCallback(callback: ?fn (joystick: Joystick, event: Event) void)
 ///
 ///
 /// @ingroup input
-pub inline fn updateGamepadMappings(gamepad_mappings: [*c]const u8) Error!void {
+pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) Error!void {
     _ = c.glfwUpdateGamepadMappings(gamepad_mappings);
     try getError();
 }
@@ -407,10 +413,13 @@ pub inline fn isGamepad(self: Joystick) bool {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: gamepad, glfw.Joystick.isGamepad
-pub inline fn getGamepadName(self: Joystick) Error!?[*c]const u8 {
-    const name = c.glfwGetGamepadName(self.jid);
+pub inline fn getGamepadName(self: Joystick) Error!?[:0]const u8 {
+    const name_opt = c.glfwGetGamepadName(self.jid);
     try getError();
-    return name;
+    return if (name_opt) |name|
+        std.mem.span(name)
+    else
+        null;
 }
 
 /// Retrieves the state of the joystick remapped as a gamepad.

--- a/glfw/src/Monitor.zig
+++ b/glfw/src/Monitor.zig
@@ -141,7 +141,7 @@ pub inline fn getContentScale(self: Monitor) Error!ContentScale {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_properties
-pub inline fn getName(self: Monitor) Error![*c]const u8 {
+pub inline fn getName(self: Monitor) Error![*:0]const u8 {
     const name = c.glfwGetMonitorName(self.handle);
     try getError();
     return name;

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -57,7 +57,7 @@ pub const InternalUserPointer = struct {
     setCursorPosCallback: ?fn (window: Window, xpos: f64, ypos: f64) void,
     setCursorEnterCallback: ?fn (window: Window, entered: bool) void,
     setScrollCallback: ?fn (window: Window, xoffset: f64, yoffset: f64) void,
-    setDropCallback: ?fn (window: Window, paths: [][*c]const u8) void,
+    setDropCallback: ?fn (window: Window, paths: [][*:0]const u8) void,
 };
 
 /// Resets all window hints to their default values.
@@ -397,7 +397,7 @@ pub const Hints = struct {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: window_creation, glfw.Window.destroy
-pub inline fn create(width: usize, height: usize, title: [*c]const u8, monitor: ?Monitor, share: ?Window, hints: Hints) Error!Window {
+pub inline fn create(width: usize, height: usize, title: [*:0]const u8, monitor: ?Monitor, share: ?Window, hints: Hints) Error!Window {
     try hints.set();
     defer defaultHints() catch unreachable; // this should be unreachable, being that this should be caught in the previous call to `Hints.set`.
 
@@ -488,7 +488,7 @@ pub inline fn setShouldClose(self: Window, value: bool) Error!void {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: window_title
-pub inline fn setTitle(self: Window, title: [*c]const u8) Error!void {
+pub inline fn setTitle(self: Window, title: [*:0]const u8) Error!void {
     c.glfwSetWindowTitle(self.handle, title);
 }
 
@@ -2050,7 +2050,7 @@ pub inline fn setScrollCallback(self: Window, callback: ?fn (window: Window, xof
 fn setDropCallbackWrapper(handle: ?*c.GLFWwindow, path_count: c_int, paths: [*c][*c]const u8) callconv(.C) void {
     const window = from(handle.?) catch unreachable;
     const internal = window.getInternal();
-    internal.setDropCallback.?(window, paths[0..@intCast(usize, path_count)]);
+    internal.setDropCallback.?(window, @ptrCast([*][*:0]const u8, paths)[0..@intCast(usize, path_count)]);
 }
 
 /// Sets the path drop callback.
@@ -2078,7 +2078,7 @@ fn setDropCallbackWrapper(handle: ?*c.GLFWwindow, path_count: c_int, paths: [*c]
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: path_drop
-pub inline fn setDropCallback(self: Window, callback: ?fn (window: Window, paths: [][*c]const u8) void) Error!void {
+pub inline fn setDropCallback(self: Window, callback: ?fn (window: Window, paths: [][*:0]const u8) void) Error!void {
     var internal = self.getInternal();
     internal.setDropCallback = callback;
     _ = c.glfwSetDropCallback(self.handle, if (callback != null) setDropCallbackWrapper else null);
@@ -2863,7 +2863,7 @@ test "setDropCallback" {
     defer window.destroy();
 
     window.setDropCallback((struct {
-        fn callback(_window: Window, paths: [][*c]const u8) void {
+        fn callback(_window: Window, paths: [][*:0]const u8) void {
             _ = _window;
             _ = paths;
         }

--- a/glfw/src/clipboard.zig
+++ b/glfw/src/clipboard.zig
@@ -17,7 +17,7 @@ const getError = @import("errors.zig").getError;
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: clipboard, glfwGetClipboardString
-pub inline fn setClipboardString(value: [*c]const u8) Error!void {
+pub inline fn setClipboardString(value: [*:0]const u8) Error!void {
     c.glfwSetClipboardString(null, value);
     try getError();
 }
@@ -28,7 +28,7 @@ pub inline fn setClipboardString(value: [*c]const u8) Error!void {
 /// a UTF-8 encoded string. If the clipboard is empty or if its contents cannot be converted,
 /// glfw.Error.FormatUnavailable is returned.
 ///
-/// @return The contents of the clipboard as a UTF-8 encoded string, or null if an error occurred.
+/// @return The contents of the clipboard as a UTF-8 encoded string.
 ///
 /// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
 ///
@@ -39,10 +39,10 @@ pub inline fn setClipboardString(value: [*c]const u8) Error!void {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: clipboard, glfwSetClipboardString
-pub inline fn getClipboardString() Error![*c]const u8 {
+pub inline fn getClipboardString() Error![:0]const u8 {
     const value = c.glfwGetClipboardString(null);
     try getError();
-    return value;
+    return std.mem.span(value);
 }
 
 test "setClipboardString" {

--- a/glfw/src/key.zig
+++ b/glfw/src/key.zig
@@ -212,10 +212,13 @@ pub const Key = enum(c_int) {
     /// @thread_safety This function must only be called from the main thread.
     ///
     /// see also: input_key_name
-    pub inline fn getName(self: Key, scancode: isize) Error![*c]const u8 {
-        const name = cc.glfwGetKeyName(@enumToInt(self), @intCast(c_int, scancode));
+    pub inline fn getName(self: Key, scancode: isize) Error!?[:0]const u8 {
+        const name_opt = cc.glfwGetKeyName(@enumToInt(self), @intCast(c_int, scancode));
         try getError();
-        return name;
+        return if (name_opt) |name|
+            std.mem.span(name)
+        else
+            null;
     }
 
     /// Returns the platform-specific scancode of the specified key.

--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -182,8 +182,8 @@ fn initHint(hint: InitHint, value: anytype) Error!void {
 /// @pointer_lifetime The returned string is static and compile-time generated.
 ///
 /// @thread_safety This function may be called from any thread.
-pub inline fn getVersionString() [*c]const u8 {
-    return c.glfwGetVersionString();
+pub inline fn getVersionString() [:0]const u8 {
+    return std.mem.span(c.glfwGetVersionString());
 }
 
 /// Processes all pending events.

--- a/glfw/src/opengl.zig
+++ b/glfw/src/opengl.zig
@@ -115,7 +115,7 @@ pub inline fn swapInterval(interval: isize) Error!void {
 /// @thread_safety This function may be called from any thread.
 ///
 /// see also: context_glext, glfw.getProcAddress
-pub inline fn extensionSupported(extension: [*c]const u8) Error!bool {
+pub inline fn extensionSupported(extension: [*:0]const u8) Error!bool {
     const supported = c.glfwExtensionSupported(extension);
     try getError();
     return supported == c.GLFW_TRUE;
@@ -159,7 +159,7 @@ pub const GLProc = fn () callconv(.C) void;
 /// @thread_safety This function may be called from any thread.
 ///
 /// see also: context_glext, glfwExtensionSupported
-pub inline fn getProcAddress(proc_name: [*c]const u8) ?GLProc {
+pub inline fn getProcAddress(proc_name: [*:0]const u8) ?GLProc {
     const proc_address = c.glfwGetProcAddress(proc_name);
     getError() catch |err| @panic(@errorName(err));
     if (proc_address) |addr| return addr;

--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -57,11 +57,11 @@ pub inline fn vulkanSupported() Error!bool {
 /// @thread_safety This function may be called from any thread.
 ///
 /// see also: vulkan_ext, glfwCreateWindowSurface
-pub inline fn getRequiredInstanceExtensions() Error![][*c]const u8 {
+pub inline fn getRequiredInstanceExtensions() Error![][*:0]const u8 {
     var count: u32 = 0;
     const extensions = c.glfwGetRequiredInstanceExtensions(&count);
     try getError();
-    return extensions[0..count];
+    return @ptrCast([*][*:0]const u8, extensions)[0..count];
 }
 
 /// Vulkan API function pointer type.
@@ -102,7 +102,7 @@ pub const VKProc = fn () callconv(.C) void;
 /// @pointer_lifetime The returned function pointer is valid until the library is terminated.
 ///
 /// @thread_safety This function may be called from any thread.
-pub fn getInstanceProcAddress(vk_instance: ?*opaque {}, proc_name: [*c]const u8) callconv(.C) ?VKProc {
+pub fn getInstanceProcAddress(vk_instance: ?*opaque {}, proc_name: [*:0]const u8) callconv(.C) ?VKProc {
     const proc_address = c.glfwGetInstanceProcAddress(if (vk_instance) |v| @ptrCast(c.VkInstance, v) else null, proc_name);
     getError() catch |err| @panic(@errorName(err));
     if (proc_address) |addr| return addr;


### PR DESCRIPTION
Just makes the API a bit nicer to use from Zig. According to the [Zig docs](https://ziglang.org/documentation/master/#toc-C-Pointers) `[*c]` pointers should be avoided, and should be replaced with more precise pointer types wherever possible

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.