### PR TITLE
glfw: Window hints rework

### DIFF
--- a/glfw/README.md
+++ b/glfw/README.md
@@ -71,7 +71,7 @@ pub fn main() !void {
     defer glfw.terminate();
 
     // Create our window
-    const window = try glfw.Window.create(640, 480, "Hello, mach-glfw!", null, null);
+    const window = try glfw.Window.create(640, 480, "Hello, mach-glfw!", null, null, .{});
     defer window.destroy();
 
     // Wait for the user to close the window.

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -97,7 +97,7 @@ pub const Hint = enum(c_int) {
     maximized = c.GLFW_MAXIMIZED,
 
     /// Cursor centering window hint
-    center = c.GLFW_CENTER_CURSOR,
+    center_cursor = c.GLFW_CENTER_CURSOR,
 
     /// Window framebuffer transparency hint
     transparent_framebuffer = c.GLFW_TRANSPARENT_FRAMEBUFFER,

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -78,7 +78,7 @@ pub const Hint = enum(c_int) {
     /// Input focus window hint.
     focused = c.GLFW_FOCUSED,
 
-    // Window resize-ability window hint
+    /// Window resize-ability window hint
     resizable = c.GLFW_RESIZABLE,
 
     /// Window visibility window hint
@@ -1048,7 +1048,7 @@ pub const Attrib = enum(c_int) {
     /// Window iconification window attribute.
     iconified = c.GLFW_ICONIFIED,
 
-    // Window resize-ability window attribute
+    /// Window resize-ability window attribute
     resizable = c.GLFW_RESIZABLE,
 
     /// Window visibility window attribute

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -510,7 +510,7 @@ pub inline fn setIcon(self: Window, allocator: *mem.Allocator, images: ?[]Image)
     try getError();
 }
 
-const Pos = struct {
+pub const Pos = struct {
     x: usize,
     y: usize,
 };
@@ -561,7 +561,7 @@ pub inline fn setPos(self: Window, pos: Pos) Error!void {
     try getError();
 }
 
-const Size = struct {
+pub const Size = struct {
     width: usize,
     height: usize,
 };
@@ -693,7 +693,7 @@ pub inline fn getFramebufferSize(self: Window) Error!Size {
     return Size{ .width = @intCast(usize, width), .height = @intCast(usize, height) };
 }
 
-const FrameSize = struct {
+pub const FrameSize = struct {
     left: usize,
     top: usize,
     right: usize,
@@ -1709,7 +1709,7 @@ pub inline fn getMouseButton(self: Window, button: MouseButton) Error!Action {
     return @intToEnum(Action, state);
 }
 
-const CursorPos = struct {
+pub const CursorPos = struct {
     xpos: f64,
     ypos: f64,
 };

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -75,117 +75,61 @@ inline fn defaultHints() Error!void {
 }
 
 /// Window hints
-pub const Hint = enum(c_int) {
-    /// Window resize-ability window hint
+const Hint = enum(c_int) {
     resizable = c.GLFW_RESIZABLE,
-
-    /// Window visibility window hint
     visible = c.GLFW_VISIBLE,
-
-    /// Window decoration window hint
     decorated = c.GLFW_DECORATED,
-
-    /// Input focus window hint.
     focused = c.GLFW_FOCUSED,
-
-    /// Window auto-iconification window hint
     auto_iconify = c.GLFW_AUTO_ICONIFY,
-
-    /// Window decoration window hint
     floating = c.GLFW_FLOATING,
-
-    /// Window maximization window hint
     maximized = c.GLFW_MAXIMIZED,
-
-    /// Cursor centering window hint
     center_cursor = c.GLFW_CENTER_CURSOR,
-
-    /// Window framebuffer transparency hint
     transparent_framebuffer = c.GLFW_TRANSPARENT_FRAMEBUFFER,
-
-    /// Input focus on calling show window hint
     focus_on_show = c.GLFW_FOCUS_ON_SHOW,
+    scale_to_monitor = c.GLFW_SCALE_TO_MONITOR,
 
-    /// Framebuffer bit depth hint.
+    /// Framebuffer hints
     red_bits = c.GLFW_RED_BITS,
-
-    /// Framebuffer bit depth hint.
     green_bits = c.GLFW_GREEN_BITS,
-
-    /// Framebuffer bit depth hint.
     blue_bits = c.GLFW_BLUE_BITS,
-
-    /// Framebuffer bit depth hint.
     alpha_bits = c.GLFW_ALPHA_BITS,
-
-    /// Framebuffer bit depth hint.
     depth_bits = c.GLFW_DEPTH_BITS,
-
-    /// Framebuffer bit depth hint.
     stencil_bits = c.GLFW_STENCIL_BITS,
-
-    /// Framebuffer bit depth hint.
     accum_red_bits = c.GLFW_ACCUM_RED_BITS,
-
-    /// Framebuffer bit depth hint.
     accum_green_bits = c.GLFW_ACCUM_GREEN_BITS,
-
-    /// Framebuffer bit depth hint.
     accum_blue_bits = c.GLFW_ACCUM_BLUE_BITS,
-
-    /// Framebuffer bit depth hint.
     accum_alpha_bits = c.GLFW_ACCUM_ALPHA_BITS,
-
-    /// Framebuffer auxiliary buffer hint.
     aux_buffers = c.GLFW_AUX_BUFFERS,
-
-    /// OpenGL stereoscopic rendering hint.
-    stereo = c.GLFW_STEREO,
-
-    /// Framebuffer MSAA samples hint.
+    
+    /// Framebuffer MSAA samples
     samples = c.GLFW_SAMPLES,
-
-    /// Framebuffer sRGB hint.
-    srgb_capable = c.GLFW_SRGB_CAPABLE,
-
-    /// Monitor refresh rate hint.
+    
+    /// Monitor refresh rate
     refresh_rate = c.GLFW_REFRESH_RATE,
 
-    /// Framebuffer double buffering hint.
+    /// OpenGL stereoscopic rendering
+    stereo = c.GLFW_STEREO,
+
+    /// Framebuffer sRGB
+    srgb_capable = c.GLFW_SRGB_CAPABLE,
+
+    /// Framebuffer double buffering
     doublebuffer = c.GLFW_DOUBLEBUFFER,
 
-    /// Context client API hint.
     client_api = c.GLFW_CLIENT_API,
-
-    /// Context client API major version hint.
-    context_version_major = c.GLFW_CONTEXT_VERSION_MAJOR,
-
-    /// Context client API minor version hint.
-    context_version_minor = c.GLFW_CONTEXT_VERSION_MINOR,
-
-    /// Context robustness hint.
-    context_robustness = c.GLFW_CONTEXT_ROBUSTNESS,
-
-    /// OpenGL forward-compatibility hint.
-    opengl_forward_compat = c.GLFW_OPENGL_FORWARD_COMPAT,
-
-    /// Debug mode context hint.
-    opengl_debug_context = c.GLFW_OPENGL_DEBUG_CONTEXT,
-
-    /// OpenGL profile hint.
-    opengl_profile = c.GLFW_OPENGL_PROFILE,
-
-    /// Context flush-on-release hint.
-    context_release_behavior = c.GLFW_CONTEXT_RELEASE_BEHAVIOR,
-
-    /// Context error suppression hint.
-    context_no_error = c.GLFW_CONTEXT_NO_ERROR,
-
-    /// Context creation API hint.
     context_creation_api = c.GLFW_CONTEXT_CREATION_API,
 
-    /// Window content area scaling window
-    scale_to_monitor = c.GLFW_SCALE_TO_MONITOR,
+    context_version_major = c.GLFW_CONTEXT_VERSION_MAJOR,
+    context_version_minor = c.GLFW_CONTEXT_VERSION_MINOR,
+
+    context_robustness = c.GLFW_CONTEXT_ROBUSTNESS,
+    context_release_behavior = c.GLFW_CONTEXT_RELEASE_BEHAVIOR,
+    context_no_error = c.GLFW_CONTEXT_NO_ERROR,
+
+    opengl_forward_compat = c.GLFW_OPENGL_FORWARD_COMPAT,
+    opengl_debug_context = c.GLFW_OPENGL_DEBUG_CONTEXT,
+
+    opengl_profile = c.GLFW_OPENGL_PROFILE,
 
     /// macOS specific
     cocoa_retina_framebuffer = c.GLFW_COCOA_RETINA_FRAMEBUFFER,
@@ -218,6 +162,7 @@ pub const Hints = struct {
     focus_on_show: bool = true,
     scale_to_monitor: bool = false,
 
+    /// Framebuffer hints
     red_bits: c_int = 8,
     green_bits: c_int = 8,
     blue_bits: c_int = 8,
@@ -229,11 +174,20 @@ pub const Hints = struct {
     accum_blue_bits: c_int = 0,
     accum_alpha_bits: c_int = 0,
     aux_buffers: c_int = 0,
+    
+    /// Framebuffer MSAA samples
     samples: c_int = 0,
+    
+    /// Monitor refresh rate
     refresh_rate: c_int = glfw.dont_care,
 
+    /// OpenGL stereoscopic rendering
     stereo: bool = false,
+
+    /// Framebuffer sRGB
     srgb_capable: bool = false,
+
+    /// Framebuffer double buffering
     doublebuffer: bool = true,
 
     client_api: ClientApi = .opengl_api,
@@ -254,13 +208,19 @@ pub const Hints = struct {
 
     opengl_profile: OpenGLProfile = .opengl_any_profile,
 
+    /// macOS specific
     cocoa_retina_framebuffer: bool = true,
 
+    /// macOS specific
     cocoa_frame_name: [:0]const u8 = "",
 
+    /// macOS specific
     cocoa_graphics_switching: bool = false,
 
+    /// X11 specific
     x11_class_name: [:0]const u8 = "",
+
+    /// X11 specific
     x11_instance_name: [:0]const u8 = "",
 
     pub const ClientApi = enum(c_int) {

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -210,67 +210,6 @@ const Hint = enum(c_int) {
     x11_instance_name = c.GLFW_X11_INSTANCE_NAME,
 };
 
-/// Sets the specified window hint to the desired value.
-///
-/// This function sets hints for the next call to glfw.Window.create. The hints, once set, retain
-/// their values until changed by a call to this function or glfw.window.defaultHints, or until the
-/// library is terminated.
-///
-/// This function does not check whether the specified hint values are valid. If you set hints to
-/// invalid values this will instead be reported by the next call to glfw.createWindow.
-///
-/// Some hints are platform specific. These may be set on any platform but they will only affect
-/// their specific platform. Other platforms will ignore them.
-///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.InvalidEnum.
-///
-/// @pointer_lifetime in the event that value is of a str type, the specified string is copied before this function returns.
-///
-/// @thread_safety This function must only be called from the main thread.
-///
-/// see also: window_hints, glfw.Window.defaultHints
-inline fn hint(h: Hint, value: anytype) Error!void {
-    const value_type = @TypeOf(value);
-    const value_type_info: std.builtin.TypeInfo = @typeInfo(value_type);
-
-    switch (value_type_info) {
-        .Int, .ComptimeInt => {
-            c.glfwWindowHint(@enumToInt(h), @intCast(c_int, value));
-        },
-        .Bool => {
-            const int_value = @boolToInt(value);
-            c.glfwWindowHint(@enumToInt(h), @intCast(c_int, int_value));
-        },
-        .Enum => {
-            const int_value = @enumToInt(value);
-            c.glfwWindowHint(@enumToInt(h), @intCast(c_int, int_value));
-        },
-        .Array => |arr_type| {
-            if (arr_type.child != u8) {
-                @compileError("expected array of u8, got " ++ @typeName(arr_type));
-            }
-            c.glfwWindowHintString(@enumToInt(h), &value[0]);
-        },
-        .Pointer => |pointer_info| {
-            const pointed_type = @typeInfo(pointer_info.child);
-            switch (pointed_type) {
-                .Array => |arr_type| {
-                    if (arr_type.child != u8) {
-                        @compileError("expected pointer to array of u8, got " ++ @typeName(arr_type));
-                    }
-                },
-                else => @compileError("expected pointer to array, got " ++ @typeName(pointed_type)),
-            }
-
-            c.glfwWindowHintString(@enumToInt(h), &value[0]);
-        },
-        else => {
-            @compileError("expected a int, bool, enum, array, or pointer, got " ++ @typeName(value_type));
-        },
-    }
-    try getError();
-}
-
 /// Window hints
 pub const Hints = struct {
     resizable: bool = true,
@@ -2184,6 +2123,70 @@ pub inline fn setDropCallback(self: Window, callback: ?fn (window: Window, paths
     var internal = self.getInternal();
     internal.setDropCallback = callback;
     _ = c.glfwSetDropCallback(self.handle, if (callback != null) setDropCallbackWrapper else null);
+    try getError();
+}
+
+
+
+/// For testing purposes only; see glfw.Window.Hints and glfw.Window.create for the public API.
+/// Sets the specified window hint to the desired value.
+///
+/// This function sets hints for the next call to glfw.Window.create. The hints, once set, retain
+/// their values until changed by a call to this function or glfw.window.defaultHints, or until the
+/// library is terminated.
+///
+/// This function does not check whether the specified hint values are valid. If you set hints to
+/// invalid values this will instead be reported by the next call to glfw.createWindow.
+///
+/// Some hints are platform specific. These may be set on any platform but they will only affect
+/// their specific platform. Other platforms will ignore them.
+///
+/// Possible errors include glfw.Error.NotInitialized and glfw.Error.InvalidEnum.
+///
+/// @pointer_lifetime in the event that value is of a str type, the specified string is copied before this function returns.
+///
+/// @thread_safety This function must only be called from the main thread.
+///
+/// see also: window_hints, glfw.Window.defaultHints
+inline fn hint(h: Hint, value: anytype) Error!void {
+    const value_type = @TypeOf(value);
+    const value_type_info: std.builtin.TypeInfo = @typeInfo(value_type);
+
+    switch (value_type_info) {
+        .Int, .ComptimeInt => {
+            c.glfwWindowHint(@enumToInt(h), @intCast(c_int, value));
+        },
+        .Bool => {
+            const int_value = @boolToInt(value);
+            c.glfwWindowHint(@enumToInt(h), @intCast(c_int, int_value));
+        },
+        .Enum => {
+            const int_value = @enumToInt(value);
+            c.glfwWindowHint(@enumToInt(h), @intCast(c_int, int_value));
+        },
+        .Array => |arr_type| {
+            if (arr_type.child != u8) {
+                @compileError("expected array of u8, got " ++ @typeName(arr_type));
+            }
+            c.glfwWindowHintString(@enumToInt(h), &value[0]);
+        },
+        .Pointer => |pointer_info| {
+            const pointed_type = @typeInfo(pointer_info.child);
+            switch (pointed_type) {
+                .Array => |arr_type| {
+                    if (arr_type.child != u8) {
+                        @compileError("expected pointer to array of u8, got " ++ @typeName(arr_type));
+                    }
+                },
+                else => @compileError("expected pointer to array, got " ++ @typeName(pointed_type)),
+            }
+
+            c.glfwWindowHintString(@enumToInt(h), &value[0]);
+        },
+        else => {
+            @compileError("expected a int, bool, enum, array, or pointer, got " ++ @typeName(value_type));
+        },
+    }
     try getError();
 }
 

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -163,11 +163,6 @@ const Hint = enum(c_int) {
     /// Context client API minor version hint.
     context_version_minor = c.GLFW_CONTEXT_VERSION_MINOR,
 
-    // TODO: The docs don't specify GLFW_CONTEXT_REVISION as a hint, only as an attribute; is there a reason this is here? Commented to make current
-    // draft work, which is mostly copying from the docs
-    // /// Context client API revision number hint.
-    // context_revision = c.GLFW_CONTEXT_REVISION,
-
     /// Context robustness hint.
     context_robustness = c.GLFW_CONTEXT_ROBUSTNESS,
 
@@ -183,10 +178,8 @@ const Hint = enum(c_int) {
     /// Context flush-on-release hint.
     context_release_behavior = c.GLFW_CONTEXT_RELEASE_BEHAVIOR,
 
-    // TODO: The docs don't specify GLFW_CONTEXT_REVISION as a hint, only as an attribute; is there a reason this is here? Commented to make current
-    // draft work, which is mostly copying from the docs
-    // /// Context error suppression hint.
-    // context_no_error = c.GLFW_CONTEXT_NO_ERROR,
+    /// Context error suppression hint.
+    context_no_error = c.GLFW_CONTEXT_NO_ERROR,
 
     /// Context creation API hint.
     context_creation_api = c.GLFW_CONTEXT_CREATION_API,
@@ -251,6 +244,7 @@ pub const Hints = struct {
     context_robustness: ContextRobustness = .no_robustness,
     context_release_behavior: ContextReleaseBehavior = .any_release_behavior,
     
+    context_no_error: bool = !std.debug.runtime_safety,
     opengl_forward_compat: bool = false,
     opengl_debug_context: bool = false,
     

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -252,7 +252,7 @@ pub const Hints = struct {
     opengl_forward_compat: bool = false,
     opengl_debug_context: bool = false,
     
-    opengl_profile: OpenGlProfile = .opengl_any_profile,
+    opengl_profile: OpenGLProfile = .opengl_any_profile,
     
     cocoa_retina_framebuffer: bool = true,
     

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -76,9 +76,6 @@ inline fn defaultHints() Error!void {
 
 /// Window hints
 const Hint = enum(c_int) {
-    /// Input focus window hint.
-    focused = c.GLFW_FOCUSED,
-
     /// Window resize-ability window hint
     resizable = c.GLFW_RESIZABLE,
 
@@ -87,6 +84,9 @@ const Hint = enum(c_int) {
 
     /// Window decoration window hint
     decorated = c.GLFW_DECORATED,
+
+    /// Input focus window hint.
+    focused = c.GLFW_FOCUSED,
 
     /// Window auto-iconification window hint
     auto_iconify = c.GLFW_AUTO_ICONIFY,

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -263,33 +263,33 @@ pub const Hints = struct {
     x11_instance_name: [:0]const u8 = "",
     
     pub const ClientApi = enum(c_int) {
-        opengl_api = consts.opengl_api,
-        opengl_es_api = consts.opengl_es_api,
-        no_api = consts.no_api,
+        opengl_api = c.GLFW_OPENGL_API,
+        opengl_es_api = c.GLFW_OPENGL_ES_API,
+        no_api = c.GLFW_NO_API,
     };
     
     pub const ContextCreationApi = enum(c_int) {
-        native_context_api = consts.native_context_api,
-        egl_context_api = consts.egl_context_api,
-        osmesa_context_api = consts.osmesa_context_api,
+        native_context_api = c.GLFW_NATIVE_CONTEXT_API,
+        egl_context_api = c.GLFW_EGL_CONTEXT_API,
+        osmesa_context_api = c.GLFW_OSMESA_CONTEXT_API,
     };
     
     pub const ContextRobustness = enum(c_int) {
-        no_robustness = consts.no_robustness,
-        no_reset_notification = consts.no_reset_notification,
-        lose_context_on_reset = consts.lose_context_on_reset,
+        no_robustness = c.GLFW_NO_ROBUSTNESS,
+        no_reset_notification = c.GLFW_NO_RESET_NOTIFICATION,
+        lose_context_on_reset = c.GLFW_LOSE_CONTEXT_ON_RESET,
     };
     
     pub const ContextReleaseBehavior = enum(c_int) {
-        any_release_behavior = consts.any_release_behavior,
-        release_behavior_flush = consts.release_behavior_flush,
-        release_behavior_none = consts.release_behavior_none,
+        any_release_behavior = c.GLFW_ANY_RELEASE_BEHAVIOR,
+        release_behavior_flush = c.GLFW_RELEASE_BEHAVIOR_FLUSH,
+        release_behavior_none = c.GLFW_RELEASE_BEHAVIOR_NONE,
     };
     
     pub const OpenGlProfile = enum(c_int) {
-        opengl_any_profile = consts.opengl_any_profile,
-        opengl_compat_profile = consts.opengl_compat_profile,
-        opengl_core_profile = consts.opengl_core_profile,
+        opengl_any_profile = c.GLFW_OPENGL_ANY_PROFILE,
+        opengl_compat_profile = c.GLFW_OPENGL_COMPAT_PROFILE,
+        opengl_core_profile = c.GLFW_OPENGL_CORE_PROFILE,
     };
     
     fn set(hints: Hints) !void {

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -293,7 +293,7 @@ pub const Hints = struct {
     };
     
     fn set(hints: Hints) !void {
-        inline for (comptime std.meta.fieldNames(Hints)) |field_name| {
+        inline for (comptime std.meta.fieldNames(Hint)) |field_name| {
             const hint_tag = @enumToInt(@field(Hint, field_name));
             const hint_value = @field(hints, field_name);
             switch (@TypeOf(hint_value)) {

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -205,6 +205,7 @@ const Hint = enum(c_int) {
 
 /// Window hints
 pub const Hints = struct {
+    // Note: The defaults here are directly from the GLFW source of the glfwDefaultWindowHints function
     resizable: bool = true,
     visible: bool = true,
     decorated: bool = true,

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -317,7 +317,7 @@ pub const Hints = struct {
             
             getError() catch |err| switch (err) {
                 error.NotInitialized => return err,
-                // `glfw.Error.InvalidEnum` should not be possible, given that only values defined within this struct are possible.
+                Error.InvalidEnum => unreachable, // should not be possible, given that only values defined within this struct are possible.
                 else => unreachable,
             };
         }

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -84,7 +84,7 @@ pub const Hint = enum(c_int) {
 
     /// Window decoration window hint
     decorated = c.GLFW_DECORATED,
-    
+
     /// Input focus window hint.
     focused = c.GLFW_FOCUSED,
 
@@ -217,7 +217,7 @@ pub const Hints = struct {
     transparent_framebuffer: bool = false,
     focus_on_show: bool = true,
     scale_to_monitor: bool = false,
-    
+
     red_bits: c_int = 8,
     green_bits: c_int = 8,
     blue_bits: c_int = 8,
@@ -231,68 +231,68 @@ pub const Hints = struct {
     aux_buffers: c_int = 0,
     samples: c_int = 0,
     refresh_rate: c_int = glfw.dont_care,
-    
+
     stereo: bool = false,
     srgb_capable: bool = false,
     doublebuffer: bool = true,
-    
+
     client_api: ClientApi = .opengl_api,
     context_creation_api: ContextCreationApi = .native_context_api,
-    
+
     context_version_major: c_int = 1,
     context_version_minor: c_int = 0,
-    
+
     context_robustness: ContextRobustness = .no_robustness,
     context_release_behavior: ContextReleaseBehavior = .any_release_behavior,
-    
+
     /// Note: disables the context creating errors,
     /// instead turning them into undefined behavior.
     context_no_error: bool = false,
-    
+
     opengl_forward_compat: bool = false,
     opengl_debug_context: bool = false,
-    
+
     opengl_profile: OpenGLProfile = .opengl_any_profile,
-    
+
     cocoa_retina_framebuffer: bool = true,
-    
+
     cocoa_frame_name: [:0]const u8 = "",
-    
+
     cocoa_graphics_switching: bool = false,
-    
+
     x11_class_name: [:0]const u8 = "",
     x11_instance_name: [:0]const u8 = "",
-    
+
     pub const ClientApi = enum(c_int) {
         opengl_api = c.GLFW_OPENGL_API,
         opengl_es_api = c.GLFW_OPENGL_ES_API,
         no_api = c.GLFW_NO_API,
     };
-    
+
     pub const ContextCreationApi = enum(c_int) {
         native_context_api = c.GLFW_NATIVE_CONTEXT_API,
         egl_context_api = c.GLFW_EGL_CONTEXT_API,
         osmesa_context_api = c.GLFW_OSMESA_CONTEXT_API,
     };
-    
+
     pub const ContextRobustness = enum(c_int) {
         no_robustness = c.GLFW_NO_ROBUSTNESS,
         no_reset_notification = c.GLFW_NO_RESET_NOTIFICATION,
         lose_context_on_reset = c.GLFW_LOSE_CONTEXT_ON_RESET,
     };
-    
+
     pub const ContextReleaseBehavior = enum(c_int) {
         any_release_behavior = c.GLFW_ANY_RELEASE_BEHAVIOR,
         release_behavior_flush = c.GLFW_RELEASE_BEHAVIOR_FLUSH,
         release_behavior_none = c.GLFW_RELEASE_BEHAVIOR_NONE,
     };
-    
+
     pub const OpenGLProfile = enum(c_int) {
         opengl_any_profile = c.GLFW_OPENGL_ANY_PROFILE,
         opengl_compat_profile = c.GLFW_OPENGL_COMPAT_PROFILE,
         opengl_core_profile = c.GLFW_OPENGL_CORE_PROFILE,
     };
-    
+
     fn set(hints: Hints) !void {
         inline for (comptime std.meta.fieldNames(Hint)) |field_name| {
             const hint_tag = @enumToInt(@field(Hint, field_name));
@@ -300,19 +300,19 @@ pub const Hints = struct {
             switch (@TypeOf(hint_value)) {
                 bool => c.glfwWindowHint(hint_tag, @boolToInt(hint_value)),
                 c_int => c.glfwWindowHint(hint_tag, hint_value),
-                
+
                 ClientApi,
                 ContextCreationApi,
                 ContextRobustness,
                 ContextReleaseBehavior,
                 OpenGLProfile,
                 => c.glfwWindowHint(hint_tag, @enumToInt(hint_value)),
-                
+
                 [:0]const u8 => c.glfwWindowHintString(hint_tag, hint_value.ptr),
-                
+
                 else => unreachable,
             }
-            
+
             getError() catch |err| switch (err) {
                 error.NotInitialized => return err,
                 Error.InvalidEnum => unreachable, // should not be possible, given that only values defined within this struct are possible.
@@ -440,7 +440,7 @@ pub const Hints = struct {
 pub inline fn create(width: usize, height: usize, title: [*c]const u8, monitor: ?Monitor, share: ?Window, hints: Hints) Error!Window {
     try hints.set();
     defer defaultHints() catch unreachable; // this should be unreachable, being that this should be caught in the previous call to `Hints.set`.
-    
+
     const handle = c.glfwCreateWindow(
         @intCast(c_int, width),
         @intCast(c_int, height),
@@ -449,7 +449,7 @@ pub inline fn create(width: usize, height: usize, title: [*c]const u8, monitor: 
         if (share) |w| w.handle else null,
     );
     try getError();
-    
+
     return from(handle.?);
 }
 
@@ -2124,8 +2124,6 @@ pub inline fn setDropCallback(self: Window, callback: ?fn (window: Window, paths
     _ = c.glfwSetDropCallback(self.handle, if (callback != null) setDropCallbackWrapper else null);
     try getError();
 }
-
-
 
 /// For testing purposes only; see glfw.Window.Hints and glfw.Window.create for the public API.
 /// Sets the specified window hint to the desired value.

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -439,6 +439,7 @@ pub const Hints = struct {
 /// see also: window_creation, glfw.Window.destroy
 pub inline fn create(width: usize, height: usize, title: [*c]const u8, monitor: ?Monitor, share: ?Window, hints: Hints) Error!Window {
     try hints.set();
+    defer defaultHints() catch unreachable; // this should be unreachable, being that this should be caught in the previous call to `Hints.set`.
     
     const handle = c.glfwCreateWindow(
         @intCast(c_int, width),
@@ -449,7 +450,6 @@ pub inline fn create(width: usize, height: usize, title: [*c]const u8, monitor: 
     );
     try getError();
     
-    try Window.defaultHints();
     return from(handle.?);
 }
 

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -439,7 +439,6 @@ pub const Hints = struct {
 /// see also: window_creation, glfw.Window.destroy
 pub inline fn create(width: usize, height: usize, title: [*c]const u8, monitor: ?Monitor, share: ?Window, hints: Hints) Error!Window {
     try hints.set();
-    try Window.defaultHints();
     
     const handle = c.glfwCreateWindow(
         @intCast(c_int, width),
@@ -449,6 +448,8 @@ pub inline fn create(width: usize, height: usize, title: [*c]const u8, monitor: 
         if (share) |w| w.handle else null,
     );
     try getError();
+    
+    try Window.defaultHints();
     return from(handle.?);
 }
 

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -244,7 +244,10 @@ pub const Hints = struct {
     context_robustness: ContextRobustness = .no_robustness,
     context_release_behavior: ContextReleaseBehavior = .any_release_behavior,
     
-    context_no_error: bool = !std.debug.runtime_safety,
+    /// Note: disables the context creating errors,
+    /// instead turning them into undefined behavior.
+    context_no_error: bool = false,
+    
     opengl_forward_compat: bool = false,
     opengl_debug_context: bool = false,
     

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -5,7 +5,7 @@ const testing = std.testing;
 const mem = std.mem;
 const c = @import("c.zig").c;
 
-const consts = @import("consts.zig");
+const glfw = @import("main.zig");
 const Error = @import("errors.zig").Error;
 const getError = @import("errors.zig").getError;
 const Image = @import("Image.zig");
@@ -230,7 +230,7 @@ pub const Hints = struct {
     accum_alpha_bits: c_int = 0,
     aux_buffers: c_int = 0,
     samples: c_int = 0,
-    refresh_rate: c_int = consts.dont_care,
+    refresh_rate: c_int = glfw.dont_care,
     
     stereo: bool = false,
     srgb_capable: bool = false,
@@ -305,7 +305,7 @@ pub const Hints = struct {
                 ContextCreationApi,
                 ContextRobustness,
                 ContextReleaseBehavior,
-                OpenGlProfile,
+                OpenGLProfile,
                 => c.glfwWindowHint(hint_tag, @enumToInt(hint_value)),
                 
                 [:0]const u8 => c.glfwWindowHintString(hint_tag, hint_value.ptr),
@@ -2190,7 +2190,6 @@ inline fn hint(h: Hint, value: anytype) Error!void {
 }
 
 test "defaultHints" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2198,7 +2197,6 @@ test "defaultHints" {
 }
 
 test "hint comptime int" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2207,7 +2205,6 @@ test "hint comptime int" {
 }
 
 test "hint int" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2218,7 +2215,6 @@ test "hint int" {
 }
 
 test "hint bool" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2227,7 +2223,6 @@ test "hint bool" {
 }
 
 test "hint enum(u1)" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2241,7 +2236,6 @@ test "hint enum(u1)" {
 }
 
 test "hint enum(i32)" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2255,7 +2249,6 @@ test "hint enum(i32)" {
 }
 
 test "hint array str" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2266,7 +2259,6 @@ test "hint array str" {
 }
 
 test "hint pointer str" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2274,7 +2266,6 @@ test "hint pointer str" {
 }
 
 test "createWindow" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2288,7 +2279,6 @@ test "createWindow" {
 }
 
 test "setShouldClose" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2303,7 +2293,6 @@ test "setShouldClose" {
 }
 
 test "setTitle" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2320,7 +2309,6 @@ test "setTitle" {
 
 test "setIcon" {
     const allocator = testing.allocator;
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2352,7 +2340,6 @@ test "setIcon" {
 }
 
 test "getPos" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2368,7 +2355,6 @@ test "getPos" {
 }
 
 test "setPos" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2384,7 +2370,6 @@ test "setPos" {
 }
 
 test "getSize" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2400,7 +2385,6 @@ test "getSize" {
 }
 
 test "setSize" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2416,7 +2400,6 @@ test "setSize" {
 }
 
 test "setSizeLimits" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2435,7 +2418,6 @@ test "setSizeLimits" {
 }
 
 test "setAspectRatio" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2451,7 +2433,6 @@ test "setAspectRatio" {
 }
 
 test "getFramebufferSize" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2467,7 +2448,6 @@ test "getFramebufferSize" {
 }
 
 test "getFrameSize" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2483,7 +2463,6 @@ test "getFrameSize" {
 }
 
 test "getContentScale" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2499,7 +2478,6 @@ test "getContentScale" {
 }
 
 test "getOpacity" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2515,7 +2493,6 @@ test "getOpacity" {
 }
 
 test "iconify" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2531,7 +2508,6 @@ test "iconify" {
 }
 
 test "restore" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2547,7 +2523,6 @@ test "restore" {
 }
 
 test "maximize" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2563,7 +2538,6 @@ test "maximize" {
 }
 
 test "show" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2579,7 +2553,6 @@ test "show" {
 }
 
 test "hide" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2595,7 +2568,6 @@ test "hide" {
 }
 
 test "focus" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2611,7 +2583,6 @@ test "focus" {
 }
 
 test "requestAttention" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2627,7 +2598,6 @@ test "requestAttention" {
 }
 
 test "swapBuffers" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2643,7 +2613,6 @@ test "swapBuffers" {
 }
 
 test "getMonitor" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2659,7 +2628,6 @@ test "getMonitor" {
 }
 
 test "setMonitor" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2675,7 +2643,6 @@ test "setMonitor" {
 }
 
 test "getAttrib" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2691,7 +2658,6 @@ test "getAttrib" {
 }
 
 test "setAttrib" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2707,7 +2673,6 @@ test "setAttrib" {
 }
 
 test "setUserPointer" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2726,7 +2691,6 @@ test "setUserPointer" {
 }
 
 test "getUserPointer" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2747,7 +2711,6 @@ test "getUserPointer" {
 }
 
 test "setPosCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2769,7 +2732,6 @@ test "setPosCallback" {
 }
 
 test "setSizeCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2791,7 +2753,6 @@ test "setSizeCallback" {
 }
 
 test "setCloseCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2811,7 +2772,6 @@ test "setCloseCallback" {
 }
 
 test "setRefreshCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2831,7 +2791,6 @@ test "setRefreshCallback" {
 }
 
 test "setFocusCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2852,7 +2811,6 @@ test "setFocusCallback" {
 }
 
 test "setIconifyCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2873,7 +2831,6 @@ test "setIconifyCallback" {
 }
 
 test "setMaximizeCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2894,7 +2851,6 @@ test "setMaximizeCallback" {
 }
 
 test "setFramebufferSizeCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2916,7 +2872,6 @@ test "setFramebufferSizeCallback" {
 }
 
 test "setContentScaleCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2938,7 +2893,6 @@ test "setContentScaleCallback" {
 }
 
 test "setDropCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2959,7 +2913,6 @@ test "setDropCallback" {
 }
 
 test "getInputModeCursor" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2975,7 +2928,6 @@ test "getInputModeCursor" {
 }
 
 test "setInputModeCursor" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -2991,7 +2943,6 @@ test "setInputModeCursor" {
 }
 
 test "getInputModeStickyKeys" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3007,7 +2958,6 @@ test "getInputModeStickyKeys" {
 }
 
 test "setInputModeStickyKeys" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3023,7 +2973,6 @@ test "setInputModeStickyKeys" {
 }
 
 test "getInputModeStickyMouseButtons" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3039,7 +2988,6 @@ test "getInputModeStickyMouseButtons" {
 }
 
 test "setInputModeStickyMouseButtons" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3055,7 +3003,6 @@ test "setInputModeStickyMouseButtons" {
 }
 
 test "getInputModeLockKeyMods" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3071,7 +3018,6 @@ test "getInputModeLockKeyMods" {
 }
 
 test "setInputModeLockKeyMods" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3087,7 +3033,6 @@ test "setInputModeLockKeyMods" {
 }
 
 test "getInputModeRawMouseMotion" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3103,7 +3048,6 @@ test "getInputModeRawMouseMotion" {
 }
 
 test "setInputModeRawMouseMotion" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3119,7 +3063,6 @@ test "setInputModeRawMouseMotion" {
 }
 
 test "getInputMode" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3135,7 +3078,6 @@ test "getInputMode" {
 }
 
 test "setInputMode" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3155,7 +3097,6 @@ test "setInputMode" {
 }
 
 test "getKey" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3171,7 +3112,6 @@ test "getKey" {
 }
 
 test "getMouseButton" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3187,7 +3127,6 @@ test "getMouseButton" {
 }
 
 test "getCursorPos" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3203,7 +3142,6 @@ test "getCursorPos" {
 }
 
 test "setCursorPos" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3219,7 +3157,6 @@ test "setCursorPos" {
 }
 
 test "setCursor" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3241,7 +3178,6 @@ test "setCursor" {
 }
 
 test "setKeyCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3265,7 +3201,6 @@ test "setKeyCallback" {
 }
 
 test "setCharCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3286,7 +3221,6 @@ test "setCharCallback" {
 }
 
 test "setMouseButtonCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3309,7 +3243,6 @@ test "setMouseButtonCallback" {
 }
 
 test "setCursorPosCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3331,7 +3264,6 @@ test "setCursorPosCallback" {
 }
 
 test "setCursorEnterCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 
@@ -3352,7 +3284,6 @@ test "setCursorEnterCallback" {
 }
 
 test "setScrollCallback" {
-    const glfw = @import("main.zig");
     try glfw.init(.{});
     defer glfw.terminate();
 

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -100,10 +100,10 @@ const Hint = enum(c_int) {
     accum_blue_bits = c.GLFW_ACCUM_BLUE_BITS,
     accum_alpha_bits = c.GLFW_ACCUM_ALPHA_BITS,
     aux_buffers = c.GLFW_AUX_BUFFERS,
-    
+
     /// Framebuffer MSAA samples
     samples = c.GLFW_SAMPLES,
-    
+
     /// Monitor refresh rate
     refresh_rate = c.GLFW_REFRESH_RATE,
 
@@ -174,10 +174,10 @@ pub const Hints = struct {
     accum_blue_bits: c_int = 0,
     accum_alpha_bits: c_int = 0,
     aux_buffers: c_int = 0,
-    
+
     /// Framebuffer MSAA samples
     samples: c_int = 0,
-    
+
     /// Monitor refresh rate
     refresh_rate: c_int = glfw.dont_care,
 
@@ -190,8 +190,8 @@ pub const Hints = struct {
     /// Framebuffer double buffering
     doublebuffer: bool = true,
 
-    client_api: ClientApi = .opengl_api,
-    context_creation_api: ContextCreationApi = .native_context_api,
+    client_api: ClientAPI = .opengl_api,
+    context_creation_api: ContextCreationAPI = .native_context_api,
 
     context_version_major: c_int = 1,
     context_version_minor: c_int = 0,
@@ -223,13 +223,13 @@ pub const Hints = struct {
     /// X11 specific
     x11_instance_name: [:0]const u8 = "",
 
-    pub const ClientApi = enum(c_int) {
+    pub const ClientAPI = enum(c_int) {
         opengl_api = c.GLFW_OPENGL_API,
         opengl_es_api = c.GLFW_OPENGL_ES_API,
         no_api = c.GLFW_NO_API,
     };
 
-    pub const ContextCreationApi = enum(c_int) {
+    pub const ContextCreationAPI = enum(c_int) {
         native_context_api = c.GLFW_NATIVE_CONTEXT_API,
         egl_context_api = c.GLFW_EGL_CONTEXT_API,
         osmesa_context_api = c.GLFW_OSMESA_CONTEXT_API,
@@ -261,8 +261,8 @@ pub const Hints = struct {
                 bool => c.glfwWindowHint(hint_tag, @boolToInt(hint_value)),
                 c_int => c.glfwWindowHint(hint_tag, hint_value),
 
-                ClientApi,
-                ContextCreationApi,
+                ClientAPI,
+                ContextCreationAPI,
                 ContextRobustness,
                 ContextReleaseBehavior,
                 OpenGLProfile,

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -287,7 +287,7 @@ pub const Hints = struct {
         release_behavior_none = c.GLFW_RELEASE_BEHAVIOR_NONE,
     };
     
-    pub const OpenGlProfile = enum(c_int) {
+    pub const OpenGLProfile = enum(c_int) {
         opengl_any_profile = c.GLFW_OPENGL_ANY_PROFILE,
         opengl_compat_profile = c.GLFW_OPENGL_COMPAT_PROFILE,
         opengl_core_profile = c.GLFW_OPENGL_CORE_PROFILE,

--- a/glfw/src/consts.zig
+++ b/glfw/src/consts.zig
@@ -2,30 +2,5 @@
 
 const c = @import("c.zig").c;
 
-/// Possible values for glfw.Window.Hint.client_api hint
-pub const no_api = c.GLFW_NO_API;
-pub const opengl_api = c.GLFW_OPENGL_API;
-pub const opengl_es_api = c.GLFW_OPENGL_ES_API;
-
-/// Possible values for glfw.Window.Hint.context_robustness hint
-pub const no_robustness = c.GLFW_NO_ROBUSTNESS;
-pub const no_reset_notification = c.GLFW_NO_RESET_NOTIFICATION;
-pub const lose_context_on_reset = c.GLFW_LOSE_CONTEXT_ON_RESET;
-
-/// Possible values for glfw.Window.Hint.opengl_profile hint
-pub const opengl_any_profile = c.GLFW_OPENGL_ANY_PROFILE;
-pub const opengl_core_profile = c.GLFW_OPENGL_CORE_PROFILE;
-pub const opengl_compat_profile = c.GLFW_OPENGL_COMPAT_PROFILE;
-
-/// Possible values for glfw.Window.Hint.context_release_behavior hint
-pub const any_release_behavior = c.GLFW_ANY_RELEASE_BEHAVIOR;
-pub const release_behavior_flush = c.GLFW_RELEASE_BEHAVIOR_FLUSH;
-pub const release_behavior_none = c.GLFW_RELEASE_BEHAVIOR_NONE;
-
-/// Possible values for glfw.Window.Hint.context_creation_api hint
-pub const native_context_api = c.GLFW_NATIVE_CONTEXT_API;
-pub const egl_context_api = c.GLFW_EGL_CONTEXT_API;
-pub const osmesa_context_api = c.GLFW_OSMESA_CONTEXT_API;
-
 /// Possible value for various window hints, etc.
 pub const dont_care = c.GLFW_DONT_CARE;

--- a/glfw/src/consts.zig
+++ b/glfw/src/consts.zig
@@ -1,6 +1,0 @@
-//! General constants
-
-const c = @import("c.zig").c;
-
-/// Possible value for various window hints, etc.
-pub const dont_care = c.GLFW_DONT_CARE;

--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -5,7 +5,9 @@ const c = @import("c.zig").c;
 
 const key = @import("key.zig");
 
-pub usingnamespace @import("consts.zig");
+/// Possible value for various window hints, etc.
+pub const dont_care = c.GLFW_DONT_CARE;
+
 pub const Error = @import("errors.zig").Error;
 const getError = @import("errors.zig").getError;
 

--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -335,7 +335,7 @@ pub fn basicTest() !void {
     try init(.{});
     defer terminate();
 
-    const window = Window.create(640, 480, "GLFW example", null, null) catch |err| {
+    const window = Window.create(640, 480, "GLFW example", null, null, .{}) catch |err| {
         // return without fail, because most of our CI environments are headless / we cannot open
         // windows on them.
         std.debug.print("note: failed to create window: {}\n", .{err});

--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -96,13 +96,13 @@ pub const InitHints = struct {
     /// Specifies whether to also expose joystick hats as buttons, for compatibility with earlier
     /// versions of GLFW that did not have glfwGetJoystickHats.
     joystick_hat_buttons: bool = true,
-    
+
     /// macOS specific init hint. Ignored on other platforms.
     ///
     /// Specifies whether to set the current directory to the application to the Contents/Resources
     /// subdirectory of the application's bundle, if present.
     cocoa_chdir_resources: bool = true,
-    
+
     /// macOS specific init hint. Ignored on other platforms.
     ///
     /// specifies whether to create a basic menu bar, either from a nib or manually, when the first

--- a/glfw/src/opengl.zig
+++ b/glfw/src/opengl.zig
@@ -171,7 +171,7 @@ test "makeContextCurrent" {
     try glfw.init(.{});
     defer glfw.terminate();
 
-    const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
+    const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null, .{}) catch |err| {
         // return without fail, because most of our CI environments are headless / we cannot open
         // windows on them.
         std.debug.print("note: failed to create window: {}\n", .{err});
@@ -199,7 +199,7 @@ test "swapInterval" {
     try glfw.init(.{});
     defer glfw.terminate();
 
-    const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
+    const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null, .{}) catch |err| {
         // return without fail, because most of our CI environments are headless / we cannot open
         // windows on them.
         std.debug.print("note: failed to create window: {}\n", .{err});
@@ -216,7 +216,7 @@ test "getProcAddress" {
     try glfw.init(.{});
     defer glfw.terminate();
 
-    const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
+    const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null, .{}) catch |err| {
         // return without fail, because most of our CI environments are headless / we cannot open
         // windows on them.
         std.debug.print("note: failed to create window: {}\n", .{err});
@@ -233,7 +233,7 @@ test "extensionSupported" {
     try glfw.init(.{});
     defer glfw.terminate();
 
-    const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null) catch |err| {
+    const window = glfw.Window.create(640, 480, "Hello, Zig!", null, null, .{}) catch |err| {
         // return without fail, because most of our CI environments are headless / we cannot open
         // windows on them.
         std.debug.print("note: failed to create window: {}\n", .{err});


### PR DESCRIPTION
~~I took a different approach to the one used for initialization hints, because I realized that it would probably a lot of overhead to call `Window.hint` for every possible hint, compared to how status quo allows one to avoid that overhead; as well, it would probably be a lot harder to maintain, given that, unlike `InitHint`, window initialization hints are of more types than just booleans.~~
~~This approach is (quite a bit) more verbose, but avoids the overhead, and probably makes it easier to maintain.~~

Also, I found that `context_revision` and `context_no_error` are listed in `Window.Hint`, but are not listed as hints in the docs, only as attributes; I commented them out to make what I have pass tests - is this intentional and I'm missing something, or is this the result of some mishap? 

Edit: ~~it should also be noted that unlike the change made to initialization hints, I didn't completely re-use the in-place API, because I ran into some issues regarding the type-inference in the `Window.hint` function, so you'll see I ended up re-implementing the code for `Window.hint` in `HintValue.set` (where `HintValue` is a tagged union, with a tag type of `Hint`).~~

Edit: as pointed out by @silversquirl, there isn't actually a lot of overhead involved in the struct approach, so now the union slice is no more. ~~Now just to address the other components of this problem, such as `Window.hint`, which seems to have some some type inference issues which caused compilation to fail under this new model. Should we try and rework it, or discard it in favor of `Hints.set` (private function)?~~

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.