### PR TITLE
glfw: patch more undefined behaviour

### DIFF
--- a/glfw/upstream/glfw/src/x11_window.c
+++ b/glfw/upstream/glfw/src/x11_window.c
@@ -1283,7 +1283,7 @@ static void processEvent(XEvent *event)
                 //       (the server never sends a timestamp of zero)
                 // NOTE: Timestamp difference is compared to handle wrap-around
                 Time diff = event->xkey.time - window->x11.keyPressTimes[keycode];
-                if (diff == event->xkey.time || (diff > 0 && diff < (1 << 31)))
+                if (diff == event->xkey.time || (diff > 0 && diff < ((Time)1 << 31)))
                 {
                     if (keycode)
                         _glfwInputKey(window, key, keycode, GLFW_PRESS, mods);


### PR DESCRIPTION
Pressing any given modifier key twice caused ubsan crashes on X11


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.