### PR TITLE
glfw: make `glfw.Cursor.Shape` public

### DIFF
--- a/glfw/src/Cursor.zig
+++ b/glfw/src/Cursor.zig
@@ -13,7 +13,7 @@ const Cursor = @This();
 ptr: *c.GLFWcursor,
 
 // Standard system cursor shapes.
-const Shape = enum(isize) {
+pub const Shape = enum(isize) {
     /// The regular arrow cursor shape.
     arrow = c.GLFW_ARROW_CURSOR,
 


### PR DESCRIPTION
Following a similar change made to types in 'Window.zig'



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.