### PR TITLE
glfw: reorganize `Window.Attrib` to be in the same style as `Window.Hint`

### DIFF
--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -1075,18 +1075,18 @@ pub const Attrib = enum(c_int) {
     focus_on_show = c.GLFW_FOCUS_ON_SHOW,
 
     client_api = c.GLFW_CLIENT_API,
+    context_creation_api = c.GLFW_CONTEXT_CREATION_API,
     context_version_major = c.GLFW_CONTEXT_VERSION_MAJOR,
     context_version_minor = c.GLFW_CONTEXT_VERSION_MINOR,
     context_revision = c.GLFW_CONTEXT_REVISION,
+
     context_robustness = c.GLFW_CONTEXT_ROBUSTNESS,
+    context_release_behavior = c.GLFW_CONTEXT_RELEASE_BEHAVIOR,
+    context_no_error = c.GLFW_CONTEXT_NO_ERROR,
 
     opengl_forward_compat = c.GLFW_OPENGL_FORWARD_COMPAT,
     opengl_debug_context = c.GLFW_OPENGL_DEBUG_CONTEXT,
     opengl_profile = c.GLFW_OPENGL_PROFILE,
-
-    context_release_behavior = c.GLFW_CONTEXT_RELEASE_BEHAVIOR,
-    context_no_error = c.GLFW_CONTEXT_NO_ERROR,
-    context_creation_api = c.GLFW_CONTEXT_CREATION_API,
 };
 
 /// Returns an attribute of the specified window.

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -1062,70 +1062,30 @@ pub inline fn setMonitor(self: Window, monitor: ?Monitor, xpos: isize, ypos: isi
 
 /// Window attributes
 pub const Attrib = enum(c_int) {
-    /// Input focus window hit or window attribute.
-    focused = c.GLFW_FOCUSED,
-
-    /// Window iconification window attribute.
     iconified = c.GLFW_ICONIFIED,
-
-    /// Window resize-ability window attribute
     resizable = c.GLFW_RESIZABLE,
-
-    /// Window visibility window attribute
     visible = c.GLFW_VISIBLE,
-
-    /// Window decoration window attribute
     decorated = c.GLFW_DECORATED,
-
-    /// Window auto-iconification window attribute
+    focused = c.GLFW_FOCUSED,
     auto_iconify = c.GLFW_AUTO_ICONIFY,
-
-    /// Window decoration window attribute
     floating = c.GLFW_FLOATING,
-
-    /// Window maximization window attribute
     maximized = c.GLFW_MAXIMIZED,
-
-    /// Window framebuffer transparency attribute
     transparent_framebuffer = c.GLFW_TRANSPARENT_FRAMEBUFFER,
-
-    /// Mouse cursor hover window attribute.
     hovered = c.GLFW_HOVERED,
-
-    /// Input focus on calling show window attribute
     focus_on_show = c.GLFW_FOCUS_ON_SHOW,
 
-    /// Context client API attribute.
     client_api = c.GLFW_CLIENT_API,
-
-    /// Context client API major version attribute.
     context_version_major = c.GLFW_CONTEXT_VERSION_MAJOR,
-
-    /// Context client API minor version attribute.
     context_version_minor = c.GLFW_CONTEXT_VERSION_MINOR,
-
-    /// Context client API revision number attribute.
     context_revision = c.GLFW_CONTEXT_REVISION,
-
-    /// Context robustness attribute.
     context_robustness = c.GLFW_CONTEXT_ROBUSTNESS,
 
-    /// OpenGL forward-compatibility attribute.
     opengl_forward_compat = c.GLFW_OPENGL_FORWARD_COMPAT,
-
-    /// Debug mode context attribute.
     opengl_debug_context = c.GLFW_OPENGL_DEBUG_CONTEXT,
-
-    /// OpenGL profile attribute.
     opengl_profile = c.GLFW_OPENGL_PROFILE,
 
-    /// Context flush-on-release attribute.
     context_release_behavior = c.GLFW_CONTEXT_RELEASE_BEHAVIOR,
-
-    /// Context error suppression attribute.
     context_no_error = c.GLFW_CONTEXT_NO_ERROR,
-
-    /// Context creation API attribute.
     context_creation_api = c.GLFW_CONTEXT_CREATION_API,
 };
 


### PR DESCRIPTION
Compared to `Window.Hint`, where some comments were worth keeping, all comments within `Window.Attribute` appear to be basically redundant. 

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.