### PR TITLE
glfw: update system_sdk to use latest MacOS 12.0 SDK

### DIFF
--- a/glfw/system_sdk.zig
+++ b/glfw/system_sdk.zig
@@ -6,7 +6,7 @@
 //! The SDKs used by this script by default are:
 //!
 //! * Linux: https://github.com/hexops/sdk-linux-x86_64 (~40MB, X11, Wayland, etc. development libraries)
-//! * MacOS: https://github.com/hexops/sdk-macos-11.3 (~160MB, most frameworks you'd find in the XCode SDK)
+//! * MacOS: https://github.com/hexops/sdk-macos-12.0 (~112MB, most frameworks you'd find in the XCode SDK)
 //! * Windows: not needed
 //!
 //! You may supply your own SDKs via the Options struct if needed, although the Mach versions above
@@ -35,7 +35,7 @@ pub const Options = struct {
     github_org: []const u8 = "hexops",
 
     /// The MacOS SDK repository name.
-    macos_sdk: []const u8 = "sdk-macos-11.3",
+    macos_sdk: []const u8 = "sdk-macos-12.0",
 
     /// The Linux x86-64 SDK repository name.
     linux_x86_64_sdk: []const u8 = "sdk-linux-x86_64",
@@ -104,7 +104,7 @@ fn getSdkRoot(allocator: *std.mem.Allocator, org: []const u8, name: []const u8) 
     // 1. $SDK_PATH/<name> (if set, e.g. for testing changes to SDKs easily)
     // 2. <appdata>/<name> (default)
     //
-    // Where `<name>` is the name of the SDK, e.g. `sdk-macos-11.3`.
+    // Where `<name>` is the name of the SDK, e.g. `sdk-macos-12.0`.
     var sdk_root_dir: []const u8 = undefined;
     var sdk_path_dir: []const u8 = undefined;
     if (std.process.getEnvVarOwned(allocator, "SDK_PATH")) |sdk_path| {
@@ -124,7 +124,7 @@ fn getSdkRoot(allocator: *std.mem.Allocator, org: []const u8, name: []const u8) 
     } else |err| return switch (err) {
         error.FileNotFound => {
             std.log.info("cloning required sdk..\ngit clone https://github.com/{s}/{s} '{s}'..\n", .{ org, name, sdk_root_dir });
-            if (std.mem.eql(u8, name, "sdk-macos-11.3")) {
+            if (std.mem.eql(u8, name, "sdk-macos-12.0")) {
                 if (!try confirmAppleSDKAgreement(allocator)) @panic("cannot continue");
             }
             try std.fs.cwd().makePath(sdk_path_dir);

--- a/glfw/upstream/glfw/src/cocoa_platform.h
+++ b/glfw/upstream/glfw/src/cocoa_platform.h
@@ -27,6 +27,19 @@
 #include <stdint.h>
 #include <dlfcn.h>
 
+// HACK(mach): Zig's C stdlib headers conflict with those in sdk-macos-12.0, in specific _CDEFS_H_
+// is already defined once sys/cdefs.h from sdk-macos-12.0 is included. This leads to these not
+// being defined as empty, and that leads to syntax errors such as:
+//
+// sdk-macos-12.0/root/System/Library/Frameworks/IOKit.framework/Headers/IOTypes.h:81:49: error: expected ';' after top level declarator
+//
+// We patch this here by defining these, which appears to be good enough to workaround the issue for
+// now. Presumably Zig's C stdlib headers will define these on macOS once updated for macOS 12.0,
+// they're just slightly out of date for now.
+#define __kernel_ptr_semantics
+#define __kernel_data_semantics
+#define __kernel_dual_semantics
+
 #include <Carbon/Carbon.h>
 
 // NOTE: All of NSGL was deprecated in the 10.14 SDK


### PR DESCRIPTION
Updates us to using the newer SDK https://github.com/hexops/sdk-macos-12.0

Also enables cross-compilation of the `mach/gpu` backend for macOS.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.