### PR TITLE
glfw: update possible errors comment

### DIFF
--- a/glfw/src/clipboard.zig
+++ b/glfw/src/clipboard.zig
@@ -36,7 +36,7 @@ pub inline fn setClipboardString(value: [*:0]const u8) Error!void {
 ///
 /// @return The contents of the clipboard as a UTF-8 encoded string.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.NotInitialized, glfw.Error.FormatUnavailable and glfw.Error.PlatformError.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the next call to glfw.getClipboardString or glfw.setClipboardString


### PR DESCRIPTION
Add 'FormatUnavailable' as a possible error to the 'getClipboardString' comment, which can set it on wayland.

I made a pull request upstream for the same change: https://github.com/glfw/glfw/pull/1998
This is already reflected in the catch block for 'getError()', which caught this in the CI for #92.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.