### PR TITLE
glfw: re-instate prong

### DIFF
--- a/glfw/src/errors.zig
+++ b/glfw/src/errors.zig
@@ -84,6 +84,7 @@ pub const Error = error{
 fn convertError(e: c_int) Error!void {
     return switch (e) {
         c.GLFW_NO_ERROR => {},
+        c.GLFW_NOT_INITIALIZED => unreachable,
         c.GLFW_NO_CURRENT_CONTEXT => Error.NoCurrentContext,
         c.GLFW_INVALID_ENUM => Error.InvalidEnum,
         c.GLFW_INVALID_VALUE => Error.InvalidValue,


### PR DESCRIPTION
Bring back the 'c.GLFW_NOT_INITIALIZED' prong in 'convertError', such that if it is ever passed that error code, we can differentiate it from just an invalid input; because it is an valid input, we just guarantee that it won't occur.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.