### PR TITLE
glfw: Force init follow up

### DIFF
--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -568,7 +568,7 @@ pub const Pos = struct {
 /// Retrieves the position of the content area of the specified window.
 ///
 /// This function retrieves the position, in screen coordinates, of the upper-left corner of the
-// content area of the specified window.
+/// content area of the specified window.
 ///
 /// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
 ///

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -2191,6 +2191,7 @@ pub inline fn setDropCallback(self: Window, callback: ?fn (window: Window, paths
 ///
 /// see also: window_hints, glfw.Window.defaultHints
 inline fn hint(h: Hint, value: anytype) Error!void {
+    internal_debug.assertInitialized();
     const value_type = @TypeOf(value);
     const value_type_info: std.builtin.TypeInfo = @typeInfo(value_type);
 


### PR DESCRIPTION
Turns out I combed through the codebase the first time pretty well, only found one function that didn't have the appropriate `internal_debug.assertInitialized()` statement.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.