### PR TITLE
glfw: Eliminate `InvalidEnum`

### DIFF
--- a/glfw/src/Cursor.zig
+++ b/glfw/src/Cursor.zig
@@ -84,8 +84,6 @@ pub inline fn createStandard(shape: Shape) Error!Cursor {
     internal_debug.assertInitialized();
     const cursor = c.glfwCreateStandardCursor(@intCast(c_int, @enumToInt(shape)));
     getError() catch |err| return switch (err) {
-        // should be unreachable given that only the values in 'Shape' are available, unless the user explicitly gives us a bad value via casting
-        Error.InvalidEnum => unreachable,
         Error.PlatformError => err,
         else => unreachable,
     };

--- a/glfw/src/Joystick.zig
+++ b/glfw/src/Joystick.zig
@@ -91,7 +91,6 @@ pub inline fn present(self: Joystick) Error!bool {
     internal_debug.assertInitialized();
     const is_present = c.glfwJoystickPresent(@enumToInt(self.jid));
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
         Error.PlatformError => err,
         else => unreachable,
     };
@@ -123,7 +122,6 @@ pub inline fn getAxes(self: Joystick) Error!?[]const f32 {
     var count: c_int = undefined;
     const axes = c.glfwGetJoystickAxes(@enumToInt(self.jid), &count);
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
         Error.PlatformError => err,
         else => unreachable,
     };
@@ -160,7 +158,6 @@ pub inline fn getButtons(self: Joystick) Error!?[]const u8 {
     var count: c_int = undefined;
     const buttons = c.glfwGetJoystickButtons(@enumToInt(self.jid), &count);
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
         Error.PlatformError => err,
         else => unreachable,
     };
@@ -213,7 +210,6 @@ pub inline fn getHats(self: Joystick) Error!?[]const Hat {
     var count: c_int = undefined;
     const hats = c.glfwGetJoystickHats(@enumToInt(self.jid), &count);
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
         Error.PlatformError => err,
         else => unreachable,
     };
@@ -245,7 +241,6 @@ pub inline fn getName(self: Joystick) Error!?[:0]const u8 {
     internal_debug.assertInitialized();
     const name_opt = c.glfwGetJoystickName(@enumToInt(self.jid));
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
         Error.PlatformError => err,
         else => unreachable,
     };
@@ -286,7 +281,6 @@ pub inline fn getGUID(self: Joystick) Error!?[:0]const u8 {
     internal_debug.assertInitialized();
     const guid_opt = c.glfwGetJoystickGUID(@enumToInt(self.jid));
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
         Error.PlatformError => err,
         else => unreachable,
     };
@@ -401,7 +395,7 @@ pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) Error!void 
     internal_debug.assertInitialized();
     _ = c.glfwUpdateGamepadMappings(gamepad_mappings);
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
+        Error.InvalidValue => err, // TODO: Evaluate if this is preventable, or if this is like a parsing error which should definitely be returned
         else => unreachable,
     };
 }
@@ -424,10 +418,7 @@ pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) Error!void 
 pub inline fn isGamepad(self: Joystick) bool {
     internal_debug.assertInitialized();
     const is_gamepad = c.glfwJoystickIsGamepad(@enumToInt(self.jid));
-    getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
-        else => unreachable,
-    };
+    getError() catch unreachable;
     return is_gamepad == c.GLFW_TRUE;
 }
 
@@ -454,7 +445,6 @@ pub inline fn getGamepadName(self: Joystick) Error!?[:0]const u8 {
     internal_debug.assertInitialized();
     const name_opt = c.glfwGetGamepadName(@enumToInt(self.jid));
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
         else => unreachable,
     };
     return if (name_opt) |name|
@@ -487,14 +477,11 @@ pub inline fn getGamepadName(self: Joystick) Error!?[:0]const u8 {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: gamepad, glfw.UpdateGamepadMappings, glfw.Joystick.isGamepad
-pub inline fn getGamepadState(self: Joystick) Error!?GamepadState {
+pub inline fn getGamepadState(self: Joystick) ?GamepadState {
     internal_debug.assertInitialized();
     var state: GamepadState = undefined;
     const success = c.glfwGetGamepadState(@enumToInt(self.jid), @ptrCast(*c.GLFWgamepadstate, &state));
-    getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // intentionally invalid enum value
-        else => unreachable,
-    };
+    getError() catch unreachable;
     return if (success == c.GLFW_TRUE) state else null;
 }
 
@@ -626,7 +613,7 @@ test "getGamepadState" {
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
-    _ = joystick.getGamepadState() catch |err| std.debug.print("failed to get gamepad state, joysticks not supported? error={}\n", .{err});
+    _ = joystick.getGamepadState();
     _ = (std.mem.zeroes(GamepadState)).getAxis(.left_x);
     _ = (std.mem.zeroes(GamepadState)).getButton(.dpad_up);
 }

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -1707,7 +1707,7 @@ pub inline fn getInputMode(self: Window, mode: InputMode) isize {
     const value = c.glfwGetInputMode(self.handle, @enumToInt(mode));
 
     // Possible errors: 'GLFW_NOT_INITIALIZED' and 'GLFW_INVALID_ENUM'; we guarantee both to be unreachable
-    getError() catch unreachable; 
+    getError() catch unreachable;
 
     return @intCast(isize, value);
 }

--- a/glfw/src/errors.zig
+++ b/glfw/src/errors.zig
@@ -11,12 +11,6 @@ pub const Error = error{
     /// glfw.SwapInterval.
     NoCurrentContext,
 
-    /// One of the arguments to the function was an invalid enum value.
-    ///
-    /// One of the arguments to the function was an invalid enum value, for example requesting
-    /// glfw.red_bits with glfw.getWindowAttrib.
-    InvalidEnum,
-
     /// One of the arguments to the function was an invalid value.
     ///
     /// One of the arguments to the function was an invalid value, for example requesting a
@@ -86,7 +80,7 @@ fn convertError(e: c_int) Error!void {
         c.GLFW_NO_ERROR => {},
         c.GLFW_NOT_INITIALIZED => unreachable,
         c.GLFW_NO_CURRENT_CONTEXT => Error.NoCurrentContext,
-        c.GLFW_INVALID_ENUM => Error.InvalidEnum,
+        c.GLFW_INVALID_ENUM => unreachable,
         c.GLFW_INVALID_VALUE => Error.InvalidValue,
         c.GLFW_OUT_OF_MEMORY => Error.OutOfMemory,
         c.GLFW_API_UNAVAILABLE => Error.APIUnavailable,

--- a/glfw/src/key.zig
+++ b/glfw/src/key.zig
@@ -243,7 +243,6 @@ pub const Key = enum(c_int) {
         internal_debug.assertInitialized();
         const scancode = cc.glfwGetKeyScancode(@enumToInt(self));
         getError() catch |err| return switch (err) {
-            Error.InvalidEnum => unreachable, // Should be unreachable for any valid 'Key' value.
             Error.PlatformError => err,
             else => unreachable,
         };

--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -177,7 +177,6 @@ fn initHint(hint: InitHint, value: anytype) Error!void {
         else => @compileError("expected a int or bool, got " ++ @typeName(@TypeOf(value))),
     }
     getError() catch |err| return switch (err) {
-        Error.InvalidEnum => unreachable, // impossible for any valid 'InitHint' value
         Error.InvalidValue => err,
         else => unreachable,
     };


### PR DESCRIPTION
An initial effort to eliminate the need for `InvalidEnum`; there are a couple of places preventing straight removal of the error, so I'll have a look at the GLFW source to see if they can be omitted safely. 

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.