### PR TITLE
glfw: Eliminate `Error.InvalidValue`

### DIFF
--- a/glfw/src/Joystick.zig
+++ b/glfw/src/Joystick.zig
@@ -395,7 +395,11 @@ pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) Error!void 
     internal_debug.assertInitialized();
     _ = c.glfwUpdateGamepadMappings(gamepad_mappings);
     getError() catch |err| return switch (err) {
-        Error.InvalidValue => err, // TODO: Evaluate if this is preventable, or if this is like a parsing error which should definitely be returned
+        // TODO: Maybe return as 'ParseError' here?
+        // TODO: Look into upstream proposal for GLFW to publicize
+        // their Gamepad mappings parsing functions/interface
+        // for a better error message in debug.
+        Error.InvalidValue => err,
         else => unreachable,
     };
 }

--- a/glfw/src/Monitor.zig
+++ b/glfw/src/Monitor.zig
@@ -274,12 +274,15 @@ pub inline fn getVideoMode(self: Monitor) Error!VideoMode {
 /// see also: monitor_gamma
 pub inline fn setGamma(self: Monitor, gamma: f32) Error!void {
     internal_debug.assertInitialized();
+
+    std.debug.assert(!std.math.isNan(gamma));
+    std.debug.assert(gamma >= 0);
+    std.debug.assert(gamma <= std.math.f32_max);
+
     c.glfwSetGamma(self.handle, gamma);
     getError() catch |err| return switch (err) {
-        // TODO: Consider whether to assert that 'gamma' is a valid value instead of leaving it to GLFW's error handling.
-        Error.InvalidValue,
-        Error.PlatformError,
-        => err,
+        Error.InvalidValue => unreachable, // we assert that 'gamma' is a valid value, so this should be impossible
+        Error.PlatformError => err,
         else => unreachable,
     };
 }

--- a/glfw/src/opengl.zig
+++ b/glfw/src/opengl.zig
@@ -131,13 +131,16 @@ pub inline fn swapInterval(interval: isize) Error!void {
 /// @thread_safety This function may be called from any thread.
 ///
 /// see also: context_glext, glfw.getProcAddress
-pub inline fn extensionSupported(extension: [*:0]const u8) Error!bool {
+pub inline fn extensionSupported(extension: [:0]const u8) Error!bool {
     internal_debug.assertInitialized();
+    
+    std.debug.assert(extension.len != 0);
+    std.debug.assert(extension[0] != 0);
+    
     const supported = c.glfwExtensionSupported(extension);
     getError() catch |err| return switch (err) {
-        Error.NoCurrentContext,
-        Error.InvalidValue,
-        => err,
+        Error.NoCurrentContext => err,
+        Error.InvalidValue => unreachable, // we assert that 'extension' is a minimally valid value, so this should be impossible
         else => unreachable,
     };
     return supported == c.GLFW_TRUE;

--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -219,9 +219,9 @@ pub inline fn createWindowSurface(vk_instance: anytype, window: Window, vk_alloc
         @ptrCast(*c.VkSurfaceKHR, @alignCast(@alignOf(*c.VkSurfaceKHR), vk_surface_khr)),
     );
     getError() catch |err| return switch (err) {
+        Error.InvalidValue => @panic("Attempted to use window with client api to create vulkan surface."),
         Error.APIUnavailable,
         Error.PlatformError,
-        Error.InvalidValue,
         => err,
         else => unreachable,
     };


### PR DESCRIPTION
Closes #101.

As will be noted, the actual error hasn't been deleted, but measures have been taken such that it will never be encountered as an error by the user, save for in the case of `Joystick.updateGamepadMappings`, which will be changed to have its own error `ParseError` later on, when errors are denormalized. 

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.