### PR TITLE
glfw: support building with latest Zig master

### DIFF
--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -218,17 +218,9 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
             }
             step.linkSystemLibrary("objc");
             step.linkFramework("AppKit");
-
-            // TODO(system_sdk): update MacOS system SDK so we can remove this, see:
-            // https://github.com/hexops/mach/pull/63#issuecomment-962141088
-            switch (@import("builtin").target.os.tag) {
-                .macos => {},
-                else => {
-                    step.linkFramework("CoreServices");
-                    step.linkFramework("CoreGraphics");
-                    step.linkFramework("Foundation");
-                },
-            }
+            step.linkFramework("CoreServices");
+            step.linkFramework("CoreGraphics");
+            step.linkFramework("Foundation");
         },
         else => {
             // Assume Linux-like


### PR DESCRIPTION
This removes a linker hack which was preventing building with the latest
Zig master version. Of particular note, anyone wishing to use this library
will need to ensure they are up to date with latest master.

The binary releases available at https://ziglang.org/download/ (1783+eec825c and
beyond) are sufficient (really, anything released after today.)

Fixes hexops/mach#103

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.