### PR TITLE
glfw: system_sdk version pinning, automatic updates, and correctex Apple license prompt

### DIFF
--- a/glfw/system_sdk.zig
+++ b/glfw/system_sdk.zig
@@ -132,7 +132,7 @@ fn getSdkRoot(allocator: *std.mem.Allocator, org: []const u8, name: []const u8) 
     } else |err| return switch (err) {
         error.FileNotFound => {
             std.log.info("cloning required sdk..\ngit clone https://github.com/{s}/{s} '{s}'..\n", .{ org, name, sdk_root_dir });
-            if (std.mem.eql(u8, name, "sdk-macos-12.0")) {
+            if (std.mem.startsWith(u8, name, "sdk-macos-")) {
                 if (!try confirmAppleSDKAgreement(allocator)) @panic("cannot continue");
             }
             try std.fs.cwd().makePath(sdk_path_dir);

--- a/glfw/system_sdk.zig
+++ b/glfw/system_sdk.zig
@@ -43,7 +43,7 @@ pub const Options = struct {
     macos_sdk_11: []const u8 = "sdk-macos-11.3",
 
     /// The Linux x86-64 SDK repository name.
-    linux_x86_64_sdk: []const u8 = "sdk-linux-x86_64",
+    linux_x86_64: []const u8 = "sdk-linux-x86_64",
 
     /// If true, the Builder.sysroot will set to the SDK path. This has the drawback of preventing
     /// you from including headers, libraries, etc. from outside the SDK generally. However, it can
@@ -88,7 +88,7 @@ fn includeSdkMacOS(b: *Builder, step: *std.build.LibExeObjStep, options: Options
 }
 
 fn includeSdkLinuxX8664(b: *Builder, step: *std.build.LibExeObjStep, options: Options) void {
-    const sdk_root_dir = getSdkRoot(b.allocator, options.github_org, options.linux_x86_64_sdk) catch unreachable;
+    const sdk_root_dir = getSdkRoot(b.allocator, options.github_org, options.linux_x86_64) catch unreachable;
     defer b.allocator.free(sdk_root_dir);
 
     if (options.set_sysroot) {


### PR DESCRIPTION
This brings various improvements to the way we use native system SDKs:

1. Fixed a bug where the Apple SDK license prompt would not appear for older SDKs.
2. We now pin and auto-update SDK versions, see commit message for details: https://github.com/hexops/mach/commit/dfcfb5ba4851af8bd3485dfdd94ea1a7af1fdc9c

Helps hexops/mach#108

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.