### PR TITLE
glfw: Fix pointer cast

### DIFF
--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -215,8 +215,8 @@ pub inline fn createWindowSurface(vk_instance: anytype, window: Window, vk_alloc
     const v = c.glfwCreateWindowSurface(
         instance,
         window.handle,
-        if (vk_allocation_callbacks == null) null else @ptrCast(*c.VkAllocationCallbacks, @alignCast(@alignOf(*c.VkAllocationCallbacks), vk_allocation_callbacks)),
-        @ptrCast(*c.VkSurfaceKHR, @alignCast(@alignOf(*c.VkSurfaceKHR), vk_surface_khr)),
+        if (vk_allocation_callbacks == null) null else @ptrCast(*const c.VkAllocationCallbacks, @alignCast(@alignOf(c.VkAllocationCallbacks), vk_allocation_callbacks)),
+        @ptrCast(*c.VkSurfaceKHR, @alignCast(@alignOf(c.VkSurfaceKHR), vk_surface_khr)),
     );
     getError() catch |err| return switch (err) {
         Error.InvalidValue => @panic("Attempted to use window with client api to create vulkan surface."),


### PR DESCRIPTION
The GLFW implementation takes a constant pointer to a `VkAllocationCallbacks` struct; casting it to a mutable pointer equivalent here doesn't break anything, but does prevent passing a valid const pointer, which is often what one should prefer to do.
As well, the `@alignOf` builtin takes the alignment expected of the type directly, so `@alignOf(*T)` returns the alignment of `*T`, not `T`, so that has also been corrected.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.