### PR TITLE
glfw: replace usage of glfw.dont_care as sentinel value

### DIFF
--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -704,6 +704,8 @@ pub inline fn setSize(self: Window, size: Size) error{PlatformError}!void {
     };
 }
 
+/// A size with option width/height, used to represent e.g. constraints on a windows size while
+/// allowing specific axis to be unconstrained (null) if desired.
 pub const SizeOptional = struct {
     width: ?usize,
     height: ?usize,

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -1424,9 +1424,6 @@ pub inline fn setPosCallback(self: Window, callback: ?fn (window: Window, xpos: 
     };
 }
 
-// TODO: don't the calls to `from` in these `set*CallbackWrapper` functions cause a leak?
-// is this what's being reported by valgrind in [#60](https://github.com/hexops/mach/issues/60)?
-
 fn setSizeCallbackWrapper(handle: ?*c.GLFWwindow, width: c_int, height: c_int) callconv(.C) void {
     internal_debug.assertInitialized();
     const window = from(handle.?) catch unreachable;

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -272,7 +272,7 @@ pub const Hints = struct {
             const hint_value = @field(hints, field_name);
             switch (@TypeOf(hint_value)) {
                 bool => c.glfwWindowHint(hint_tag, @boolToInt(hint_value)),
-                ?PositiveCInt => c.glfwWindowHint(hint_tag, if (hint_value) |refresh_rate| refresh_rate else glfw.dont_care),
+                ?PositiveCInt => c.glfwWindowHint(hint_tag, if (hint_value) |unwrapped| unwrapped else glfw.dont_care),
                 c_int => c.glfwWindowHint(hint_tag, hint_value),
 
                 ClientAPI,


### PR DESCRIPTION
Change some parameters in `glfw.Window` functions to accept null in place of `glfw.dont_care` as a sentinel value.

Closes #119.

This is a quick change, but there are other places where `glfw.dont_care` is an accepted value to ask for "default behavior", such as in hints; should we also change those to be null-able, or leave them as is?

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.