### PR TITLE
glfw: reduce compilation units to bring iteration time down to ~90ms

### DIFF
--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -56,61 +56,13 @@ fn buildLibrary(b: *Builder, step: *std.build.LibExeObjStep, options: Options) *
     // TODO(build-system): pass system SDK options through
     system_sdk.include(b, step, .{});
     const target = (std.zig.system.NativeTargetInfo.detect(b.allocator, step.target) catch unreachable).target;
+    const include_glfw_src = "-I" ++ thisDir() ++ "/upstream/glfw/src";
     switch (target.os.tag) {
-        .windows => {
-            var sources = std.ArrayList([]const u8).init(b.allocator);
-            for ([_][]const u8{
-                // Windows-specific sources
-                "upstream/glfw/src/win32_thread.c",
-                "upstream/glfw/src/wgl_context.c",
-                "upstream/glfw/src/win32_init.c",
-                "upstream/glfw/src/win32_monitor.c",
-                "upstream/glfw/src/win32_time.c",
-                "upstream/glfw/src/win32_joystick.c",
-                "upstream/glfw/src/win32_window.c",
-
-                // General sources
-                "upstream/glfw/src/monitor.c",
-                "upstream/glfw/src/init.c",
-                "upstream/glfw/src/vulkan.c",
-                "upstream/glfw/src/input.c",
-                "upstream/glfw/src/osmesa_context.c",
-                "upstream/glfw/src/egl_context.c",
-                "upstream/glfw/src/context.c",
-                "upstream/glfw/src/window.c",
-            }) |path| {
-                const abs_path = std.fs.path.join(b.allocator, &.{ thisDir(), path }) catch unreachable;
-                sources.append(abs_path) catch unreachable;
-            }
-            lib.addCSourceFiles(sources.items, &.{"-D_GLFW_WIN32"});
-        },
-        .macos => {
-            var sources = std.ArrayList([]const u8).init(b.allocator);
-            for ([_][]const u8{
-                // MacOS-specific sources
-                "upstream/glfw/src/cocoa_joystick.m",
-                "upstream/glfw/src/cocoa_init.m",
-                "upstream/glfw/src/cocoa_window.m",
-                "upstream/glfw/src/cocoa_time.c",
-                "upstream/glfw/src/cocoa_monitor.m",
-                "upstream/glfw/src/nsgl_context.m",
-                "upstream/glfw/src/posix_thread.c",
-
-                // General sources
-                "upstream/glfw/src/monitor.c",
-                "upstream/glfw/src/init.c",
-                "upstream/glfw/src/vulkan.c",
-                "upstream/glfw/src/input.c",
-                "upstream/glfw/src/osmesa_context.c",
-                "upstream/glfw/src/egl_context.c",
-                "upstream/glfw/src/context.c",
-                "upstream/glfw/src/window.c",
-            }) |path| {
-                const abs_path = std.fs.path.join(b.allocator, &.{ thisDir(), path }) catch unreachable;
-                sources.append(abs_path) catch unreachable;
-            }
-            lib.addCSourceFiles(sources.items, &.{"-D_GLFW_COCOA"});
-        },
+        .windows => lib.addCSourceFile(thisDir() ++ "/src/sources_windows.c", &.{ "-D_GLFW_WIN32", include_glfw_src }),
+        .macos => lib.addCSourceFiles(&.{
+            thisDir() ++ "/src/sources_macos.m",
+            thisDir() ++ "/src/sources_macos.c",
+        }, &.{ "-D_GLFW_COCOA", include_glfw_src }),
         else => {
             // TODO(future): for now, Linux must be built with glibc, not musl:
             //
@@ -121,60 +73,17 @@ fn buildLibrary(b: *Builder, step: *std.build.LibExeObjStep, options: Options) *
             step.target.abi = .gnu;
             lib.setTarget(step.target);
 
-            var general_sources = std.ArrayList([]const u8).init(b.allocator);
+            var sources = std.ArrayList([]const u8).init(b.allocator);
             const flag = switch (options.linux_window_manager) {
                 .X11 => "-D_GLFW_X11",
                 .Wayland => "-D_GLFW_WAYLAND",
             };
-            for ([_][]const u8{
-                // General Linux-like sources
-                "upstream/glfw/src/posix_time.c",
-                "upstream/glfw/src/posix_thread.c",
-                "upstream/glfw/src/linux_joystick.c",
-
-                // General sources
-                "upstream/glfw/src/monitor.c",
-                "upstream/glfw/src/init.c",
-                "upstream/glfw/src/vulkan.c",
-                "upstream/glfw/src/input.c",
-                "upstream/glfw/src/osmesa_context.c",
-                "upstream/glfw/src/egl_context.c",
-                "upstream/glfw/src/context.c",
-                "upstream/glfw/src/window.c",
-            }) |path| {
-                const abs_path = std.fs.path.join(b.allocator, &.{ thisDir(), path }) catch unreachable;
-                general_sources.append(abs_path) catch unreachable;
-            }
-            lib.addCSourceFiles(general_sources.items, &.{flag});
-
+            sources.append(thisDir() ++ "/src/sources_linux.c") catch unreachable;
             switch (options.linux_window_manager) {
-                .X11 => {
-                    var x11_sources = std.ArrayList([]const u8).init(b.allocator);
-                    for ([_][]const u8{
-                        "upstream/glfw/src/x11_init.c",
-                        "upstream/glfw/src/x11_window.c",
-                        "upstream/glfw/src/x11_monitor.c",
-                        "upstream/glfw/src/xkb_unicode.c",
-                        "upstream/glfw/src/glx_context.c",
-                    }) |path| {
-                        const abs_path = std.fs.path.join(b.allocator, &.{ thisDir(), path }) catch unreachable;
-                        x11_sources.append(abs_path) catch unreachable;
-                    }
-                    lib.addCSourceFiles(x11_sources.items, &.{flag});
-                },
-                .Wayland => {
-                    var wayland_sources = std.ArrayList([]const u8).init(b.allocator);
-                    for ([_][]const u8{
-                        "upstream/glfw/src/wl_monitor.c",
-                        "upstream/glfw/src/wl_window.c",
-                        "upstream/glfw/src/wl_init.c",
-                    }) |path| {
-                        const abs_path = std.fs.path.join(b.allocator, &.{ thisDir(), path }) catch unreachable;
-                        wayland_sources.append(abs_path) catch unreachable;
-                    }
-                    lib.addCSourceFiles(wayland_sources.items, &.{flag});
-                },
+                .X11 => sources.append(thisDir() ++ "/src/sources_linux_x11.c") catch unreachable,
+                .Wayland => sources.append(thisDir() ++ "/src/sources_linux_wayland.c") catch unreachable,
             }
+            lib.addCSourceFiles(sources.items, &.{ flag, "-I" ++ thisDir() ++ "/upstream/glfw/src" });
         },
     }
     linkGLFWDependencies(b, lib, options);

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -293,7 +293,6 @@ pub const Hints = struct {
                 else => unreachable,
             };
         }
-
     }
 };
 

--- a/glfw/src/sources_all.c
+++ b/glfw/src/sources_all.c
@@ -1,0 +1,9 @@
+// General sources
+#include "monitor.c"
+#include "init.c"
+#include "vulkan.c"
+#include "input.c"
+#include "osmesa_context.c"
+#include "egl_context.c"
+#include "context.c"
+#include "window.c"

--- a/glfw/src/sources_linux.c
+++ b/glfw/src/sources_linux.c
@@ -1,0 +1,6 @@
+#include "sources_all.c"
+
+// General Linux-like sources
+#include "posix_time.c"
+#include "posix_thread.c"
+#include "linux_joystick.c"

--- a/glfw/src/sources_linux_wayland.c
+++ b/glfw/src/sources_linux_wayland.c
@@ -1,0 +1,4 @@
+// General Linux-like sources
+#include "wl_monitor.c"
+#include "wl_window.c"
+#include "wl_init.c"

--- a/glfw/src/sources_linux_x11.c
+++ b/glfw/src/sources_linux_x11.c
@@ -1,0 +1,6 @@
+// General Linux-like sources
+#include "x11_init.c"
+#include "x11_window.c"
+#include "x11_monitor.c"
+#include "xkb_unicode.c"
+#include "glx_context.c"

--- a/glfw/src/sources_macos.c
+++ b/glfw/src/sources_macos.c
@@ -1,0 +1,5 @@
+#include "sources_all.c"
+
+// MacOS-specific sources
+#include "cocoa_time.c"
+#include "posix_thread.c"

--- a/glfw/src/sources_macos.m
+++ b/glfw/src/sources_macos.m
@@ -1,0 +1,6 @@
+// MacOS-specific sources
+#include "cocoa_joystick.m"
+#include "cocoa_init.m"
+#include "cocoa_window.m"
+#include "cocoa_monitor.m"
+#include "nsgl_context.m"

--- a/glfw/src/sources_windows.c
+++ b/glfw/src/sources_windows.c
@@ -1,0 +1,10 @@
+#include "sources_all.c"
+
+// Windows-specific sources
+#include "win32_thread.c"
+#include "wgl_context.c"
+#include "win32_init.c"
+#include "win32_monitor.c"
+#include "win32_time.c"
+#include "win32_joystick.c"
+#include "win32_window.c"


### PR DESCRIPTION
This consistently shaves off about 40ms (~130ms -> ~90ms, 30% reduction) from build times when iterating.

On Windows, I suspect the result will be much greater due to slow filesystem perf there and the fact that this reduces the # of files read.

This was originally brought to my attention as a possibility by @meshula in hexops/dawn#2, the way this works is by reducing compilation units so that C headers only need to be read/parsed/interpreted once rather than once per individual C source file we are compiling.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.