### PR TITLE
gpu: Fix invalid parameter type of glfw framebuffer callback function

### DIFF
--- a/gpu/src/dawn/hello_triangle.zig
+++ b/gpu/src/dawn/hello_triangle.zig
@@ -116,7 +116,7 @@ pub fn main() !void {
     };
     setup.window.setUserPointer(CallbackPayload, &.{ .swap_chain = swap_chain, .swap_chain_format = swap_chain_format });
     setup.window.setFramebufferSizeCallback((struct {
-        fn callback(window: glfw.Window, width: isize, height: isize) void {
+        fn callback(window: glfw.Window, width: u32, height: u32) void {
             const pl = window.getUserPointer(*CallbackPayload);
             c.wgpuSwapChainConfigure(pl.?.swap_chain, pl.?.swap_chain_format, c.WGPUTextureUsage_RenderAttachment, @intCast(u32, width), @intCast(u32, height));
         }


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

The dawn example currently wasnt compiling because the parameter type of glfw's framebuffer callback was incorrect. This was a leftover from #126 

Feel free to close it if already done locally.