### PR TITLE
glfw: expose glfwSetErrorCallback for retrieving optional error descriptions

### DIFF
--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -8,8 +8,10 @@ const key = @import("key.zig");
 /// Possible value for various window hints, etc.
 pub const dont_care = c.GLFW_DONT_CARE;
 
-pub const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
+const errors = @import("errors.zig");
+const getError = errors.getError;
+pub const setErrorCallback = errors.setErrorCallback;
+pub const Error = errors.Error;
 
 pub const Action = @import("action.zig").Action;
 pub const GamepadAxis = @import("gamepad_axis.zig").GamepadAxis;


### PR DESCRIPTION

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

closes #144 