### PR TITLE
gpu-dawn: update to latest glfw get/setUserPointer API introduced in hexops/mach#152

### DIFF
--- a/gpu-dawn/src/dawn/hello_triangle.zig
+++ b/gpu-dawn/src/dawn/hello_triangle.zig
@@ -114,10 +114,10 @@ pub fn main() !void {
         swap_chain: c.WGPUSwapChain,
         swap_chain_format: c.WGPUTextureFormat,
     };
-    setup.window.setUserPointer(CallbackPayload, &.{ .swap_chain = swap_chain, .swap_chain_format = swap_chain_format });
+    setup.window.setUserPointer(&.{ .swap_chain = swap_chain, .swap_chain_format = swap_chain_format });
     setup.window.setFramebufferSizeCallback((struct {
         fn callback(window: glfw.Window, width: u32, height: u32) void {
-            const pl = window.getUserPointer(*CallbackPayload);
+            const pl = window.getUserPointer(CallbackPayload);
             c.wgpuSwapChainConfigure(pl.?.swap_chain, pl.?.swap_chain_format, c.WGPUTextureUsage_RenderAttachment, @intCast(u32, width), @intCast(u32, height));
         }
     }).callback);


### PR DESCRIPTION
@slimsag this PR fixes the `gpu-dawn/hello_triangle` example. All the build steps in `gpu-dawn/build.zig` are working for me now (tested on MacOS only). Not 100% sure I understand the pointer usage, but it seems to work for me.

Reference issues:

- https://github.com/hexops/mach/issues/153
- https://github.com/hexops/mach/pull/152

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.