### PR TITLE
glfw: Use `anyopaque` instead of `opaque{}`

### DIFF
--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -143,8 +143,8 @@ pub fn getInstanceProcAddress(vk_instance: ?*anyopaque, proc_name: [*:0]const u8
 ///
 /// see also: vulkan_present
 pub inline fn getPhysicalDevicePresentationSupport(
-    vk_instance: *opaque {},
-    vk_physical_device: *opaque {},
+    vk_instance: *anyopaque,
+    vk_physical_device: *anyopaque,
     queue_family: u32,
 ) error{ APIUnavailable, PlatformError }!bool {
     internal_debug.assertInitialized();

--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -109,7 +109,7 @@ pub const VKProc = fn () callconv(.C) void;
 /// @pointer_lifetime The returned function pointer is valid until the library is terminated.
 ///
 /// @thread_safety This function may be called from any thread.
-pub fn getInstanceProcAddress(vk_instance: ?*opaque {}, proc_name: [*:0]const u8) callconv(.C) ?VKProc {
+pub fn getInstanceProcAddress(vk_instance: ?*anyopaque, proc_name: [*:0]const u8) callconv(.C) ?VKProc {
     internal_debug.assertInitialized();
     const proc_address = c.glfwGetInstanceProcAddress(if (vk_instance) |v| @ptrCast(c.VkInstance, v) else null, proc_name);
     getError() catch |err| @panic(@errorName(err));


### PR DESCRIPTION
Using an inline `opaque{}` type forces the use of `@typeInfo` to cast to the specific type of the parameter.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.