### PR TITLE
glfw: dont use `@errSetCast`

### DIFF
--- a/glfw/src/Cursor.zig
+++ b/glfw/src/Cursor.zig
@@ -66,7 +66,7 @@ pub inline fn create(image: Image, xhot: i32, yhot: i32) error{PlatformError}!Cu
     const cursor = c.glfwCreateCursor(&img, @intCast(c_int, xhot), @intCast(c_int, yhot));
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return Cursor{ .ptr = cursor.? };
@@ -87,7 +87,7 @@ pub inline fn createStandard(shape: Shape) error{PlatformError}!Cursor {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return Cursor{ .ptr = cursor.? };

--- a/glfw/src/Joystick.zig
+++ b/glfw/src/Joystick.zig
@@ -93,7 +93,7 @@ pub inline fn present(self: Joystick) error{PlatformError}!bool {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return is_present == c.GLFW_TRUE;
@@ -126,7 +126,7 @@ pub inline fn getAxes(self: Joystick) error{PlatformError}!?[]const f32 {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     if (axes == null) return null;
@@ -164,7 +164,7 @@ pub inline fn getButtons(self: Joystick) error{PlatformError}!?[]const u8 {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     if (buttons == null) return null;
@@ -218,7 +218,7 @@ pub inline fn getHats(self: Joystick) error{PlatformError}!?[]const Hat {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     if (hats == null) return null;
@@ -251,7 +251,7 @@ pub inline fn getName(self: Joystick) error{PlatformError}!?[:0]const u8 {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return if (name_opt) |name|
@@ -293,7 +293,7 @@ pub inline fn getGUID(self: Joystick) error{PlatformError}!?[:0]const u8 {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return if (guid_opt) |guid|
@@ -421,7 +421,7 @@ pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) error{Inval
         // TODO: Look into upstream proposal for GLFW to publicize
         // their Gamepad mappings parsing functions/interface
         // for a better error message in debug.
-        Error.InvalidValue => @errSetCast(error{InvalidValue}, err),
+        Error.InvalidValue => |e| e,
         else => unreachable,
     };
 }

--- a/glfw/src/Monitor.zig
+++ b/glfw/src/Monitor.zig
@@ -39,7 +39,7 @@ pub inline fn getPos(self: Monitor) error{PlatformError}!Pos {
     c.glfwGetMonitorPos(self.handle, &xpos, &ypos);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return Pos{ .x = @intCast(u32, xpos), .y = @intCast(u32, ypos) };
@@ -74,7 +74,7 @@ pub inline fn getWorkarea(self: Monitor) error{PlatformError}!Workarea {
     c.glfwGetMonitorWorkarea(self.handle, &xpos, &ypos, &width, &height);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return Workarea{ .x = @intCast(u32, xpos), .y = @intCast(u32, ypos), .width = @intCast(u32, width), .height = @intCast(u32, height) };
@@ -142,7 +142,7 @@ pub inline fn getContentScale(self: Monitor) error{PlatformError}!ContentScale {
     c.glfwGetMonitorContentScale(self.handle, &x_scale, &y_scale);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return ContentScale{ .x_scale = @floatCast(f32, x_scale), .y_scale = @floatCast(f32, y_scale) };
@@ -237,7 +237,7 @@ pub inline fn getVideoModes(self: Monitor, allocator: mem.Allocator) (mem.Alloca
     const modes = c.glfwGetVideoModes(self.handle, &count);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 
@@ -265,7 +265,7 @@ pub inline fn getVideoMode(self: Monitor) error{PlatformError}!VideoMode {
     const mode = c.glfwGetVideoMode(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return VideoMode{ .handle = mode.?.* };
@@ -301,7 +301,7 @@ pub inline fn setGamma(self: Monitor, gamma: f32) error{PlatformError}!void {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidValue => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -326,7 +326,7 @@ pub inline fn getGammaRamp(self: Monitor) error{PlatformError}!GammaRamp {
     const ramp = c.glfwGetGammaRamp(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return GammaRamp.fromC(ramp.*);
@@ -362,7 +362,7 @@ pub inline fn setGammaRamp(self: Monitor, ramp: GammaRamp) error{PlatformError}!
     c.glfwSetGammaRamp(self.handle, &ramp.toC());
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }

--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -437,10 +437,11 @@ pub inline fn create(
         Error.InvalidEnum => unreachable,
         Error.InvalidValue => unreachable,
         Error.APIUnavailable,
+        Error.PlatformError,
         Error.VersionUnavailable,
         Error.FormatUnavailable,
-        Error.PlatformError,
-        => @errSetCast(error{ APIUnavailable, VersionUnavailable, FormatUnavailable, PlatformError }, err),
+        => |e| e,
+
         else => unreachable,
     };
 
@@ -537,7 +538,7 @@ pub inline fn setTitle(self: Window, title: [*:0]const u8) error{PlatformError}!
     c.glfwSetWindowTitle(self.handle, title);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -580,7 +581,7 @@ pub inline fn setIcon(self: Window, allocator: mem.Allocator, images: ?[]Image) 
     } else c.glfwSetWindowIcon(self.handle, 0, null);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -610,7 +611,7 @@ pub inline fn getPos(self: Window) error{PlatformError}!Pos {
     c.glfwGetWindowPos(self.handle, &x, &y);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return Pos{ .x = @intCast(u32, x), .y = @intCast(u32, y) };
@@ -641,7 +642,7 @@ pub inline fn setPos(self: Window, pos: Pos) error{PlatformError}!void {
     c.glfwSetWindowPos(self.handle, @intCast(c_int, pos.x), @intCast(c_int, pos.y));
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -669,7 +670,7 @@ pub inline fn getSize(self: Window) error{PlatformError}!Size {
     c.glfwGetWindowSize(self.handle, &width, &height);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return Size{ .width = @intCast(u32, width), .height = @intCast(u32, height) };
@@ -702,7 +703,7 @@ pub inline fn setSize(self: Window, size: Size) error{PlatformError}!void {
     c.glfwSetWindowSize(self.handle, @intCast(c_int, size.width), @intCast(c_int, size.height));
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -755,7 +756,7 @@ pub inline fn setSizeLimits(self: Window, min: SizeOptional, max: SizeOptional) 
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidValue => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -802,7 +803,7 @@ pub inline fn setAspectRatio(self: Window, numerator: ?u32, denominator: ?u32) e
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidValue => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -824,7 +825,7 @@ pub inline fn getFramebufferSize(self: Window) error{PlatformError}!Size {
     c.glfwGetFramebufferSize(self.handle, &width, &height);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return Size{ .width = @intCast(u32, width), .height = @intCast(u32, height) };
@@ -860,7 +861,7 @@ pub inline fn getFrameSize(self: Window) error{PlatformError}!FrameSize {
     c.glfwGetWindowFrameSize(self.handle, &left, &top, &right, &bottom);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return FrameSize{
@@ -900,7 +901,7 @@ pub inline fn getContentScale(self: Window) error{PlatformError}!ContentScale {
     c.glfwGetWindowContentScale(self.handle, &x_scale, &y_scale);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return ContentScale{ .x_scale = x_scale, .y_scale = y_scale };
@@ -926,7 +927,7 @@ pub inline fn getOpacity(self: Window) error{PlatformError}!f32 {
     const opacity = c.glfwGetWindowOpacity(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return opacity;
@@ -954,7 +955,7 @@ pub inline fn setOpacity(self: Window, opacity: f32) error{PlatformError}!void {
     c.glfwSetWindowOpacity(self.handle, opacity);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -980,7 +981,7 @@ pub inline fn iconify(self: Window) error{PlatformError}!void {
     c.glfwIconifyWindow(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1003,7 +1004,7 @@ pub inline fn restore(self: Window) error{PlatformError}!void {
     c.glfwRestoreWindow(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1025,7 +1026,7 @@ pub inline fn maximize(self: Window) error{PlatformError}!void {
     c.glfwMaximizeWindow(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1049,7 +1050,7 @@ pub inline fn show(self: Window) error{PlatformError}!void {
     c.glfwShowWindow(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1069,7 +1070,7 @@ pub inline fn hide(self: Window) error{PlatformError}!void {
     c.glfwHideWindow(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1103,7 +1104,7 @@ pub inline fn focus(self: Window) error{PlatformError}!void {
     c.glfwFocusWindow(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1128,7 +1129,7 @@ pub inline fn requestAttention(self: Window) error{PlatformError}!void {
     c.glfwRequestWindowAttention(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1159,9 +1160,7 @@ pub inline fn swapBuffers(self: Window) error{ NoWindowContext, PlatformError }!
     c.glfwSwapBuffers(self.handle);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.NoWindowContext,
-        Error.PlatformError,
-        => @errSetCast(error{ NoWindowContext, PlatformError }, err),
+        Error.NoWindowContext, Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1243,7 +1242,7 @@ pub inline fn setMonitor(self: Window, monitor: ?Monitor, xpos: i32, ypos: i32, 
     );
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1302,7 +1301,7 @@ pub inline fn getAttrib(self: Window, attrib: Attrib) error{PlatformError}!i32 {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return v;
@@ -1348,7 +1347,7 @@ pub inline fn setAttrib(self: Window, attrib: Attrib, value: bool) error{Platfor
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
         Error.InvalidValue => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1873,7 +1872,7 @@ pub inline fn setInputMode(self: Window, mode: InputMode, value: anytype) error{
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidEnum => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -1978,7 +1977,7 @@ pub inline fn getCursorPos(self: Window) error{PlatformError}!CursorPos {
     c.glfwGetCursorPos(self.handle, &pos.xpos, &pos.ypos);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
     return pos;
@@ -2014,7 +2013,7 @@ pub inline fn setCursorPos(self: Window, xpos: f64, ypos: f64) error{PlatformErr
     c.glfwSetCursorPos(self.handle, xpos, ypos);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -2039,7 +2038,7 @@ pub inline fn setCursor(self: Window, cursor: Cursor) error{PlatformError}!void 
     c.glfwSetCursor(self.handle, cursor.ptr);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }

--- a/glfw/src/clipboard.zig
+++ b/glfw/src/clipboard.zig
@@ -24,7 +24,7 @@ pub inline fn setClipboardString(value: [*:0]const u8) error{PlatformError}!void
     c.glfwSetClipboardString(null, value);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -51,9 +51,7 @@ pub inline fn getClipboardString() error{ FormatUnavailable, PlatformError }![:0
     const value = c.glfwGetClipboardString(null);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.FormatUnavailable,
-        Error.PlatformError,
-        => @errSetCast(error{ FormatUnavailable, PlatformError }, err),
+        Error.FormatUnavailable, Error.PlatformError => |e| e,
         else => unreachable,
     };
     return std.mem.span(value);

--- a/glfw/src/key.zig
+++ b/glfw/src/key.zig
@@ -219,7 +219,7 @@ pub const Key = enum(c_int) {
         const name_opt = cc.glfwGetKeyName(@enumToInt(self), @intCast(c_int, scancode));
         getError() catch |err| return switch (err) {
             Error.NotInitialized => unreachable,
-            Error.PlatformError => @errSetCast(error{PlatformError}, err),
+            Error.PlatformError => |e| e,
             else => unreachable,
         };
         return if (name_opt) |name|
@@ -246,7 +246,7 @@ pub const Key = enum(c_int) {
         getError() catch |err| return switch (err) {
             Error.NotInitialized => unreachable,
             Error.InvalidEnum => unreachable,
-            Error.PlatformError => @errSetCast(error{PlatformError}, err),
+            Error.PlatformError => |e| e,
             else => unreachable,
         };
         return scancode;

--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -76,7 +76,7 @@ pub inline fn init(hints: InitHints) error{PlatformError}!void {
 
     _ = c.glfwInit();
     getError() catch |err| return switch (err) {
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -247,7 +247,7 @@ pub inline fn pollEvents() error{PlatformError}!void {
     c.glfwPollEvents();
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -287,7 +287,7 @@ pub inline fn waitEvents() error{PlatformError}!void {
     c.glfwWaitEvents();
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -335,7 +335,7 @@ pub inline fn waitEventsTimeout(timeout: f64) error{PlatformError}!void {
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidValue => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -355,7 +355,7 @@ pub inline fn postEmptyEvent() error{PlatformError}!void {
     c.glfwPostEmptyEvent();
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.PlatformError => @errSetCast(error{PlatformError}, err),
+        Error.PlatformError => |e| e,
         else => unreachable,
     };
 }

--- a/glfw/src/native.zig
+++ b/glfw/src/native.zig
@@ -134,7 +134,7 @@ pub fn Native(comptime options: BackendOptions) type {
             const context = native.glfwGetWGLContext(@ptrCast(*native.GLFWwindow, window.handle));
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| @errSetCast(error{NoWindowContext}, e),
+                Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return context;
@@ -180,7 +180,7 @@ pub fn Native(comptime options: BackendOptions) type {
             const context = native.glfwGetNSGLContext(@ptrCast(*native.GLFWwindow, window.handle));
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| @errSetCast(error{NoWindowContext}, e),
+                Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return context;
@@ -258,7 +258,7 @@ pub fn Native(comptime options: BackendOptions) type {
             native.glfwSetX11SelectionString(string);
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.PlatformError => |e| @errSetCast(error{PlatformError}, e),
+                Error.PlatformError => |e| e,
                 else => unreachable,
             };
         }
@@ -277,7 +277,7 @@ pub fn Native(comptime options: BackendOptions) type {
             const str = native.glfwGetX11SelectionString();
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.FormatUnavailable => |e| @errSetCast(error{FormatUnavailable}, e),
+                Error.FormatUnavailable => |e| e,
                 else => unreachable,
             };
             return str;
@@ -293,7 +293,7 @@ pub fn Native(comptime options: BackendOptions) type {
             const context = native.glfwGetGLXContext(@ptrCast(*native.GLFWwindow, window.handle));
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| @errSetCast(error{NoWindowContext}, e),
+                Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return @ptrCast(*anyopaque, context);
@@ -309,7 +309,7 @@ pub fn Native(comptime options: BackendOptions) type {
             const win = native.glfwGetGLXWindow(@ptrCast(*native.GLFWwindow, window.handle));
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| @errSetCast(error{NoWindowContext}, e),
+                Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return @ptrCast(*anyopaque, win);
@@ -385,7 +385,7 @@ pub fn Native(comptime options: BackendOptions) type {
             const context = native.glfwGetEGLContext(@ptrCast(*native.GLFWwindow, window.handle));
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| @errSetCast(error{NoWindowContext}, e),
+                Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return @ptrCast(*anyopaque, context);
@@ -401,7 +401,7 @@ pub fn Native(comptime options: BackendOptions) type {
             const surface = native.glfwGetEGLSurface(@ptrCast(*native.GLFWwindow, window.handle));
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| @errSetCast(error{NoWindowContext}, e),
+                Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return @ptrCast(*anyopaque, surface);
@@ -426,7 +426,7 @@ pub fn Native(comptime options: BackendOptions) type {
             _ = native.glfwGetOSMesaColorBuffer(@ptrCast(*native.GLFWwindow, window.handle), &buf.width, &buf.height, &buf.format, &buf.buffer);
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.PlatformError, Error.NoWindowContext => |e| @errSetCast(error{ PlatformError, NoWindowContext }, e),
+                Error.PlatformError, Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return buf;
@@ -451,7 +451,7 @@ pub fn Native(comptime options: BackendOptions) type {
             _ = native.glfwGetOSMesaDepthBuffer(@ptrCast(*native.GLFWwindow, window.handle), &buf.width, &buf.height, &buf.bytes_per_value, &buf.buffer);
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.PlatformError, Error.NoWindowContext => |e| @errSetCast(error{ PlatformError, NoWindowContext }, e),
+                Error.PlatformError, Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return buf;
@@ -467,7 +467,7 @@ pub fn Native(comptime options: BackendOptions) type {
             const context = native.glfwGetOSMesa(@ptrCast(*native.GLFWwindow, window.handle));
             getError() catch |err| return switch (err) {
                 Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| @errSetCast(error{NoWindowContext}, e),
+                Error.NoWindowContext => |e| e,
                 else => unreachable,
             };
             return @ptrCast(*anyopaque, context);

--- a/glfw/src/opengl.zig
+++ b/glfw/src/opengl.zig
@@ -36,9 +36,7 @@ pub inline fn makeContextCurrent(window: ?Window) error{ NoWindowContext, Platfo
     if (window) |w| c.glfwMakeContextCurrent(w.handle) else c.glfwMakeContextCurrent(null);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.NoWindowContext,
-        Error.PlatformError,
-        => @errSetCast(error{ NoWindowContext, PlatformError }, err),
+        Error.NoWindowContext, Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -104,9 +102,7 @@ pub inline fn swapInterval(interval: i32) error{ NoCurrentContext, PlatformError
     c.glfwSwapInterval(@intCast(c_int, interval));
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.NoCurrentContext,
-        Error.PlatformError,
-        => @errSetCast(error{ NoCurrentContext, PlatformError }, err),
+        Error.NoCurrentContext, Error.PlatformError => |e| e,
         else => unreachable,
     };
 }
@@ -144,9 +140,7 @@ pub inline fn extensionSupported(extension: [:0]const u8) error{ NoCurrentContex
 
     const supported = c.glfwExtensionSupported(extension);
     getError() catch |err| return switch (err) {
-        Error.NoCurrentContext,
-        Error.PlatformError,
-        => @errSetCast(error{ NoCurrentContext, PlatformError }, err),
+        Error.NoCurrentContext, Error.PlatformError => |e| e,
         Error.NotInitialized => unreachable,
         Error.InvalidValue => unreachable,
         else => unreachable,

--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -65,7 +65,7 @@ pub inline fn getRequiredInstanceExtensions() error{APIUnavailable}![][*:0]const
     const extensions = c.glfwGetRequiredInstanceExtensions(&count);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.APIUnavailable => @errSetCast(error{APIUnavailable}, err),
+        Error.APIUnavailable => |e| e,
         else => unreachable,
     };
     return @ptrCast([*][*:0]const u8, extensions)[0..count];
@@ -155,9 +155,7 @@ pub inline fn getPhysicalDevicePresentationSupport(
     );
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
-        Error.APIUnavailable,
-        Error.PlatformError,
-        => @errSetCast(error{ APIUnavailable, PlatformError }, err),
+        Error.APIUnavailable, Error.PlatformError => |e| e,
         else => unreachable,
     };
     return v == c.GLFW_TRUE;
@@ -226,9 +224,7 @@ pub inline fn createWindowSurface(vk_instance: anytype, window: Window, vk_alloc
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.InvalidValue => @panic("Attempted to use window with client api to create vulkan surface."),
-        Error.APIUnavailable,
-        Error.PlatformError,
-        => @errSetCast(error{ APIUnavailable, PlatformError }, err),
+        Error.APIUnavailable, Error.PlatformError => |e| e,
         else => unreachable,
     };
     return v;


### PR DESCRIPTION
In safe build modes `@errSetCast` emits *runtime* checks to validate the error is in the destination errorset.

As switches do errorset narrowing automatically `@errSetCast` is unnecessary and validation of the error being in the errorset occurs at compile time.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.