### PR TITLE
gpu-dawn: update Dawn to latest generated-2022-02-17

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "gpu-dawn/libs/dawn"]
 	path = gpu-dawn/libs/dawn
 	url = https://github.com/hexops/dawn.git
+	shallow = true
+	branch = "generated-2022-02-17"

--- a/gpu-dawn/.gitmodules
+++ b/gpu-dawn/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "libs/dawn"]
 	path = libs/dawn
 	url = https://github.com/hexops/dawn.git
+	shallow = true
+	branch = "generated-2022-02-17"

--- a/gpu-dawn/build.zig
+++ b/gpu-dawn/build.zig
@@ -492,6 +492,7 @@ fn buildLibDawnNative(b: *Builder, step: *std.build.LibExeObjStep, options: Opti
     appendDawnEnableBackendTypeFlags(&flags, options) catch unreachable;
     if (options.desktop_gl.?) {
         // OpenGL requires spriv-cross until Dawn moves OpenGL shader generation to Tint.
+        // TODO: need to verify this is still accurate, do we need spirv-cross at all anymore?
         flags.append(include("libs/dawn/third_party/vulkan-deps/spirv-cross/src")) catch unreachable;
     }
     flags.appendSlice(&.{
@@ -509,6 +510,8 @@ fn buildLibDawnNative(b: *Builder, step: *std.build.LibExeObjStep, options: Opti
         "-DTINT_BUILD_WGSL_WRITER=1",
         "-DTINT_BUILD_MSL_WRITER=1",
         "-DTINT_BUILD_HLSL_WRITER=1",
+        "-DTINT_BUILD_GLSL_WRITER=1",
+
         include("libs/dawn/third_party/tint"),
         include("libs/dawn/third_party/tint/include"),
 

--- a/gpu-dawn/src/dawn/dawn_native_mach.cpp
+++ b/gpu-dawn/src/dawn/dawn_native_mach.cpp
@@ -1,8 +1,8 @@
-#include <dawn_native/DawnNative.h>
-#include <dawn_native/wgpu_structs_autogen.h>
-#include "utils/BackendBinding.h"
+#include <dawn/native/DawnNative.h>
+#include <dawn/native/wgpu_structs_autogen.h>
+#include "dawn/utils/BackendBinding.h"
 #if defined(DAWN_ENABLE_BACKEND_OPENGL)
-#include <dawn_native/OpenGLBackend.h>
+#include <dawn/native/OpenGLBackend.h>
 #endif
 #include "dawn_native_mach.h"
 

--- a/gpu-dawn/src/dawn/hello_triangle.zig
+++ b/gpu-dawn/src/dawn/hello_triangle.zig
@@ -157,7 +157,7 @@ fn frame(params: FrameParams) !void {
     const pass = c.wgpuCommandEncoderBeginRenderPass(encoder, &render_pass_info);
     c.wgpuRenderPassEncoderSetPipeline(pass, params.pipeline);
     c.wgpuRenderPassEncoderDraw(pass, 3, 1, 0, 0);
-    c.wgpuRenderPassEncoderEndPass(pass);
+    c.wgpuRenderPassEncoderEnd(pass);
     c.wgpuRenderPassEncoderRelease(pass);
 
     const commands = c.wgpuCommandEncoderFinish(encoder, null);


### PR DESCRIPTION
Updates `gpu-dawn` to the latest upstream Dawn version.

https://github.com/hexops/dawn now has an even better generation strategy now, too:

* `upstream` branch tracks the dawn.googlesource.com upstream repo.
* `main` branch is `upstream` with our `mach/` generation scripts, and sometimes temporary patches we're upstreaming.
* `generated-2022-02-17` contains the result of updating `upstream` and `main`, then forking `main` and comitting the Dawn dependencies and generated code.

This makes updating Dawn easier, and by using separate `generated-<date>` branches we always get a clean history: we can trim down Dawn further, etc. to reduce the size. And we can more easily compare our changes against upstream and past generated branches.

`gpu-dawn` then targets a `generated-<date>` branch, and performs a shallow clone for faster source downloads.

Tested on:

* [x] aarch64-macos
* [x] x86_64-macos
* [x] x86_64-linux

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.