### PR TITLE
gpu-dawn: update example, use newer WGPUSurface API where available

### DIFF
--- a/glfw/src/main.zig
+++ b/glfw/src/main.zig
@@ -28,6 +28,7 @@ pub const VideoMode = @import("VideoMode.zig");
 pub const Window = @import("Window.zig");
 pub const Cursor = @import("Cursor.zig");
 pub const Native = @import("native.zig").Native;
+pub const BackendOptions = @import("native.zig").BackendOptions;
 pub const Key = key.Key;
 
 pub usingnamespace @import("clipboard.zig");

--- a/glfw/src/native.zig
+++ b/glfw/src/native.zig
@@ -8,7 +8,7 @@ const getError = @import("errors.zig").getError;
 
 const internal_debug = @import("internal_debug.zig");
 
-const BackendOptions = struct {
+pub const BackendOptions = struct {
     win32: bool = false,
     wgl: bool = false,
     cocoa: bool = false,

--- a/glfw/src/native.zig
+++ b/glfw/src/native.zig
@@ -167,7 +167,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// Possible errors include glfw.Error.NotInitalized.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
-        pub fn getCocoaWindow(window: Window) u32 {
+        pub fn getCocoaWindow(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
             const win = native.glfwGetCocoaWindow(@ptrCast(*native.GLFWwindow, window.handle));
             getError() catch |err| return switch (err) {

--- a/gpu-dawn/build.zig
+++ b/gpu-dawn/build.zig
@@ -107,6 +107,7 @@ pub const Options = struct {
             if (zero_debug_symbols) try flags.append("-g0") else try flags.append("-g1");
         }
         if (is_cpp) try flags.append("-std=c++17");
+        if (self.linux_window_manager != null and self.linux_window_manager.? == .X11) try flags.append("-DDAWN_USE_X11");
     }
 };
 

--- a/gpu-dawn/src/dawn/dawn_native_mach.cpp
+++ b/gpu-dawn/src/dawn/dawn_native_mach.cpp
@@ -223,6 +223,9 @@ MACH_EXPORT const DawnProcTable* machDawnNativeGetProcs() {
 
 
 // typedef struct MachUtilsBackendBindingImpl* MachUtilsBackendBinding;
+//
+// This is a legacy method. If using OpenGL, it must be used to create a backend binding
+// as Dawn does not yet support the WGPUSurface API for OpenGL yet. https://bugs.chromium.org/p/dawn/issues/detail?id=269&q=surface&can=2
 MACH_EXPORT MachUtilsBackendBinding machUtilsCreateBinding(WGPUBackendType backendType, GLFWwindow* window, WGPUDevice device) {
     wgpu::BackendType cppBackendType;
     switch (backendType) {
@@ -259,10 +262,14 @@ MACH_EXPORT MachUtilsBackendBinding machUtilsCreateBinding(WGPUBackendType backe
     return reinterpret_cast<MachUtilsBackendBinding>(utils::CreateBinding(cppBackendType, window, device));
 }
 
+// This is a legacy method. If using OpenGL, it must be used to create a backend binding
+// as Dawn does not yet support the WGPUSurface API for OpenGL yet. https://bugs.chromium.org/p/dawn/issues/detail?id=269&q=surface&can=2
 MACH_EXPORT uint64_t machUtilsBackendBinding_getSwapChainImplementation(MachUtilsBackendBinding binding) {
     auto self = reinterpret_cast<utils::BackendBinding*>(binding);
     return self->GetSwapChainImplementation();
 }
+// This is a legacy method. If using OpenGL, it must be used to create a backend binding
+// as Dawn does not yet support the WGPUSurface API for OpenGL yet. https://bugs.chromium.org/p/dawn/issues/detail?id=269&q=surface&can=2
 MACH_EXPORT WGPUTextureFormat machUtilsBackendBinding_getPreferredSwapChainTextureFormat(MachUtilsBackendBinding binding) {
     auto self = reinterpret_cast<utils::BackendBinding*>(binding);
     return self->GetPreferredSwapChainTextureFormat();

--- a/gpu-dawn/src/dawn/dawn_native_mach.cpp
+++ b/gpu-dawn/src/dawn/dawn_native_mach.cpp
@@ -147,6 +147,9 @@ MACH_EXPORT MachDawnNativeInstance machDawnNativeInstance_init(void) {
 MACH_EXPORT void machDawnNativeInstance_deinit(MachDawnNativeInstance instance) {
     delete reinterpret_cast<dawn_native::Instance*>(instance);
 }
+MACH_EXPORT WGPUInstance machDawnNativeInstance_get(MachDawnNativeInstance instance) {
+    return reinterpret_cast<dawn_native::Instance*>(instance)->Get();
+}
 // TODO(dawn-native-mach): These API* methods correlate to the new API (which is unified between Dawn
 // and wgpu-native?), e.g. dawn_native::Instance::APIRequestAdapter corresponds to wgpuInstanceRequestAdapter
 // These are not implemented in Dawn yet according to austineng, but we should switch to this API once they do:
@@ -217,10 +220,6 @@ MACH_EXPORT const DawnProcTable* machDawnNativeGetProcs() {
 
 // TODO(dawn-native-mach):
 // void SetPlatform(dawn_platform::Platform* platform);
-
-// TODO(dawn-native-mach):
-// // Returns the underlying WGPUInstance object.
-// WGPUInstance Get() const;
 
 
 // typedef struct MachUtilsBackendBindingImpl* MachUtilsBackendBinding;

--- a/gpu-dawn/src/dawn/dawn_native_mach.h
+++ b/gpu-dawn/src/dawn/dawn_native_mach.h
@@ -103,8 +103,10 @@ typedef struct MachDawnNativeAdapterDiscoveryOptions_OpenGLES {
 } MachDawnNativeAdapterDiscoveryOptions_OpenGLES;
 
 // utils
+//
+// These are legacy methods. If using OpenGL, they must be used to create a backend binding
+// as Dawn does not yet support the WGPUSurface API for OpenGL yet. https://bugs.chromium.org/p/dawn/issues/detail?id=269&q=surface&can=2
 #include <GLFW/glfw3.h>
-
 typedef struct MachUtilsBackendBindingImpl* MachUtilsBackendBinding;
 MACH_EXPORT MachUtilsBackendBinding machUtilsCreateBinding(WGPUBackendType backendType, GLFWwindow* window, WGPUDevice device);
 MACH_EXPORT uint64_t machUtilsBackendBinding_getSwapChainImplementation(MachUtilsBackendBinding binding);

--- a/gpu-dawn/src/dawn/dawn_native_mach.h
+++ b/gpu-dawn/src/dawn/dawn_native_mach.h
@@ -80,6 +80,7 @@ typedef struct MachDawnNativeInstanceImpl* MachDawnNativeInstance;
 
 MACH_EXPORT MachDawnNativeInstance machDawnNativeInstance_init(void);
 MACH_EXPORT void machDawnNativeInstance_deinit(MachDawnNativeInstance);
+MACH_EXPORT WGPUInstance machDawnNativeInstance_get(MachDawnNativeInstance instance);
 MACH_EXPORT void machDawnNativeInstance_discoverDefaultAdapters(MachDawnNativeInstance);
 
 // Adds adapters that can be discovered with the options provided (like a getProcAddress).

--- a/gpu-dawn/src/dawn/hello_triangle.zig
+++ b/gpu-dawn/src/dawn/hello_triangle.zig
@@ -52,11 +52,16 @@ pub fn main() !void {
         window_data.swap_chain = c.wgpuDeviceCreateSwapChain(setup.device, null, &descriptor);
 
         window_data.swap_chain_format = c.machUtilsBackendBinding_getPreferredSwapChainTextureFormat(binding);
-        c.wgpuSwapChainConfigure(window_data.swap_chain.?, window_data.swap_chain_format, c.WGPUTextureUsage_RenderAttachment, 640, 480);
+        c.wgpuSwapChainConfigure(
+            window_data.swap_chain.?,
+            window_data.swap_chain_format,
+            c.WGPUTextureUsage_RenderAttachment,
+            framebuffer_size.width,
+            framebuffer_size.height,
+        );
     }
     window_data.current_desc = descriptor;
     window_data.target_desc = descriptor;
-
 
     const vs =
         \\ @stage(vertex) fn main(

--- a/gpu-dawn/src/dawn/hello_triangle.zig
+++ b/gpu-dawn/src/dawn/hello_triangle.zig
@@ -3,14 +3,6 @@ const sample_utils = @import("sample_utils.zig");
 const c = @import("c.zig").c;
 const glfw = @import("glfw");
 
-// #include "utils/SystemUtils.h"
-// #include "utils/WGPUHelpers.h"
-
-// WGPUSwapChain swapchain;
-// WGPURenderPipeline pipeline;
-
-// WGPUTextureFormat swapChainFormat;
-
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator = gpa.allocator();
@@ -26,9 +18,9 @@ pub fn main() !void {
     c.wgpuSwapChainConfigure(swap_chain, swap_chain_format, c.WGPUTextureUsage_RenderAttachment, 640, 480);
 
     const vs =
-        \\ [[stage(vertex)]] fn main(
-        \\     [[builtin(vertex_index)]] VertexIndex : u32
-        \\ ) -> [[builtin(position)]] vec4<f32> {
+        \\ @stage(vertex) fn main(
+        \\     @builtin(vertex_index) VertexIndex : u32
+        \\ ) -> @builtin(position) vec4<f32> {
         \\     var pos = array<vec2<f32>, 3>(
         \\         vec2<f32>( 0.0,  0.5),
         \\         vec2<f32>(-0.5, -0.5),
@@ -48,7 +40,7 @@ pub fn main() !void {
     const vs_module = c.wgpuDeviceCreateShaderModule(setup.device, &vs_shader_descriptor);
 
     const fs =
-        \\ [[stage(fragment)]] fn main() -> [[location(0)]] vec4<f32> {
+        \\ @stage(fragment) fn main() -> @location(0) vec4<f32> {
         \\     return vec4<f32>(1.0, 0.0, 0.0, 1.0);
         \\ }
     ;
@@ -168,11 +160,5 @@ fn frame(params: FrameParams) !void {
     c.wgpuSwapChainPresent(params.swap_chain);
     c.wgpuTextureViewRelease(back_buffer_view);
 
-    //     if (cmdBufType == CmdBufType::Terrible) {
-    //         bool c2sSuccess = c2sBuf->Flush();
-    //         bool s2cSuccess = s2cBuf->Flush();
-
-    //         ASSERT(c2sSuccess && s2cSuccess);
-    //     }
     try glfw.pollEvents();
 }

--- a/gpu-dawn/src/dawn/sample_utils.zig
+++ b/gpu-dawn/src/dawn/sample_utils.zig
@@ -167,7 +167,7 @@ pub fn createSurfaceForWindow(
         desc.chain.next = null;
         desc.chain.sType = c.WGPUSType_SurfaceDescriptorFromWindowsHWND;
 
-        desc.hinstance = c.GetModuleHandle(null);
+        desc.hinstance = std.os.windows.kernel32.GetModuleHandleW(null);
         desc.hwnd = glfw_native.getWin32Window(window);
 
         var descriptor: c.WGPUSurfaceDescriptor = undefined;

--- a/gpu-dawn/src/dawn/sample_utils.zig
+++ b/gpu-dawn/src/dawn/sample_utils.zig
@@ -17,8 +17,9 @@ fn printDeviceError(error_type: c.WGPUErrorType, message: [*c]const u8, _: ?*any
 }
 
 const Setup = struct {
+    instance: c.WGPUInstance,
+    backend_type: c.WGPUBackendType,
     device: c.WGPUDevice,
-    binding: c.MachUtilsBackendBinding,
     window: glfw.Window,
 };
 
@@ -93,16 +94,12 @@ pub fn setup(allocator: std.mem.Allocator) !Setup {
     const backend_device = c.machDawnNativeAdapter_createDevice(backend_adapter.?, null);
     const backend_procs = c.machDawnNativeGetProcs();
 
-    const binding = c.machUtilsCreateBinding(backend_type, @ptrCast(*c.GLFWwindow, window.handle), backend_device);
-    if (binding == null) {
-        @panic("failed to create binding");
-    }
-
     c.dawnProcSetProcs(backend_procs);
     backend_procs.*.deviceSetUncapturedErrorCallback.?(backend_device, printDeviceError, null);
     return Setup{
+        .instance = c.machDawnNativeInstance_get(instance),
+        .backend_type = backend_type,
         .device = backend_device,
-        .binding = binding,
         .window = window,
     };
 }


### PR DESCRIPTION
i.e. everywhere except OpenGL backends, as Dawn does not yet support the WGPUSurface API for OpenGL backends.

Fixes #121

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.