### PR TITLE
glfw: remove alignment from packed structs / fix compilation with latest Zig

### DIFF
--- a/glfw/src/hat.zig
+++ b/glfw/src/hat.zig
@@ -5,7 +5,7 @@ const c = @import("c.zig").c;
 ///
 /// See glfw.Joystick.getHats for how these are used.
 pub const Hat = packed struct {
-    up: bool align(@alignOf(u8)) = false,
+    up: bool = false,
     right: bool = false,
     down: bool = false,
     left: bool = false,

--- a/glfw/src/mod.zig
+++ b/glfw/src/mod.zig
@@ -7,7 +7,7 @@ const c = @import("c.zig").c;
 // must be in sync with GLFW C constants in modifier group, search for "@defgroup mods Modifier key flags"
 /// A bitmask of all key modifiers
 pub const Mods = packed struct {
-    shift: bool align(@alignOf(c_int)) = false,
+    shift: bool = false,
     control: bool = false,
     alt: bool = false,
     super: bool = false,


### PR DESCRIPTION
Not sure why we had these here, but alignment on a packed struct seems somewhat
nonsensical (after all, it's fields are packed as closely together as possible
so what would alignment refer to?) removing seems fine and fixes compilation with
latest Zig:

```
/Users/slimsag/Desktop/hexops/mach/gpu-dawn/libs/mach-glfw/src/hat.zig:8:20: error: unable to override alignment of packed struct fields
    up: bool align(@alignOf(u8)) = false,
                   ^
/Users/slimsag/Desktop/hexops/mach/gpu-dawn/libs/mach-glfw/src/mod.zig:10:23: error: unable to override alignment of packed struct fields
    shift: bool align(@alignOf(c_int)) = false,
                      ^
```

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.