### PR TITLE
gpu-dawn: build.zig needs to reference thisDir for C file

### DIFF
--- a/gpu-dawn/build.zig
+++ b/gpu-dawn/build.zig
@@ -503,7 +503,9 @@ fn buildLibMachDawnNative(b: *Builder, step: *std.build.LibExeObjStep, options: 
         }) catch unreachable;
     }
 
-    lib.addCSourceFile("src/dawn/dawn_native_mach.cpp", cpp_flags.items);
+    lib.addCSourceFile(std.fs.path.join(b.allocator, &.{
+        thisDir(), "src/dawn/dawn_native_mach.cpp",
+    }) catch unreachable, cpp_flags.items);
     return lib;
 }
 


### PR DESCRIPTION
This allows gpu-dawn to be vendored into a project when building from source.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.