### PR TITLE
Tweak build.zigs to make using app library slightly easier

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,7 +10,7 @@ pub fn build(b: *std.build.Builder) void {
     const gpu_dawn_options = gpu_dawn.Options{
         .from_source = b.option(bool, "dawn-from-source", "Build Dawn from source") orelse false,
     };
-    const options = Options {.gpu_dawn_options = gpu_dawn_options};
+    const options = Options{ .gpu_dawn_options = gpu_dawn_options };
 
     const main_tests = b.addTest("src/main.zig");
     main_tests.setBuildMode(mode);
@@ -43,7 +43,7 @@ pub const Options = struct {
     gpu_dawn_options: gpu_dawn.Options = .{},
 };
 
-pub const pkg = .{
+pub const pkg = std.build.Pkg{
     .name = "mach",
     .path = .{ .path = thisDir() ++ "/src/main.zig" },
     .dependencies = &.{ gpu.pkg, glfw.pkg },

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
-const gpu = @import("gpu/build.zig");
+pub const gpu = @import("gpu/build.zig");
 const gpu_dawn = @import("gpu-dawn/build.zig");
-const glfw = @import("glfw/build.zig");
+pub const glfw = @import("glfw/build.zig");
 
 pub fn build(b: *std.build.Builder) void {
     const mode = b.standardReleaseOptions();

--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -41,7 +41,7 @@ pub const Options = struct {
     system_sdk: system_sdk.Options = .{},
 };
 
-pub const pkg = .{
+pub const pkg = std.build.Pkg{
     .name = "glfw",
     .path = .{ .path = thisDir() ++ "/src/main.zig" },
 };

--- a/gpu/build.zig
+++ b/gpu/build.zig
@@ -44,7 +44,7 @@ pub const Options = struct {
     gpu_dawn_options: gpu_dawn.Options = .{},
 };
 
-pub const pkg = .{
+pub const pkg = std.build.Pkg{
     .name = "gpu",
     .path = .{ .path = thisDir() ++ "/src/main.zig" },
     .dependencies = &.{glfw.pkg},


### PR DESCRIPTION
There are a few changes in one PR here:
- Add explicit `std.build.Pkg` types to `pkg` variables in `build.zig`s
- Publicize `gpu` and `glfw` from the toplevel `build.zig` to make it easier to use those from projects importing that
- Run `zig fmt` on the toplevel build.zig (one tiny whitespace change)

---

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.