### PR TITLE
gpu: VertexBufferLayout.attributes field needs to be a pointer to mul…

### DIFF
--- a/gpu/src/data.zig
+++ b/gpu/src/data.zig
@@ -83,7 +83,7 @@ pub const VertexBufferLayout = extern struct {
     array_stride: u64,
     step_mode: VertexStepMode,
     attribute_count: u32,
-    attributes: *const VertexAttribute,
+    attributes: [*]const VertexAttribute,
 };
 
 test {


### PR DESCRIPTION
…tiple structures.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.