### PR TITLE
build: never use pkg-config to link system libraries

### DIFF
--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -115,14 +115,14 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
     const target = (std.zig.system.NativeTargetInfo.detect(b.allocator, step.target) catch unreachable).target;
     switch (target.os.tag) {
         .windows => {
-            step.linkSystemLibrary("gdi32");
-            step.linkSystemLibrary("user32");
-            step.linkSystemLibrary("shell32");
+            step.linkSystemLibraryName("gdi32");
+            step.linkSystemLibraryName("user32");
+            step.linkSystemLibraryName("shell32");
             if (options.opengl) {
-                step.linkSystemLibrary("opengl32");
+                step.linkSystemLibraryName("opengl32");
             }
             if (options.gles) {
-                step.linkSystemLibrary("GLESv3");
+                step.linkSystemLibraryName("GLESv3");
             }
         },
         .macos => {
@@ -134,7 +134,7 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
             if (options.opengl) {
                 step.linkFramework("OpenGL");
             }
-            step.linkSystemLibrary("objc");
+            step.linkSystemLibraryName("objc");
             step.linkFramework("AppKit");
             step.linkFramework("CoreServices");
             step.linkFramework("CoreGraphics");
@@ -144,20 +144,20 @@ fn linkGLFWDependencies(b: *Builder, step: *std.build.LibExeObjStep, options: Op
             // Assume Linux-like
             switch (options.linux_window_manager) {
                 .X11 => {
-                    step.linkSystemLibrary("X11");
-                    step.linkSystemLibrary("xcb");
-                    step.linkSystemLibrary("Xau");
-                    step.linkSystemLibrary("Xdmcp");
+                    step.linkSystemLibraryName("X11");
+                    step.linkSystemLibraryName("xcb");
+                    step.linkSystemLibraryName("Xau");
+                    step.linkSystemLibraryName("Xdmcp");
                 },
-                .Wayland => step.linkSystemLibrary("wayland-client"),
+                .Wayland => step.linkSystemLibraryName("wayland-client"),
             }
             // Note: no need to link against vulkan, GLFW finds it dynamically at runtime.
             // https://www.glfw.org/docs/3.3/vulkan_guide.html#vulkan_loader
             if (options.opengl) {
-                step.linkSystemLibrary("GL");
+                step.linkSystemLibraryName("GL");
             }
             if (options.gles) {
-                step.linkSystemLibrary("GLESv3");
+                step.linkSystemLibraryName("GLESv3");
             }
         },
     }

--- a/gpu-dawn/build.zig
+++ b/gpu-dawn/build.zig
@@ -236,14 +236,14 @@ pub fn linkFromBinary(b: *Builder, step: *std.build.LibExeObjStep, options: Opti
     const include_dir = std.fs.path.join(b.allocator, &.{ commit_cache_dir, "include" }) catch unreachable;
 
     step.addLibraryPath(target_cache_dir);
-    step.linkSystemLibrary("dawn");
+    step.linkSystemLibraryName("dawn");
     step.linkLibCpp();
 
     step.addIncludeDir(include_dir);
     step.addIncludeDir(thisDir() ++ "/src/dawn");
 
     if (options.linux_window_manager != null and options.linux_window_manager.? == .X11) {
-        step.linkSystemLibrary("X11");
+        step.linkSystemLibraryName("X11");
     }
     if (options.metal.?) {
         step.linkFramework("Metal");
@@ -254,8 +254,8 @@ pub fn linkFromBinary(b: *Builder, step: *std.build.LibExeObjStep, options: Opti
         step.linkFramework("QuartzCore");
     }
     if (options.d3d12.?) {
-        step.linkSystemLibrary("ole32");
-        step.linkSystemLibrary("dxguid");
+        step.linkSystemLibraryName("ole32");
+        step.linkSystemLibraryName("dxguid");
     }
 }
 
@@ -701,8 +701,8 @@ fn buildLibDawnNative(b: *Builder, step: *std.build.LibExeObjStep, options: Opti
 
     var cpp_sources = std.ArrayList([]const u8).init(b.allocator);
     if (options.d3d12.?) {
-        lib.linkSystemLibrary("dxgi");
-        lib.linkSystemLibrary("dxguid");
+        lib.linkSystemLibraryName("dxgi");
+        lib.linkSystemLibraryName("dxguid");
 
         for ([_][]const u8{
             "src/dawn/mingw_helpers.cpp",
@@ -739,7 +739,7 @@ fn buildLibDawnNative(b: *Builder, step: *std.build.LibExeObjStep, options: Opti
     }
 
     if (options.linux_window_manager != null and options.linux_window_manager.? == .X11) {
-        lib.linkSystemLibrary("X11");
+        lib.linkSystemLibraryName("X11");
         for ([_][]const u8{
             "src/dawn/native/XlibXcbFunctions.cpp",
         }) |path| {
@@ -1136,7 +1136,7 @@ fn buildLibAbseilCpp(b: *Builder, step: *std.build.LibExeObjStep, options: Optio
 
     const target = (std.zig.system.NativeTargetInfo.detect(b.allocator, step.target) catch unreachable).target;
     if (target.os.tag == .macos) lib.linkFramework("CoreFoundation");
-    if (target.os.tag == .windows) lib.linkSystemLibrary("bcrypt");
+    if (target.os.tag == .windows) lib.linkSystemLibraryName("bcrypt");
 
     var flags = std.ArrayList([]const u8).init(b.allocator);
     flags.appendSlice(&.{
@@ -1304,10 +1304,10 @@ fn buildLibDxcompiler(b: *Builder, step: *std.build.LibExeObjStep, options: Opti
     };
     system_sdk.include(b, lib, .{});
 
-    lib.linkSystemLibrary("oleaut32");
-    lib.linkSystemLibrary("ole32");
-    lib.linkSystemLibrary("dbghelp");
-    lib.linkSystemLibrary("dxguid");
+    lib.linkSystemLibraryName("oleaut32");
+    lib.linkSystemLibraryName("ole32");
+    lib.linkSystemLibraryName("dbghelp");
+    lib.linkSystemLibraryName("dxguid");
     lib.linkLibCpp();
 
     var flags = std.ArrayList([]const u8).init(b.allocator);


### PR DESCRIPTION
Every library we want to link against is either provided by the Zig
toolchain or part of our SDK. Therefore, using pkg-config to link
against libraries on the host system is never what we intend.

To fix this, use linkSystemLibraryName() everywhere instead of
linkSystemLibrary() as the latter integrates with pkg-config while the
former just passes -lfoo to the zig compiler.

In combination with Zig commit 38d6e1d8a8 fixing an std.build bug,
this change fixes the linking of the necessary X11 libraries on my
x86_64 glibc based Void Linux system.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.