### PR TITLE
fix getMappedRange size alignment

### DIFF
--- a/gpu/src/Buffer.zig
+++ b/gpu/src/Buffer.zig
@@ -37,12 +37,14 @@ pub inline fn destroy(buf: Buffer) void {
 }
 
 pub inline fn getConstMappedRange(buf: Buffer, comptime T: type, offset: usize, len: usize) []const T {
-    const data = buf.vtable.getConstMappedRange(buf.ptr, offset, @sizeOf(T) * len);
-    return @ptrCast([*]const T, data.ptr)[0..len];
+    const size = @sizeOf(T) * len;
+    const data = buf.vtable.getConstMappedRange(buf.ptr, offset, size + size % 4);
+    return @ptrCast([*]const T, @alignCast(@alignOf(T), data.ptr))[0..len];
 }
 
 pub inline fn getMappedRange(buf: Buffer, comptime T: type, offset: usize, len: usize) []T {
-    const data = buf.vtable.getMappedRange(buf.ptr, offset, @sizeOf(T) * len);
+    const size = @sizeOf(T) * len;
+    const data = buf.vtable.getMappedRange(buf.ptr, offset, size + size % 4);
     return @ptrCast([*]T, @alignCast(@alignOf(T), data.ptr))[0..len];
 }
 

--- a/gpu/src/Device.zig
+++ b/gpu/src/Device.zig
@@ -177,7 +177,9 @@ pub inline fn destroy(device: Device) void {
 }
 
 pub inline fn createBuffer(device: Device, descriptor: *const Buffer.Descriptor) Buffer {
-    return device.vtable.createBuffer(device.ptr, descriptor);
+    var local_descriptor = descriptor.*;
+    local_descriptor.size += local_descriptor.size % 4;
+    return device.vtable.createBuffer(device.ptr, &local_descriptor);
 }
 
 pub inline fn createCommandEncoder(device: Device, descriptor: ?*const CommandEncoder.Descriptor) CommandEncoder {


### PR DESCRIPTION
+ same for getConstMappedRange
+ mirror align fix for getConstMappedRange

rationale:

user needs to align buffer on creation, as in

    gpu.Buffer.Descriptor{ .size = size, ... }

so `size == sizeOf(T) * len` might not always hold true.

on `getMappedRange` request, there is no way to specify
that size was manually aligned, and using the function directly
with realigned size gives extremely unhelpful error:

    thread 254201 panic: attempt to use null value
    .../mach/gpu/src/NativeInstance.zig:1721:42: 0x480747
    in .gpu.NativeInstance.buffer_vtable.getMappedRange (game)
            return @ptrCast([*c]u8, range.?)[0..size];
                                          ^

it seems, requested size must match size specified on creation exactly.

so this commit does exactly that. aligns buffer size to 4 - something
that user must have done already if this point is reached.

aligned buffer sizes stay unchanged.

the whole point is to reduce mental load for the user and prevent hacks
and workarounds for corner cases. original issue originated with
having u16 index buffer array with odd number of elements, which is a
perfectly valid thing to have.

it would be best to also auto align size on buffer creation to not force
user to know such obscure implementation details and learn magic numbers.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.