### PR TITLE
mach: set error message to be shown on glfw error

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -52,6 +52,11 @@ pub const Options = struct {
     power_preference: gpu.PowerPreference = .none,
 };
 
+/// Default GLFW error handling callback
+fn glfwErrorCallback(error_code: glfw.Error, description: [:0]const u8) void {
+    std.debug.print("glfw: {}: {s}\n", .{ error_code, description });
+}
+
 /// A Mach application.
 ///
 /// The Context type is your own data type which can later be accessed via app.context from within
@@ -78,6 +83,7 @@ pub fn App(comptime Context: type, comptime config: AppConfig) type {
         pub fn init(allocator: std.mem.Allocator, context: Context, options: Options) !Self {
             const backend_type = try util.detectBackendType(allocator);
 
+            glfw.setErrorCallback(glfwErrorCallback);
             try glfw.init(.{});
 
             // Create the test window and discover adapters using it (esp. for OpenGL)


### PR DESCRIPTION
This uses glfw.setErrorCallback to set a global callback in mach's App which would work across all mach applications

How would this behave?
- The callback would show the error message first and then the regular behavior will follow: app would shutdown with an error trace


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.