### PR TITLE
gpu-dawn: update Dawn to latest revision as of 2022-04-17

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,12 +2,12 @@
 	path = gpu-dawn/libs/dawn
 	url = https://github.com/hexops/dawn.git
 	shallow = true
-	branch = "generated-2022-03-04"
+	branch = "generated-2022-04-17"
 [submodule "gpu-dawn/libs/DirectXShaderCompiler"]
 	path = gpu-dawn/libs/DirectXShaderCompiler
 	url = https://github.com/hexops/DirectXShaderCompiler
-        shallow = true
-        branch = "mach"
+	shallow = true
+	branch = "mach"
 
 [submodule "examples/libs/zmath"]
 	path = examples/libs/zmath

--- a/gpu-dawn/.gitmodules
+++ b/gpu-dawn/.gitmodules
@@ -2,7 +2,7 @@
 	path = libs/dawn
 	url = https://github.com/hexops/dawn.git
 	shallow = true
-	branch = "generated-2022-03-04"
+	branch = "generated-2022-04-17"
 [submodule "libs/DirectXShaderCompiler"]
 	path = libs/DirectXShaderCompiler
 	url = https://github.com/hexops/DirectXShaderCompiler


### PR DESCRIPTION
Updates Dawn to latest revision as of 2022-04-17 https://github.com/hexops/dawn/commit/69daaab75938cbe10c40f1a04988d46e09c3007d

* Followed https://github.com/hexops/dawn/tree/main/mach#updating
* Includes a fix for UB issue https://github.com/hexops/dawn/pull/9 (I will send a CL for this upstream soon.)
* Verified examples run on macOS (other OSes will get built by CI and verified later)

Closes hexops/mach#221

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.