### PR TITLE
gpu: Changes needed for latest Dawn (generated-2022-04-18).

### DIFF
--- a/gpu/src/Device.zig
+++ b/gpu/src/Device.zig
@@ -249,6 +249,7 @@ pub const Descriptor = struct {
     label: ?[*:0]const u8 = null,
     required_features: ?[]Feature = null,
     required_limits: ?Limits = null,
+    default_queue: ?Queue.Descriptor = null,
 };
 
 pub const LostReason = enum(u32) {

--- a/gpu/src/Queue.zig
+++ b/gpu/src/Queue.zig
@@ -99,6 +99,10 @@ pub const WorkDoneCallback = struct {
     }
 };
 
+pub const Descriptor = struct {
+    label: ?[*:0]const u8 = null,
+};
+
 pub const WorkDoneStatus = enum(u32) {
     Success = 0x00000000,
     Error = 0x00000001,

--- a/gpu/src/Texture.zig
+++ b/gpu/src/Texture.zig
@@ -48,6 +48,7 @@ pub const Descriptor = struct {
     format: Format,
     mip_level_count: u32,
     sample_count: u32,
+    view_formats: ?[]const Format = null,
 };
 
 pub const Usage = packed struct {


### PR DESCRIPTION
There were some changes in `webgpu.h` -- changes in this PR are required for "release-51a7db1" binaries and when using `-Ddawn-from-source=true`.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.