### PR TITLE
examples: fix blend mode in triangle example

### DIFF
--- a/examples/triangle/main.zig
+++ b/examples/triangle/main.zig
@@ -26,12 +26,12 @@ pub fn main() !void {
         .color = .{
             .operation = .add,
             .src_factor = .one,
-            .dst_factor = .one,
+            .dst_factor = .zero,
         },
         .alpha = .{
             .operation = .add,
             .src_factor = .one,
-            .dst_factor = .one,
+            .dst_factor = .zero,
         },
     };
     const color_target = gpu.ColorTargetState{


### PR DESCRIPTION
current `Blend` does actually blend colors (which includes background color), which might surprise people trying to modify example. the fix introduces `Blend` that actually writes over previous color.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.