### PR TITLE
gpu-dawn: update Dawn to latest revision as of 2022-04-21

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = gpu-dawn/libs/dawn
 	url = https://github.com/hexops/dawn.git
 	shallow = true
-	branch = "generated-2022-04-18"
+	branch = "generated-2022-04-21"
 [submodule "gpu-dawn/libs/DirectXShaderCompiler"]
 	path = gpu-dawn/libs/DirectXShaderCompiler
 	url = https://github.com/hexops/DirectXShaderCompiler

--- a/gpu-dawn/.gitmodules
+++ b/gpu-dawn/.gitmodules
@@ -2,7 +2,7 @@
 	path = libs/dawn
 	url = https://github.com/hexops/dawn.git
 	shallow = true
-	branch = "generated-2022-04-18"
+	branch = "generated-2022-04-21"
 [submodule "libs/DirectXShaderCompiler"]
 	path = libs/DirectXShaderCompiler
 	url = https://github.com/hexops/DirectXShaderCompiler


### PR DESCRIPTION
upstream @ c2f9fea56bee11cf573fe90b08a296a38202500b

Includes fix for UB on Linux/Vulkan: https://github.com/hexops/dawn/pull/11

Closes hexops/mach#239

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.