### PR TITLE
mach: choose first vulkan adapter

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -142,6 +142,7 @@ pub fn App(comptime Context: type, comptime config: AppConfig) type {
                 const found_backend_type = @intToEnum(gpu.Adapter.BackendType, c.machDawnNativeAdapterProperties_getBackendType(properties));
                 if (found_backend_type == backend_type) {
                     dawn_adapter = adapter;
+                    break;
                 }
             }
             if (dawn_adapter == null) {


### PR DESCRIPTION
Choose first `vulkan` adapter, instead of last.

Fixes picking `llvmpipe` software only implementation, while accelerated one is available.

Note: fix might be not perfect, as it relies on order of adapters instead of checking the properties.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.