### PR TITLE
Fix store_op and publicize App.Funcs

### DIFF
--- a/gpu/src/NativeInstance.zig
+++ b/gpu/src/NativeInstance.zig
@@ -1898,7 +1898,7 @@ const command_encoder_vtable = CommandEncoder.VTable{
                         .view = @ptrCast(c.WGPUTextureView, v.view.ptr),
                         .resolveTarget = if (v.resolve_target) |t| @ptrCast(c.WGPUTextureView, t.ptr) else null,
                         .loadOp = @enumToInt(v.load_op),
-                        .storeOp = @enumToInt(v.load_op),
+                        .storeOp = @enumToInt(v.store_op),
                         .clearValue = @bitCast(c.WGPUColor, v.clear_value),
                         // deprecated:
                         .clearColor = c.WGPUColor{
@@ -1917,7 +1917,7 @@ const command_encoder_vtable = CommandEncoder.VTable{
                         .view = @ptrCast(c.WGPUTextureView, v.view.ptr),
                         .resolveTarget = if (v.resolve_target) |t| @ptrCast(c.WGPUTextureView, t.ptr) else null,
                         .loadOp = @enumToInt(v.load_op),
-                        .storeOp = @enumToInt(v.load_op),
+                        .storeOp = @enumToInt(v.store_op),
                         .clearValue = @bitCast(c.WGPUColor, v.clear_value),
                         // deprecated:
                         .clearColor = c.WGPUColor{

--- a/src/main.zig
+++ b/src/main.zig
@@ -239,7 +239,7 @@ pub fn App(comptime Context: type, comptime config: AppConfig) type {
             };
         }
 
-        const Funcs = struct {
+        pub const Funcs = struct {
             // Run once per frame
             frame: fn (app: *Self, ctx: Context) error{OutOfMemory}!void,
             // Run once at the start, and whenever the swapchain is recreated


### PR DESCRIPTION
Sorry for not separating this into two PRs, they're very small changes and I couldn't be bothered :)

- I forgot to make App.Funcs public when I created it
- There was a typo in NativeInstance.beginRenderPass that caused `store_op` to use the value of `load_op` instead
---
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.