### PR TITLE
build: compile examples and applications on demand

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -54,7 +54,7 @@ pub fn build(b: *std.build.Builder) void {
         example_exe.install();
 
         const example_run_cmd = example_exe.run();
-        example_run_cmd.step.dependOn(b.getInstallStep());
+        example_run_cmd.step.dependOn(&example_exe.install_step.?.step);
         const example_run_step = b.step("run-example-" ++ example.name, "Run the example");
         example_run_step.dependOn(&example_run_cmd.step);
     }
@@ -74,9 +74,12 @@ pub fn build(b: *std.build.Builder) void {
     shaderexp_exe.install();
 
     const shaderexp_run_cmd = shaderexp_exe.run();
-    shaderexp_run_cmd.step.dependOn(b.getInstallStep());
+    shaderexp_run_cmd.step.dependOn(&shaderexp_exe.install_step.?.step);
     const shaderexp_run_step = b.step("run-shaderexp", "Run shaderexp");
     shaderexp_run_step.dependOn(&shaderexp_run_cmd.step);
+
+    const compile_all = b.step("compile-all", "Compile all examples and applications");
+    compile_all.dependOn(b.getInstallStep());
 }
 
 pub const Options = struct {


### PR DESCRIPTION
Without this change, anytime a dependency is modified, all the examples and applications are rebuilt before tring to run any of them. The problem with this approach is that it leads to long compile times which will keep on increasing as more and more examples are added.

The old behavior is still preserved with a new step ``compile-all``. In future this could be added to CI just to check if all the examples and applications at least build properly. This is not being done right now because zig std lib is undergoing lots of breaking changes right now and it will keep failing CI.

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.