### PR TITLE
CI: check compilation of all examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
           AGREE: true
       - name: x86_64-linux -> x86_64-windows
         run: cd ${{ matrix.project }} && zig build test -Dtarget=x86_64-windows-gnu
+      - name: compile all examples
+        if: matrix.project == '.'
+        run: cd ${{ matrix.project }} && zig build compile-all
       - name: launch xvfb
         run: Xvfb :99 -screen 0 1680x720x24 > /dev/null 2>&1 &
       - name: test
@@ -68,6 +71,9 @@ jobs:
           AGREE: true
       - name: x86_64-windows -> x86_64-linux
         run: cd ${{ matrix.project }} && zig build test -Dtarget=x86_64-linux-gnu
+      - name: compile all examples
+        if: matrix.project == '.'
+        run: cd ${{ matrix.project }} && zig build compile-all
       - name: test
         run: cd ${{ matrix.project }} && zig build test
   x86_64-macos:

--- a/.github/workflows/m1_ci.yml
+++ b/.github/workflows/m1_ci.yml
@@ -39,3 +39,8 @@ jobs:
         run: zig build test -Dtarget=x86_64-windows-gnu
       - name: aarch64-macos -> x86_64-linux
         run: zig build test -Dtarget=x86_64-linux-gnu
+      - name: compile all examples
+        if: matrix.project == '.'
+        run: cd ${{ matrix.project }} && zig build compile-all
+        env:
+          AGREE: true


### PR DESCRIPTION
From https://github.com/hexops/mach/pull/259#issuecomment-1113944683

Updates CI to run step ``zig build compile-all`` which compiles all the examples and applications to check if all are at least building properly.

Not added to x86_64-macos because it just fails early with some other error and macos doesnt even have tests enabled, maybe for the same reason?

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.