### PR TITLE
mach: Event loop based input handling

### DIFF
--- a/examples/advanced-gen-texture-light/main.zig
+++ b/examples/advanced-gen-texture-light/main.zig
@@ -33,7 +33,6 @@ const Dir = struct {
 };
 
 pub fn init(app: *App, engine: *mach.Engine) !void {
-    engine.core.setKeyCallback(keyCallback);
     // todo
     // engine.core.internal.window.setKeyCallback(struct {
     //     fn callback(window: glfw.Window, key: glfw.Key, scancode: i32, action: glfw.Action, mods: glfw.Mods) void {
@@ -67,6 +66,42 @@ pub fn deinit(app: *App, _: *mach.Engine) void {
 }
 
 pub fn update(app: *App, engine: *mach.Engine) !bool {
+    while (engine.core.pollEvent()) |event| {
+        switch (event) {
+            .key_press => |ev| switch (ev.key) {
+                .q, .escape, .space => engine.core.setShouldClose(true),
+                .w, .up => {
+                    app.keys |= Dir.up;
+                },
+                .s, .down => {
+                    app.keys |= Dir.down;
+                },
+                .a, .left => {
+                    app.keys |= Dir.left;
+                },
+                .d, .right => {
+                    app.keys |= Dir.right;
+                },
+                else => {},
+            },
+            .key_release => |ev| switch (ev.key) {
+                .w, .up => {
+                    app.keys &= ~Dir.up;
+                },
+                .s, .down => {
+                    app.keys &= ~Dir.down;
+                },
+                .a, .left => {
+                    app.keys &= ~Dir.left;
+                },
+                .d, .right => {
+                    app.keys &= ~Dir.right;
+                },
+                else => {},
+            },
+        }
+    }
+
     // move camera
     const speed = zm.f32x4s(@floatCast(f32, engine.delta_time * 5));
     const fwd = zm.normalize3(app.camera.target - app.camera.eye);
@@ -872,40 +907,3 @@ const Instance = struct {
         return zm.mul(zm.quatToMat(self.rotation), zm.translationV(self.position));
     }
 };
-
-fn keyCallback(app: *App, engine: *mach.Engine, key: mach.Key, action: mach.Action) void {
-    if (action == .press) {
-        switch (key) {
-            .q, .escape, .space => engine.core.setShouldClose(true),
-            .w, .up => {
-                app.keys |= Dir.up;
-            },
-            .s, .down => {
-                app.keys |= Dir.down;
-            },
-            .a, .left => {
-                app.keys |= Dir.left;
-            },
-            .d, .right => {
-                app.keys |= Dir.right;
-            },
-            else => {},
-        }
-    } else if (action == .release) {
-        switch (key) {
-            .w, .up => {
-                app.keys &= ~Dir.up;
-            },
-            .s, .down => {
-                app.keys &= ~Dir.down;
-            },
-            .a, .left => {
-                app.keys &= ~Dir.left;
-            },
-            .d, .right => {
-                app.keys &= ~Dir.right;
-            },
-            else => {},
-        }
-    }
-}

--- a/examples/advanced-gen-texture-light/main.zig
+++ b/examples/advanced-gen-texture-light/main.zig
@@ -33,19 +33,6 @@ const Dir = struct {
 };
 
 pub fn init(app: *App, engine: *mach.Engine) !void {
-    // todo
-    // engine.core.internal.window.setKeyCallback(struct {
-    //     fn callback(window: glfw.Window, key: glfw.Key, scancode: i32, action: glfw.Action, mods: glfw.Mods) void {
-    //         _ = scancode;
-    //         _ = mods;
-    //         if (action == .press) {
-    //             switch (key) {
-    //                 .space => window.setShouldClose(true),
-    //                 else => {},
-    //             }
-    //         }
-    //     }
-    // }.callback);
     try engine.core.setSizeLimits(.{ .width = 20, .height = 20 }, .{ .width = null, .height = null });
 
     const eye = vec3(5.0, 7.0, 5.0);

--- a/examples/fractal-cube/main.zig
+++ b/examples/fractal-cube/main.zig
@@ -41,16 +41,6 @@ bgl: gpu.BindGroupLayout,
 pub fn init(app: *App, engine: *mach.Engine) !void {
     timer = try mach.Timer.start();
 
-    engine.core.setKeyCallback(struct {
-        fn callback(_: *App, eng: *mach.Engine, key: mach.Key, action: mach.Action) void {
-            if (action == .press) {
-                switch (key) {
-                    .space => eng.core.setShouldClose(true),
-                    else => {},
-                }
-            }
-        }
-    }.callback);
     try engine.core.setSizeLimits(.{ .width = 20, .height = 20 }, .{ .width = null, .height = null });
 
     const vs_module = engine.gpu_driver.device.createShaderModule(&.{
@@ -229,6 +219,16 @@ pub fn deinit(app: *App, _: *mach.Engine) void {
 }
 
 pub fn update(app: *App, engine: *mach.Engine) !bool {
+    while (engine.core.pollEvent()) |event| {
+        switch (event) {
+            .key_press => |ev| {
+                if (ev.key == .space)
+                    engine.core.setShouldClose(true);
+            },
+            else => {},
+        }
+    }
+
     const cube_view = app.cube_texture_view_render;
     const back_buffer_view = engine.gpu_driver.swap_chain.?.getCurrentTextureView();
 

--- a/examples/gkurve/main.zig
+++ b/examples/gkurve/main.zig
@@ -41,16 +41,6 @@ bind_group: gpu.BindGroup,
 vertices_len: u32,
 
 pub fn init(app: *App, engine: *mach.Engine) !void {
-    engine.core.setKeyCallback(struct {
-        fn callback(_: *App, eng: *mach.Engine, key: mach.Key, action: mach.Action) void {
-            if (action == .press) {
-                switch (key) {
-                    .space => eng.core.setShouldClose(true),
-                    else => {},
-                }
-            }
-        }
-    }.callback);
     try engine.core.setSizeLimits(.{ .width = 20, .height = 20 }, .{ .width = null, .height = null });
 
     const vs_module = engine.gpu_driver.device.createShaderModule(&.{
@@ -207,6 +197,16 @@ pub fn deinit(app: *App, _: *mach.Engine) void {
 }
 
 pub fn update(app: *App, engine: *mach.Engine) !bool {
+    while (engine.core.pollEvent()) |event| {
+        switch (event) {
+            .key_press => |ev| {
+                if (ev.key == .space)
+                    engine.core.setShouldClose(true);
+            },
+            else => {},
+        }
+    }
+
     const back_buffer_view = engine.gpu_driver.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,

--- a/examples/instanced-cube/main.zig
+++ b/examples/instanced-cube/main.zig
@@ -23,16 +23,6 @@ const App = @This();
 pub fn init(app: *App, engine: *mach.Engine) !void {
     timer = try mach.Timer.start();
 
-    engine.core.setKeyCallback(struct {
-        fn callback(_: *App, eng: *mach.Engine, key: mach.Key, action: mach.Action) void {
-            if (action == .press) {
-                switch (key) {
-                    .space => eng.core.setShouldClose(true),
-                    else => {},
-                }
-            }
-        }
-    }.callback);
     try engine.core.setSizeLimits(.{ .width = 20, .height = 20 }, .{ .width = null, .height = null });
 
     const vs_module = engine.gpu_driver.device.createShaderModule(&.{
@@ -148,6 +138,16 @@ pub fn deinit(app: *App, _: *mach.Engine) void {
 }
 
 pub fn update(app: *App, engine: *mach.Engine) !bool {
+    while (engine.core.pollEvent()) |event| {
+        switch (event) {
+            .key_press => |ev| {
+                if (ev.key == .space)
+                    engine.core.setShouldClose(true);
+            },
+            else => {},
+        }
+    }
+
     const back_buffer_view = engine.gpu_driver.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,

--- a/examples/rotating-cube/main.zig
+++ b/examples/rotating-cube/main.zig
@@ -23,17 +23,6 @@ bind_group: gpu.BindGroup,
 pub fn init(app: *App, engine: *mach.Engine) !void {
     timer = try mach.Timer.start();
 
-    // TODO: higher level input handlers
-    engine.core.setKeyCallback(struct {
-        fn callback(_: *App, eng: *mach.Engine, key: mach.Key, action: mach.Action) void {
-            if (action == .press) {
-                switch (key) {
-                    .space => eng.core.setShouldClose(true),
-                    else => {},
-                }
-            }
-        }
-    }.callback);
     try engine.core.setSizeLimits(.{ .width = 20, .height = 20 }, .{ .width = null, .height = null });
 
     const vs_module = engine.gpu_driver.device.createShaderModule(&.{
@@ -157,6 +146,16 @@ pub fn deinit(app: *App, _: *mach.Engine) void {
 }
 
 pub fn update(app: *App, engine: *mach.Engine) !bool {
+    while (engine.core.pollEvent()) |event| {
+        switch (event) {
+            .key_press => |ev| {
+                if (ev.key == .space)
+                    engine.core.setShouldClose(true);
+            },
+            else => {},
+        }
+    }
+
     const back_buffer_view = engine.gpu_driver.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,

--- a/examples/textured-cube/main.zig
+++ b/examples/textured-cube/main.zig
@@ -26,16 +26,6 @@ const App = @This();
 pub fn init(app: *App, engine: *mach.Engine) !void {
     timer = try mach.Timer.start();
 
-    engine.core.setKeyCallback(struct {
-        fn callback(_: *App, eng: *mach.Engine, key: mach.Key, action: mach.Action) void {
-            if (action == .press) {
-                switch (key) {
-                    .space => eng.core.setShouldClose(true),
-                    else => {},
-                }
-            }
-        }
-    }.callback);
     try engine.core.setSizeLimits(.{ .width = 20, .height = 20 }, .{ .width = null, .height = null });
 
     const vs_module = engine.gpu_driver.device.createShaderModule(&.{
@@ -186,6 +176,16 @@ pub fn deinit(app: *App, _: *mach.Engine) void {
 }
 
 pub fn update(app: *App, engine: *mach.Engine) !bool {
+    while (engine.core.pollEvent()) |event| {
+        switch (event) {
+            .key_press => |ev| {
+                if (ev.key == .space)
+                    engine.core.setShouldClose(true);
+            },
+            else => {},
+        }
+    }
+
     const back_buffer_view = engine.gpu_driver.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,

--- a/examples/two-cubes/main.zig
+++ b/examples/two-cubes/main.zig
@@ -24,16 +24,6 @@ const App = @This();
 pub fn init(app: *App, engine: *mach.Engine) !void {
     timer = try mach.Timer.start();
 
-    engine.core.setKeyCallback(struct {
-        fn callback(_: *App, eng: *mach.Engine, key: mach.Key, action: mach.Action) void {
-            if (action == .press) {
-                switch (key) {
-                    .space => eng.core.setShouldClose(true),
-                    else => {},
-                }
-            }
-        }
-    }.callback);
     try engine.core.setSizeLimits(.{ .width = 20, .height = 20 }, .{ .width = null, .height = null });
 
     const vs_module = engine.gpu_driver.device.createShaderModule(&.{
@@ -173,6 +163,16 @@ pub fn deinit(app: *App, _: *mach.Engine) void {
 }
 
 pub fn update(app: *App, engine: *mach.Engine) !bool {
+    while (engine.core.pollEvent()) |event| {
+        switch (event) {
+            .key_press => |ev| {
+                if (ev.key == .space)
+                    engine.core.setShouldClose(true);
+            },
+            else => {},
+        }
+    }
+
     const back_buffer_view = engine.gpu_driver.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,

--- a/src/Engine.zig
+++ b/src/Engine.zig
@@ -2,7 +2,6 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const glfw = @import("glfw");
 const gpu = @import("gpu");
-const App = @import("app");
 const structs = @import("structs.zig");
 const enums = @import("enums.zig");
 const Timer = @import("Timer.zig");
@@ -43,8 +42,8 @@ pub const Core = struct {
         return core.internal.setSizeLimits(min, max);
     }
 
-    pub fn setKeyCallback(core: *Core, comptime cb: fn (app: *App, engine: *Engine, key: enums.Key, action: enums.Action) void) void {
-        core.internal.setKeyCallback(cb);
+    pub fn pollEvent(core: *Core) ?structs.Event {
+        return core.internal.pollEvent();
     }
 };
 

--- a/src/enums.zig
+++ b/src/enums.zig
@@ -1,9 +1,3 @@
-pub const Action = enum {
-    release,
-    press,
-    repeat,
-};
-
 pub const Key = enum {
     a,
     b,

--- a/src/native.zig
+++ b/src/native.zig
@@ -101,7 +101,10 @@ pub const CoreGlfw = struct {
     }
 
     pub fn pollEvent(self: *CoreGlfw) ?structs.Event {
-        if (self.events.popFirst()) |n| return n.data;
+        if (self.events.popFirst()) |n| {
+            defer self.allocator.destroy(n);
+            return n.data;
+        }
         return null;
     }
 

--- a/src/native.zig
+++ b/src/native.zig
@@ -105,14 +105,6 @@ pub const CoreGlfw = struct {
         return null;
     }
 
-    fn toMachAction(action: glfw.Action) enums.Action {
-        return switch (action) {
-            .press => .press,
-            .release => .release,
-            .repeat => .repeat,
-        };
-    }
-
     fn toMachKey(key: glfw.Key) enums.Key {
         return switch (key) {
             .a => .a,

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -1,4 +1,5 @@
 const gpu = @import("gpu");
+const enums = @import("enums.zig");
 
 pub const Size = struct {
     width: u32,
@@ -50,4 +51,13 @@ pub const Options = struct {
 
     /// Whether the application has a preference for low power or high performance GPU.
     power_preference: gpu.PowerPreference = .none,
+};
+
+pub const Event = union(enum) {
+    key_press: struct {
+        key: enums.Key,
+    },
+    key_release: struct {
+        key: enums.Key,
+    },
 };


### PR DESCRIPTION
Relevent commit message:
```
This commit changes the former callback based design to handle key input
(GLFW-like) to an event loop based design (SDL-like). This uses a
TailQueue to store the events from inside of standard glfw callbacks.
This Queue is then popped while polling, thereby emulating event loop.

Removes from Engine the function: ``setKeyCallback`` and adds the
function: ``pollEvent`` which may return an event or null.

This change was done for two reasons:
1) Removing dependence of Engine on App. This was a circular dependency
   and a genuine bad design.
2) Solve the recent regression due to the same which was (i) preventing
   using types declared in Engine.zig and (ii) preventing usage of
   multiple source files in an application.

Currently only key press and release events are implemented as these are
the ones currently used in examples.
```

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.