### PR TITLE
examples: boids: use std.log.info instead of std.debug.print

### DIFF
--- a/examples/boids/main.zig
+++ b/examples/boids/main.zig
@@ -195,7 +195,7 @@ pub fn update(app: *App, engine: *mach.Engine) !bool {
 
     app.frame_counter += 1;
     if (app.frame_counter % 60 == 0) {
-        std.debug.print("Frame {}\n", .{app.frame_counter});
+        std.log.info("Frame {}", .{app.frame_counter});
     }
 
     var command = command_encoder.finish(null);


### PR DESCRIPTION
std.debug.print uses IO which depends on file system and thus needs
support from OS, which dont have in freestanding targets (like WASM).

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.