### PR TITLE
mach: initial wasm platform implementation

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -59,6 +59,7 @@ pub fn build(b: *std.build.Builder) void {
         );
         example_app.setBuildMode(mode);
         example_app.link(options);
+        example_app.install();
 
         if (target.toTarget().cpu.arch != .wasm32) {
             const example_run_cmd = example_app.run();
@@ -80,6 +81,7 @@ pub fn build(b: *std.build.Builder) void {
         );
         shaderexp_app.setBuildMode(mode);
         shaderexp_app.link(options);
+        shaderexp_app.install();
 
         const shaderexp_run_cmd = shaderexp_app.run();
         shaderexp_run_cmd.step.dependOn(&shaderexp_app.getInstallStep().?.step);
@@ -149,13 +151,16 @@ const App = struct {
 
         step.addPackage(app_pkg);
         step.setTarget(options.target);
-        step.install();
 
         return .{
             .b = b,
             .step = step,
             .name = options.name,
         };
+    }
+
+    pub fn install(app: *const App) void {
+        app.step.install();
     }
 
     pub fn link(app: *const App, options: Options) void {

--- a/gpu/build.zig
+++ b/gpu/build.zig
@@ -45,8 +45,10 @@ pub const pkg = std.build.Pkg{
 };
 
 pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep, options: Options) void {
-    glfw.link(b, step, options.glfw_options);
-    gpu_dawn.link(b, step, options.gpu_dawn_options);
+    if (step.target.toTarget().cpu.arch != .wasm32) {
+        glfw.link(b, step, options.glfw_options);
+        gpu_dawn.link(b, step, options.gpu_dawn_options);
+    }
 }
 
 fn thisDir() []const u8 {

--- a/src/Engine.zig
+++ b/src/Engine.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const builtin = @import("builtin");
 const glfw = @import("glfw");
 const gpu = @import("gpu");
 const structs = @import("structs.zig");
@@ -88,9 +89,11 @@ pub fn init(allocator: std.mem.Allocator, options: structs.Options) !Engine {
 }
 
 fn GetCoreInternalType() type {
+    if (builtin.cpu.arch == .wasm32) return @import("wasm.zig").CoreWasm;
     return @import("native.zig").CoreGlfw;
 }
 
 fn GetGpuDriverInternalType() type {
+    if (builtin.cpu.arch == .wasm32) return @import("wasm.zig").GpuDriverWeb;
     return @import("native.zig").GpuDriverNative;
 }

--- a/src/Timer.zig
+++ b/src/Timer.zig
@@ -6,7 +6,29 @@ const Timer = @This();
 backing_timer: BackingTimerType = undefined,
 
 // TODO: verify declarations and its signatures
-const BackingTimerType = if (builtin.cpu.arch == .wasm32) void else std.time.Timer;
+const BackingTimerType = if (builtin.cpu.arch == .wasm32) struct {
+    pad0: u8 = 0,
+
+    const WasmTimer = @This();
+
+    fn start() !WasmTimer {
+        return WasmTimer{};
+    }
+
+    fn read(_: *WasmTimer) u64 {
+        return 0;
+    }
+
+    fn reset(_: *WasmTimer) void {}
+
+    fn lap(_: *WasmTimer) u64 {
+        return 0;
+    }
+
+    fn timeToNs(_: f64) u64 {
+        return 0;
+    }
+} else std.time.Timer;
 
 /// Initialize the timer.
 pub fn start() !Timer {

--- a/src/mach.js
+++ b/src/mach.js
@@ -26,6 +26,19 @@ const mach = {
     }
   },
 
+  machLogWrite(str, len) {
+    log_buf += mach.getString(str, len);
+  },
+
+  machLogFlush() {
+    console.log(log_buf);
+    log_buf = "";
+  },
+
+  machPanic(str, len) {
+    throw Error(mach.getString(str, len));
+  },
+
   machCanvasInit(width, height, id) {
     let canvas = document.createElement("canvas");
     canvas.id = "#mach-canvas-" + mach.canvases.length;

--- a/src/mach.js
+++ b/src/mach.js
@@ -1,0 +1,77 @@
+const original_title = document.title;
+const text_decoder = new TextDecoder();
+const text_encoder = new TextEncoder();
+let log_buf = "";
+
+const mach = {
+  canvases: [],
+  wasm: undefined,
+  events: [],
+
+  init(wasm) {
+    this.wasm = wasm;
+  },
+
+  getString(str, len) {
+    const memory = mach.wasm.exports.memory.buffer;
+    return text_decoder.decode(new Uint8Array(memory, str, len));
+  },
+
+  setString(str, buf) {
+    const memory = this.wasm.exports.memory.buffer;
+    const strbuf = text_encoder.encode(str);
+    const outbuf = new Uint8Array(memory, buf, strbuf.length);
+    for (let i = 0; i < strbuf.length; i += 1) {
+        outbuf[i] = strbuf[i];
+    }
+  },
+
+  machCanvasInit(width, height, id) {
+    let canvas = document.createElement("canvas");
+    canvas.id = "#mach-canvas-" + mach.canvases.length;
+    canvas.width = width;
+    canvas.height = height;
+    canvas.tabIndex = 1;
+
+    mach.setString(canvas.id, id);
+
+    canvas.addEventListener("contextmenu", (ev) => ev.preventDefault());
+
+    document.body.appendChild(canvas);
+    return mach.canvases.push({ canvas: canvas, title: undefined }) - 1;
+  },
+
+  machCanvasDeinit(canvas) {
+    if (mach.canvases[canvas] != undefined) {
+      mach.canvases.splice(canvas, 1);
+    }
+  },
+
+  machCanvasSetTitle(canvas, title, len) {
+    const str = len > 0 ?
+      mach.getString(title, len) :
+      original_title;
+
+    mach.canvases[canvas].title = str;
+  },
+
+  machCanvasSetSize(canvas, width, height) {
+    const cv = mach.canvases[canvas];
+    if (width > 0 && height > 0) {
+      cv.canvas.width = width;
+      cv.canvas.height = height;
+    }
+  },
+
+  machCanvasGetWidth(canvas) {
+    const cv = mach.canvases[canvas];
+    return cv.canvas.width;
+  },
+
+  machCanvasGetHeight(canvas) {
+    const cv = mach.canvases[canvas];
+    return cv.canvas.height;
+  },
+};
+
+export { mach };

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const App = @import("app");
+const Engine = @import("Engine.zig");
+const structs = @import("structs.zig");
+const enums = @import("enums.zig");
+
+const js = struct {};
+
+pub const CoreWasm = struct {
+    pub fn init(_: std.mem.Allocator, _: *Engine) !CoreWasm {
+        return CoreWasm{};
+    }
+
+    pub fn setShouldClose(_: *CoreWasm, _: bool) void {}
+
+    pub fn getFramebufferSize(_: *CoreWasm) !structs.Size {
+        return structs.Size{ .width = 0, .height = 0 };
+    }
+
+    pub fn setSizeLimits(_: *CoreWasm, _: structs.SizeOptional, _: structs.SizeOptional) !void {}
+
+    pub fn pollEvent(_: *CoreWasm) ?structs.Event {
+        return null;
+    }
+};
+
+pub const GpuDriverWeb = struct {
+    pub fn init(_: std.mem.Allocator, _: *Engine) !GpuDriverWeb {
+        return GpuDriverWeb{};
+    }
+};
+
+var app: App = undefined;
+var engine: Engine = undefined;
+
+export fn wasmInit() void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+
+    const options = if (@hasDecl(App, "options")) App.options else structs.Options{};
+    engine = Engine.init(allocator, options) catch unreachable;
+
+    app.init(&engine) catch {};
+}
+
+export fn wasmUpdate() bool {
+    return app.update(&engine) catch false;
+}
+
+export fn wasmDeinit() void {
+    app.deinit(&engine);
+}

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -40,7 +40,11 @@ pub const CoreWasm = struct {
 
     pub fn setShouldClose(_: *CoreWasm, _: bool) void {}
 
-    pub fn getFramebufferSize(core: *CoreWasm) !structs.Size {
+    pub fn getFramebufferSize(_: *CoreWasm) !structs.Size {
+        return structs.Size{ .width = 0, .height = 0 };
+    }
+
+    pub fn getWindowSize(core: *CoreWasm) !structs.Size {
         return structs.Size{
             .width = js.machCanvasGetWidth(core.id),
             .height = js.machCanvasGetHeight(core.id),

--- a/src/wasm.zig
+++ b/src/wasm.zig
@@ -11,6 +11,11 @@ const js = struct {
     extern fn machCanvasSetSize(canvas: CanvasId, width: u32, height: u32) void;
     extern fn machCanvasGetWidth(canvas: CanvasId) u32;
     extern fn machCanvasGetHeight(canvas: CanvasId) u32;
+
+    extern fn machLog(str: [*]const u8, len: u32) void;
+    extern fn machLogWrite(str: [*]const u8, len: u32) void;
+    extern fn machLogFlush() void;
+    extern fn machPanic(str: [*]const u8, len: u32) void;
 };
 
 pub const CanvasId = u32;
@@ -74,4 +79,32 @@ export fn wasmUpdate() bool {
 
 export fn wasmDeinit() void {
     app.deinit(&engine);
+}
+
+pub const log_level = .info;
+
+const LogError = error{};
+const LogWriter = std.io.Writer(void, LogError, writeLog);
+
+fn writeLog(_: void, msg: []const u8) LogError!usize {
+    js.machLogWrite(msg.ptr, msg.len);
+    return msg.len;
+}
+
+pub fn log(
+    comptime message_level: std.log.Level,
+    comptime scope: @Type(.EnumLiteral),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    const prefix = if (scope == .default) ": " else "(" ++ @tagName(scope) ++ "): ";
+    const writer = LogWriter{ .context = {} };
+
+    writer.print(message_level.asText() ++ prefix ++ format ++ "\n", args) catch return;
+    js.machLogFlush();
+}
+
+pub fn panic(msg: []const u8, _: ?*std.builtin.StackTrace) noreturn {
+    js.machPanic(msg.ptr, msg.len);
+    unreachable;
 }

--- a/www/template.html
+++ b/www/template.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      canvas {
+        border: 1px solid;
+      }
+    </style>
+  </head>
+  <body>
+    <script type="module">
+      import { mach } from "./mach.js";
+
+      let imports = {
+        env: mach,
+      };
+
+      fetch("application.wasm")
+        .then(response => response.arrayBuffer())
+        .then(buffer => WebAssembly.instantiate(buffer, imports))
+        .then(results => results.instance)
+        .then(instance => {
+          mach.init(instance);
+          instance.exports.wasmInit();
+
+          let update = function() {
+            const r = instance.exports.wasmUpdate();
+            if (r) requestAnimationFrame(update)
+            else instance.exports.wasmDeinit();
+          };
+
+          requestAnimationFrame(update);
+        })
+        .catch(err => console.log(err));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This is very incomplete, it is not ready to support the examples yet.
This PR just implements the barebones structures needed for future wasm development. The build system support is also lacking, which will be done progressively.

In order to run:
```sh-session 
# This is actually going to compile all examples but you can only run the last one
zig build compile-all -Dtarget=wasm32-freestanding-none 
cd zig-out/lib
cp ../../www/template.html application.html
cp ../../src/mach.js .
# Run a web server
python3 -m http.server
# Navigate to https://localhost:8000/application.html
```
This PR also implements some general build.zig sdk improvements:
```
- Target is now passed as an option in App.init()
- Always install() in all case
- Add functions getInstallStep(), setBuildMode() and run()
```

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.