### PR TITLE
mach: add compile-only step for examples and shaderexp

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -61,6 +61,9 @@ pub fn build(b: *std.build.Builder) void {
         example_app.link(options);
         example_app.install();
 
+        const example_compile_step = b.step("example-" ++ example.name, "Compile the example");
+        example_compile_step.dependOn(&example_app.getInstallStep().?.step);
+
         if (target.toTarget().cpu.arch != .wasm32) {
             const example_run_cmd = example_app.run();
             example_run_cmd.step.dependOn(&example_app.getInstallStep().?.step);
@@ -82,6 +85,9 @@ pub fn build(b: *std.build.Builder) void {
         shaderexp_app.setBuildMode(mode);
         shaderexp_app.link(options);
         shaderexp_app.install();
+
+        const shaderexp_compile_step = b.step("shaderexp", "Compile shaderexp");
+        shaderexp_compile_step.dependOn(&shaderexp_app.getInstallStep().?.step);
 
         const shaderexp_run_cmd = shaderexp_app.run();
         shaderexp_run_cmd.step.dependOn(&shaderexp_app.getInstallStep().?.step);

--- a/build.zig
+++ b/build.zig
@@ -61,13 +61,13 @@ pub fn build(b: *std.build.Builder) void {
         example_app.link(options);
         example_app.install();
 
-        const example_compile_step = b.step("example-" ++ example.name, "Compile the example");
+        const example_compile_step = b.step("example-" ++ example.name, "Compile '" ++ example.name ++ "' example");
         example_compile_step.dependOn(&example_app.getInstallStep().?.step);
 
         if (target.toTarget().cpu.arch != .wasm32) {
             const example_run_cmd = example_app.run();
             example_run_cmd.step.dependOn(&example_app.getInstallStep().?.step);
-            const example_run_step = b.step("run-example-" ++ example.name, "Run the example");
+            const example_run_step = b.step("run-example-" ++ example.name, "Run '" ++ example.name ++ "' example");
             example_run_step.dependOn(&example_run_cmd.step);
         }
     }


### PR DESCRIPTION
Discussion: https://matrix.to/#/!hPlvgnLQhMkTucKPrh:matrix.org/$P_aED8yOzDymRmMF6aT0ez19GMgSY8ci9jnNAq8eRJo?via=matrix.org

Commit message:
```
These steps will only compile and install the applications but not run
it. To be used as ``zig build example-*`` and ``zig build shaderexp``
respectively, i.e without the run prefix.
```

Also made a minor change to include the name of example in their respective compile and run steps.

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.