### PR TITLE
Mach: improvements to build system (for wasm)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "freetype/upstream"]
 	path = freetype/upstream
 	url = https://github.com/hexops/freetype
+[submodule "tools/libs/apple_pie"]
+	path = tools/libs/apple_pie
+	url = https://github.com/Luukdegram/apple_pie

--- a/build.zig
+++ b/build.zig
@@ -220,6 +220,8 @@ pub const App = struct {
 
     pub fn run(app: *const App) *std.build.RunStep {
         if (app.step.target.toTarget().cpu.arch == .wasm32) {
+            ensureDependencySubmodule(app.b.allocator, "tools/libs/apple_pie") catch unreachable;
+
             const http_server = app.b.addExecutable("http-server", thisDir() ++ "/tools/http-server.zig");
             http_server.addPackage(.{
                 .name = "apple_pie",

--- a/build.zig
+++ b/build.zig
@@ -54,7 +54,7 @@ pub fn build(b: *std.build.Builder) void {
                 .name = "example-" ++ example.name,
                 .src = "examples/" ++ example.name ++ "/main.zig",
                 .target = target,
-                .deps = comptime example.packages ++ &[_]Pkg{ glfw.pkg, gpu.pkg, pkg },
+                .deps = example.packages,
             },
         );
         example_app.setBuildMode(mode);
@@ -79,7 +79,6 @@ pub fn build(b: *std.build.Builder) void {
                 .name = "shaderexp",
                 .src = "shaderexp/main.zig",
                 .target = target,
-                .deps = &.{ glfw.pkg, gpu.pkg, pkg },
             },
         );
         shaderexp_app.setBuildMode(mode);
@@ -133,10 +132,16 @@ pub const App = struct {
         target: std.zig.CrossTarget,
         deps: ?[]const Pkg = null,
     }) App {
+        const mach_deps: []const Pkg = &.{ glfw.pkg, gpu.pkg, pkg };
+        const deps = if (options.deps) |app_deps|
+            std.mem.concat(b.allocator, Pkg, &.{ mach_deps, app_deps }) catch unreachable
+        else
+            mach_deps;
+
         const app_pkg = std.build.Pkg{
             .name = "app",
             .path = .{ .path = options.src },
-            .dependencies = options.deps,
+            .dependencies = deps,
         };
 
         const step = blk: {
@@ -200,7 +205,7 @@ pub const App = struct {
 pub const pkg = std.build.Pkg{
     .name = "mach",
     .path = .{ .path = thisDir() ++ "/src/main.zig" },
-    .dependencies = &.{ gpu.pkg, glfw.pkg },
+    .dependencies = &.{gpu.pkg},
 };
 
 fn thisDir() []const u8 {

--- a/tools/html-generator.zig
+++ b/tools/html-generator.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+
+const source = @embedFile("../www/template.html");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const allocator = gpa.allocator();
+    defer _ = gpa.deinit();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    if (args.len < 3) {
+        std.debug.print("Usage: html-generator <output-name> <application-name>\n", .{});
+        return;
+    }
+
+    const output_name = args[1];
+    const application_name = args[2];
+
+    const file = try std.fs.cwd().createFile(output_name, std.fs.File.CreateFlags{});
+    defer file.close();
+
+    const writer = file.writer();
+    try std.fmt.format(writer, source, .{application_name});
+}

--- a/tools/http-server.zig
+++ b/tools/http-server.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const http = @import("apple_pie");
+const file_server = http.FileServer;
+
+pub const io_mode = .evented;
+
+pub fn main() !u8 {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const args = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, args);
+
+    std.debug.print("Served at http://127.0.0.1:8000/{s}.html\n", .{args[1]});
+
+    try file_server.init(allocator, .{ .dir_path = "." });
+    defer file_server.deinit();
+
+    try http.listenAndServe(
+        allocator,
+        try std.net.Address.parseIp("127.0.0.1", 8000),
+        {},
+        file_server.serve,
+    );
+
+    return 0;
+}

--- a/tools/http-server.zig
+++ b/tools/http-server.zig
@@ -12,14 +12,23 @@ pub fn main() !u8 {
     const args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, args);
 
-    std.debug.print("Served at http://127.0.0.1:8000/{s}.html\n", .{args[1]});
+    if (args.len < 4) {
+        std.debug.print("Usage: http-server <application-name> <address> <port>\n", .{});
+        return 0;
+    }
+
+    const application_name = args[1];
+    const address = args[2];
+    const port = try std.fmt.parseUnsigned(u16, args[3], 10);
+
+    std.debug.print("Served at http://{s}:{}/{s}.html\n", .{ address, port, application_name });
 
     try file_server.init(allocator, .{ .dir_path = "." });
     defer file_server.deinit();
 
     try http.listenAndServe(
         allocator,
-        try std.net.Address.parseIp("127.0.0.1", 8000),
+        try std.net.Address.parseIp(address, port),
         {},
         file_server.serve,
     );

--- a/www/template.html
+++ b/www/template.html
@@ -3,35 +3,35 @@
   <head>
     <meta charset="utf-8">
     <style>
-      canvas {
+      canvas {{
         border: 1px solid;
-      }
+      }}
     </style>
   </head>
   <body>
     <script type="module">
-      import { mach } from "./mach.js";
+      import {{ mach }} from "./mach.js";
 
-      let imports = {
+      let imports = {{
         env: mach,
-      };
+      }};
 
-      fetch("application.wasm")
+	  fetch("{s}.wasm")
         .then(response => response.arrayBuffer())
         .then(buffer => WebAssembly.instantiate(buffer, imports))
         .then(results => results.instance)
-        .then(instance => {
+        .then(instance => {{
           mach.init(instance);
           instance.exports.wasmInit();
 
-          let update = function() {
+          let update = function() {{
             const r = instance.exports.wasmUpdate();
             if (r) requestAnimationFrame(update)
             else instance.exports.wasmDeinit();
-          };
+          }};
 
           requestAnimationFrame(update);
-        })
+        }})
         .catch(err => console.error(err));
     </script>
   </body>


### PR DESCRIPTION
- Made general improvements to build system on how to add dependencies, removed redundant dependencies internally
- In case of wasm, install the necessary js and html files in prefix/www. The main HTML file is generated with an application placed in tools/html-generator.zig. This application would prove to be more useful in future when we have more modules inside the engine (as all js files need to be listen inside this HTML file)
- In case of wasm, serve the application using a http server placed in tools/http-server.zig. The address and port can be customized using the environment variables ``MACH_ADDRESS`` and ``MACH_PORT`` respectively.
- Finally in case of wasm, launch a web browser with the link where the application is being served.

The serve + launch steps can be customized with options in future, but right now it's kept as simple as possible.

This PR enables use of run step for wasm application. Now you can freely do ``zig build run-example-* -Dtarget=wasm32-freestanding-none`` and everything will just work (regarding the build system)

Further, now generate separate html and wasm files in install:
```
# ls zig-out/www
example-triangle.html  example-triangle.wasm  example-two-cubes.html  example-two-cubes.wasm  main.js ...
```

With this PR we achieve feature parity for general support of wasm development.

Fixes hexops/mach#18

---

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.