### PR TITLE
gpu: Queue.WorkDoneStatus fields should be snake_case.

### DIFF
--- a/gpu/src/Queue.zig
+++ b/gpu/src/Queue.zig
@@ -105,11 +105,10 @@ pub const Descriptor = struct {
 };
 
 pub const WorkDoneStatus = enum(u32) {
-    Success = 0x00000000,
-    Error = 0x00000001,
-    Unknown = 0x00000002,
-    DeviceLost = 0x00000003,
-    Force32 = 0x7FFFFFFF,
+    success = 0x00000000,
+    err = 0x00000001,
+    unknown = 0x00000002,
+    device_lost = 0x00000003,
 };
 
 test {


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.