### PR TITLE
mach: build: disable gkurve example of wasm as freetype cant be compiled for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: compile all examples
         if: matrix.project == '.'
         run: cd ${{ matrix.project }} && zig build compile-all
+      - name: compile all examples (WASM)
+        if: matrix.project == '.'
+        run: cd ${{ matrix.project }} && zig build compile-all -Dtarget=wasm32-freestanding-none
       - name: launch xvfb
         run: Xvfb :99 -screen 0 1680x720x24 > /dev/null 2>&1 &
       - name: test
@@ -74,6 +77,9 @@ jobs:
       - name: compile all examples
         if: matrix.project == '.'
         run: cd ${{ matrix.project }} && zig build compile-all
+      - name: compile all examples (WASM)
+        if: matrix.project == '.'
+        run: cd ${{ matrix.project }} && zig build compile-all -Dtarget=wasm32-freestanding-none
       - name: test
         run: cd ${{ matrix.project }} && zig build test
   x86_64-macos:

--- a/.github/workflows/m1_ci.yml
+++ b/.github/workflows/m1_ci.yml
@@ -44,3 +44,6 @@ jobs:
         run: cd ${{ matrix.project }} && zig build compile-all
         env:
           AGREE: true
+      - name: compile all examples (WASM)
+        if: matrix.project == '.'
+        run: cd ${{ matrix.project }} && zig build compile-all -Dtarget=wasm32-freestanding-none

--- a/build.zig
+++ b/build.zig
@@ -39,7 +39,7 @@ pub fn build(b: *std.build.Builder) void {
         .{ .name = "instanced-cube", .packages = &[_]Pkg{Packages.zmath} },
         .{ .name = "advanced-gen-texture-light", .packages = &[_]Pkg{Packages.zmath} },
         .{ .name = "fractal-cube", .packages = &[_]Pkg{Packages.zmath} },
-        .{ .name = "gkurve", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg, freetype.pkg } },
+        .{ .name = "gkurve", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg, freetype.pkg }, .std_platform_only = true },
         .{ .name = "textured-cube", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg } },
     }) |example| {
         // FIXME: this is workaround for a problem that some examples (having the std_platform_only=true field) as
@@ -64,7 +64,7 @@ pub fn build(b: *std.build.Builder) void {
             if (std.mem.eql(u8, p.name, freetype.pkg.name))
                 freetype.link(example_app.b, example_app.step, .{});
         }
-            
+
         example_app.link(options);
         example_app.install();
 


### PR DESCRIPTION
Also added compile-all step to CI so that these dont happen in future.
Currently CI is failing because zig version on it has not been updated yet

---
- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.