### PR TITLE
CI: automate Zig version upgrades; upgrade Zig & more

### DIFF
--- a/.github/workflows/m1_ci.yml
+++ b/.github/workflows/m1_ci.yml
@@ -1,4 +1,4 @@
-name: M1 CI
+name: CI
 on:
   # SECURITY: This must be a push event only, otherwise our M1 mac runner would be compromised by
   # third-party pull requests which could run arbitrary code. This way, we can restrict it to

--- a/.github/workflows/m1_ci.yml
+++ b/.github/workflows/m1_ci.yml
@@ -26,7 +26,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Zig
         run: |
-          zig version
+          sudo rm -rf /usr/local/bin/zig /usr/local/bin/lib/
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-linux-aarch64-0.10.0-dev.2431+0e6285c8f.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: mach::test
         run: zig build test
         env:

--- a/dev/update-zig.sh
+++ b/dev/update-zig.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"/..
+
+update_zig() {
+    gsed -i 's|\(https://ziglang.org/builds/zig-[^/ -]*-[^/ -]*-\)[^/ ]*\(\(\.tar\.xz\)[^/ ]*\)|\1'"$1"'\2|' $2
+    gsed -i 's|\(https://ziglang.org/builds/zig-[^/ -]*-[^/ -]*-\)[^/ ]*\(\(\.zip\)[^/ ]*\)|\1'"$1"'\2|' $2
+}
+
+if [ -n "${ZIG_VERSION:-}" ]; then
+    version="${ZIG_VERSION:-}"
+
+    sources=$(find . | grep './.github/workflows' | grep -v 'third_party/' | grep -v 'DirectXShaderCompiler' | grep -v '/libs/' | grep '\.yml')
+    echo "$sources" | while read line ; do update_zig "$version" "$line" ; done
+
+    update_zig "$version" README.md
+else
+    echo "must specify e.g. ZIG_VERSION=0.10.0-dev.2017+a0a2ce92c"
+    exit 0
+fi

--- a/glfw/.github/workflows/m1_ci.yml
+++ b/glfw/.github/workflows/m1_ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: M1
 on:
   # SECURITY: This must be a push event only, otherwise our M1 mac runner would be compromised by
   # third-party pull requests which could run arbitrary code. This way, we can restrict it to

--- a/glfw/.github/workflows/m1_ci.yml
+++ b/glfw/.github/workflows/m1_ci.yml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Zig
         run: |
-          zig version
+          sudo rm -rf /usr/local/bin/zig /usr/local/bin/lib/
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-linux-aarch64-0.10.0-dev.2431+0e6285c8f.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: test
         run: zig build test
         env:

--- a/gpu-dawn/.github/workflows/m1_ci.yml
+++ b/gpu-dawn/.github/workflows/m1_ci.yml
@@ -20,7 +20,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Zig
         run: |
-          zig version
+          sudo rm -rf /usr/local/bin/zig /usr/local/bin/lib/
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-linux-aarch64-0.10.0-dev.2431+0e6285c8f.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: Clone mach-glfw
         run: rm libs/mach-glfw && git clone https://github.com/hexops/mach-glfw libs/mach-glfw
       - name: install (debug)

--- a/gpu-dawn/.github/workflows/m1_ci.yml
+++ b/gpu-dawn/.github/workflows/m1_ci.yml
@@ -1,4 +1,4 @@
-name: CI M1
+name: M1
 on:
   workflow_run:
     workflows: ["Draft release"]


### PR DESCRIPTION
after this change, it should be possible for anyone to easily send a PR to update the Zig version we use:

- To upgrade Zig version, we just run e.g. `ZIG_VERSION='zig-0.10.0-dev.2431+0e6285c8f' ./dev/update-zig.sh` and it will update every CI yml file in the repository, as well as the README.
- The README now states the currently-tested Zig version.
- The M1 runner now has it's Zig version managed by the yml file (previously me manually installing it on the machine.)

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.