### PR TITLE
ECS fixes

### DIFF
--- a/ecs/src/entities.zig
+++ b/ecs/src/entities.zig
@@ -371,6 +371,10 @@ pub const Entities = struct {
         // new component was added), or the same archetype storage table (if just updating the
         // value of a component.)
         var archetype_entry = try entities.archetypes.getOrPut(entities.allocator, new_hash);
+
+        // WARNING: entities.archetypes.getOrPut() can invalidate archetype, so we refresh it here
+        archetype = entities.archetypeByID(entity);
+
         if (!archetype_entry.found_existing) {
             archetype_entry.value_ptr.* = ArchetypeStorage{
                 .allocator = entities.allocator,
@@ -488,6 +492,10 @@ pub const Entities = struct {
         // new component was added), or the same archetype storage table (if just updating the
         // value of a component.)
         var archetype_entry = try entities.archetypes.getOrPut(entities.allocator, new_hash);
+
+        // WARNING: entities.archetypes.getOrPut() can invalidate archetype, so we refresh it here
+        archetype = entities.archetypeByID(entity);
+
         if (!archetype_entry.found_existing) {
             archetype_entry.value_ptr.* = ArchetypeStorage{
                 .allocator = entities.allocator,

--- a/ecs/src/entities.zig
+++ b/ecs/src/entities.zig
@@ -428,7 +428,7 @@ pub const Entities = struct {
         while (column_iter.next()) |entry| {
             var old_component_storage = entry.value_ptr;
             var new_component_storage = current_archetype_storage.components.get(entry.key_ptr.*).?;
-            new_component_storage.copy(new_component_storage.ptr, entities.allocator, new_row, old_ptr.row_index, old_component_storage.ptr) catch |err| {
+            new_component_storage.copy(new_component_storage.ptr, entities.allocator, old_ptr.row_index, new_row, old_component_storage.ptr) catch |err| {
                 current_archetype_storage.undoNew();
                 return err;
             };
@@ -528,7 +528,7 @@ pub const Entities = struct {
         while (column_iter.next()) |entry| {
             var src_component_storage = archetype.components.get(entry.key_ptr.*).?;
             var dst_component_storage = entry.value_ptr;
-            dst_component_storage.copy(dst_component_storage.ptr, entities.allocator, new_row, old_ptr.row_index, src_component_storage.ptr) catch |err| {
+            dst_component_storage.copy(dst_component_storage.ptr, entities.allocator, old_ptr.row_index, new_row, src_component_storage.ptr) catch |err| {
                 current_archetype_storage.undoNew();
                 return err;
             };


### PR DESCRIPTION
Two small fixes for the ECS

- Fix the usage of `copy()`, which had the `src_row` and `dst_row` arguments supplied in the wrong order
- Fix a bug cause by pointer invalidation in the `setComponent()` and `removeComponent()` functions, caused by `getOrPut()` on the hash map sometimes invalidating the archetype retrieved by `archetypeByID()`.

I haven't made a minimal reproducible example for the second bug, it doesn't show up under all circumstances, in my use it showed up when 'enough' stuff was added to the ECS, which must have made `getOrPutContext()` more likely to invalidate the pointer.

Perhaps there is a better way to rewrite the usage of `archetype` in the functions, this is just the minimal change that stops things crashing.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.