### PR TITLE
freetype: Avoid dereferencing null bitmap buffer.

### DIFF
--- a/freetype/examples/single-glyph.zig
+++ b/freetype/examples/single-glyph.zig
@@ -21,7 +21,7 @@ pub fn main() !void {
     while (i < bitmap.rows()) : (i += 1) {
         var j: usize = 0;
         while (j < bitmap.width()) : (j += 1) {
-            const char: u8 = switch (bitmap.buffer()[i * bitmap.width() + j]) {
+            const char: u8 = switch (bitmap.buffer().?[i * bitmap.width() + j]) {
                 0 => ' ',
                 1...128 => ';',
                 else => '#',

--- a/freetype/src/freetype/image.zig
+++ b/freetype/src/freetype/image.zig
@@ -45,8 +45,13 @@ pub const Bitmap = struct {
         return @intToEnum(PixelMode, self.handle.pixel_mode);
     }
 
-    pub fn buffer(self: Bitmap) []const u8 {
+    pub fn buffer(self: Bitmap) ?[]const u8 {
         const buffer_size = std.math.absCast(self.pitch()) * self.rows();
-        return self.handle.buffer[0..buffer_size];
+        return if (self.handle.buffer == null)
+            // freetype returns a null pointer for zero-length allocations
+            // https://github.com/hexops/freetype/blob/bbd80a52b7b749140ec87d24b6c767c5063be356/freetype/src/base/ftutil.c#L135
+            null
+        else
+            self.handle.buffer[0..buffer_size];
     }
 };


### PR DESCRIPTION
For some characters (eg \r) the returned glyph will have .{.rows = 0, .width=0, .pitch = 0, .buffer = null}. In zig null[0..0] causes a panic rather than returning an empty slice.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.