### PR TITLE
mach: Implement fullscreen application support

### DIFF
--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -1187,7 +1187,7 @@ pub inline fn getMonitor(self: Window) ?Monitor {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: window_monitor, window_full_screen, glfw.Window.getMonitor, glfw.Window.setSize
-pub inline fn setMonitor(self: Window, monitor: ?Monitor, xpos: i32, ypos: i32, width: i32, height: i32, refresh_rate: ?u32) error{PlatformError}!void {
+pub inline fn setMonitor(self: Window, monitor: ?Monitor, xpos: u32, ypos: u32, width: u32, height: u32, refresh_rate: ?u32) error{PlatformError}!void {
     internal_debug.assertInitialized();
     c.glfwSetWindowMonitor(
         self.handle,

--- a/src/platform/mach.js
+++ b/src/platform/mach.js
@@ -182,13 +182,12 @@ const mach = {
     throw Error(mach.getString(str, len));
   },
 
-  machCanvasInit(width, height, id) {
+  machCanvasInit(id) {
     let canvas = document.createElement("canvas");
     canvas.id = "#mach-canvas-" + mach.canvases.length;
-    canvas.style.width = width + "px";
-    canvas.style.height = height + "px";
-    canvas.width = Math.floor(width * window.devicePixelRatio);
-    canvas.height = Math.floor(height * window.devicePixelRatio);
+    canvas.style.border = "1px solid";
+    canvas.style.position = "absolute";
+    canvas.style.display = "block";
     canvas.tabIndex = 1;
 
     mach.observer.observe(canvas, { attributes: true });
@@ -250,8 +249,24 @@ const mach = {
     if (width > 0 && height > 0) {
       cv.canvas.style.width = width + "px";
       cv.canvas.style.height = height + "px";
-      cv.canvas.width = width * window.devicePixelRatio;
-      cv.canvas.height = height * window.devicePixelRatio;
+      cv.canvas.width = Math.floor(width * window.devicePixelRatio);
+      cv.canvas.height = Math.floor(height * window.devicePixelRatio);
+    }
+  },
+
+  machCanvasSetFullscreen(canvas, value) {
+    const cv = mach.canvases[canvas];
+    if (value) {
+      cv.canvas.style.border = "0px";
+      cv.canvas.style.width = "100%";
+      cv.canvas.style.height = "100%";
+      cv.canvas.style.top = "0";
+      cv.canvas.style.left = "0";
+      cv.canvas.style.margin = "0px";
+    } else {
+      cv.canvas.style.border = "1px solid;"
+      cv.canvas.style.top = "2px";
+      cv.canvas.style.left = "2px";
     }
   },
 

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -17,6 +17,7 @@ pub const Platform = struct {
 
     last_window_size: structs.Size,
     last_framebuffer_size: structs.Size,
+    last_position: glfw.Window.Pos,
     wait_event_timeout: f64 = 0.0,
 
     native_instance: gpu.NativeInstance,
@@ -178,6 +179,7 @@ pub const Platform = struct {
             .allocator = engine.allocator,
             .last_window_size = .{ .width = window_size.width, .height = window_size.height },
             .last_framebuffer_size = .{ .width = framebuffer_size.width, .height = framebuffer_size.height },
+            .last_position = try window.getPos(),
             .native_instance = native_instance,
         };
     }
@@ -292,6 +294,16 @@ pub const Platform = struct {
             @bitCast(glfw.Window.SizeOptional, options.size_min),
             @bitCast(glfw.Window.SizeOptional, options.size_max),
         );
+        if (options.fullscreen) {
+            platform.last_position = try platform.window.getPos();
+
+            const monitor = glfw.Monitor.getPrimary().?;
+            const video_mode = try monitor.getVideoMode();
+            try platform.window.setMonitor(monitor, 0, 0, video_mode.getWidth(), video_mode.getHeight(), null);
+        } else {
+            const position = platform.last_position;
+            try platform.window.setMonitor(null, position.x, position.y, options.width, options.height, null);
+        }
     }
 
     pub fn setShouldClose(platform: *Platform, value: bool) void {

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -31,6 +31,9 @@ pub const Options = struct {
     /// The maximum allowed size for the window.
     size_max: SizeOptional = .{ .width = null, .height = null },
 
+    /// Fullscreen window.
+    fullscreen: bool = false,
+
     /// Monitor synchronization modes.
     vsync: enums.VSyncMode = .double,
 

--- a/www/template.html
+++ b/www/template.html
@@ -2,11 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <style>
-      canvas {{
-        border: 1px solid;
-      }}
-    </style>
   </head>
   <body>
     <script type="module">


### PR DESCRIPTION
Adds a new field to mach.Options called ``fullscreen: bool = false``. This PR implements fullscreen support for native and wasm platforms. 

For native, glfw doesn't supports getting the currently active monitor (i.e monitor having input focus), so the fullscreen window opens up on primary window by design.

For wasm, fullscreen support is primarily implemented with styles because html fullscreen support is broken in many ways. With fullscreen support, the border around canvas is also slightly broken when you switch between windows and fullscreen modes but thats a problem only for as long as we dont have rendering support for wasm.

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.