### PR TITLE
ecs: fixes for `setCapacity()` and `appendUndefined()`

### DIFF
--- a/ecs/src/entities.zig
+++ b/ecs/src/entities.zig
@@ -154,8 +154,9 @@ pub const ArchetypeStorage = struct {
 
         var offset: usize = 0;
         for (storage.columns) |*column| {
-            const align_mod = @ptrToInt(&new_block[offset]) % column.alignment;
-            const padding = if (align_mod == 0) 0 else column.alignment - align_mod;
+            const addr = @ptrToInt(&new_block[offset]);
+            const aligned_addr = std.mem.alignForward(addr, column.alignment);
+            const padding = aligned_addr - addr;
             offset += padding;
             if (storage.capacity > 0) {
                 const slice = storage.block[column.offset .. column.offset + storage.capacity * column.size];

--- a/ecs/src/entities.zig
+++ b/ecs/src/entities.zig
@@ -97,8 +97,9 @@ pub const ArchetypeStorage = struct {
     pub fn appendUndefined(storage: *ArchetypeStorage, gpa: Allocator) !u32 {
         try storage.ensureUnusedCapacity(gpa, 1);
         assert(storage.len < storage.capacity);
+        const row_index = storage.len;
         storage.len += 1;
-        return storage.len;
+        return row_index;
     }
 
     pub fn append(storage: *ArchetypeStorage, gpa: Allocator, row: anytype) !u32 {


### PR DESCRIPTION
Closes #341 and fixes two other bugs: 

- a bug with the alignment calculation in `setCapacity()` which arose when the initial offset has the correct alignment, leading to the padding equal to the column element size (as oppose to 0 padding)
- an off-by-one error in `appendUndefined()`.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.