### PR TITLE
mach<->ECS integration, ECS type safety, high-level application API proposal

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 pub const gpu = @import("gpu/build.zig");
 const gpu_dawn = @import("gpu-dawn/build.zig");
 pub const glfw = @import("glfw/build.zig");
+pub const ecs = @import("ecs/build.zig");
 const freetype = @import("freetype/build.zig");
 const Pkg = std.build.Pkg;
 
@@ -42,6 +43,7 @@ pub fn build(b: *std.build.Builder) void {
         .{ .name = "fractal-cube", .packages = &[_]Pkg{Packages.zmath} },
         .{ .name = "gkurve", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg, freetype.pkg }, .std_platform_only = true },
         .{ .name = "textured-cube", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg } },
+        .{ .name = "ecs-app", .packages = &[_]Pkg{} },
     }) |example| {
         // FIXME: this is workaround for a problem that some examples (having the std_platform_only=true field) as
         // well as zigimg uses IO which is not supported in freestanding environments. So break out of this loop
@@ -285,7 +287,7 @@ pub const App = struct {
 pub const pkg = std.build.Pkg{
     .name = "mach",
     .source = .{ .path = thisDir() ++ "/src/main.zig" },
-    .dependencies = &.{gpu.pkg},
+    .dependencies = &.{gpu.pkg, ecs.pkg},
 };
 
 fn thisDir() []const u8 {

--- a/build.zig
+++ b/build.zig
@@ -287,7 +287,7 @@ pub const App = struct {
 pub const pkg = std.build.Pkg{
     .name = "mach",
     .source = .{ .path = thisDir() ++ "/src/main.zig" },
-    .dependencies = &.{gpu.pkg, ecs.pkg},
+    .dependencies = &.{ gpu.pkg, ecs.pkg },
 };
 
 fn thisDir() []const u8 {

--- a/examples/ecs-app/main.zig
+++ b/examples/ecs-app/main.zig
@@ -3,16 +3,21 @@ const mach = @import("mach");
 const gpu = mach.gpu;
 const ecs = mach.ecs;
 
-const modules = .{
-    .core = mach.module,
-};
+const renderer = @import("renderer.zig");
+const physics2d = @import("physics2d.zig");
+
+const modules = ecs.Modules(.{
+    .mach = mach.module,
+    .renderer = renderer.module,
+    .physics2d = physics2d.module,
+});
 
 pub const App = mach.App(modules, init);
 
 pub fn init(engine: *ecs.World(modules)) !void {
-    const core = engine.get(.core);
+    const core = engine.get(.mach, .core);
     try core.setOptions(.{ .title = "Hello, ECS!" });
 
-    const device = engine.get(.device);
+    const device = engine.get(.mach, .device);
     _ = device; // use the GPU device ...
 }

--- a/examples/ecs-app/main.zig
+++ b/examples/ecs-app/main.zig
@@ -13,6 +13,6 @@ pub fn init(engine: *ecs.World(modules)) !void {
     const core = engine.get(.core);
     try core.setOptions(.{ .title = "Hello, ECS!" });
 
-    const device = core.device;
+    const device = engine.get(.device);
     _ = device; // use the GPU device ...
 }

--- a/examples/ecs-app/main.zig
+++ b/examples/ecs-app/main.zig
@@ -3,21 +3,61 @@ const mach = @import("mach");
 const gpu = mach.gpu;
 const ecs = mach.ecs;
 
+// TODO: *mach.Engine would be renamed to *mach.Core
+// TODO: the "ecs" package would be renamed to "engine"
+// TODO: *ecs.World would be renamed to *engine.Engine
+
 const renderer = @import("renderer.zig");
 const physics2d = @import("physics2d.zig");
 
+// This defines all of the modules in our application. Modules can have components, systems, state,
+// and global values in them. In the future, modules can send and receive messages to coordinate
+// with each-other.
 const modules = ecs.Modules(.{
     .mach = mach.module,
     .renderer = renderer.module,
     .physics2d = physics2d.module,
+
+    // Sometimes, you might have two modules with the same name. In this case you can rename them -
+    // you just have to tell the module it's namespace:
+    //
+    // .foo = renderer.Module(.foo),
+    // .bar = renderer.Module(.bar),
+    //
+    // This does mean, however, namespace-agnostic modules always need to be told where to find
+    // their dependencies. If renderer needed the ability to get physics2d component values, for
+    // example:
+    //
+    // .foo = renderer.Module(.foo, .physics2d),
+    // .bar = renderer.Module(.bar, .physics2d),
+    //
 });
 
+// Our Mach app, which tells Mach where to find our modules and init entry point.
+// It must be public, else you get an error. Yeah, it's a little magical.
 pub const App = mach.App(modules, init);
 
 pub fn init(engine: *ecs.World(modules)) !void {
+    // The engine *is* the ECS. That's where everything in Mach lives and operates.
+
+    // We can get the Mach core (previously called *Engine) to set window options, etc.:
     const core = engine.get(.mach, .core);
     try core.setOptions(.{ .title = "Hello, ECS!" });
 
+    // We can get the GPU device:
     const device = engine.get(.mach, .device);
     _ = device; // use the GPU device ...
+
+    // We can create entities, and set components on them. Note that components live in a module
+    // namespace, so we set the `.renderer, .location` component which is different than the
+    // `.physics2d, .location` component.
+
+    // TODO: we could cut out the `.entities.` in this API to make it more brief:
+    const player = try engine.entities.new();
+    try engine.entities.setComponent(player, .renderer, .location, .{.x = 0, .y = 0, .z = 0});
+    try engine.entities.setComponent(player, .physics2d, .location, .{.x = 0, .y = 0});
+    _ = player;
+
+    // TODO: there could be an entities wrapper to interact with a single namespace so you don't
+    // have to pass it in as a parameter always.
 }

--- a/examples/ecs-app/main.zig
+++ b/examples/ecs-app/main.zig
@@ -18,18 +18,16 @@ const modules = ecs.Modules(.{
     .renderer = renderer.module,
     .physics2d = physics2d.module,
 
-    // Sometimes, you might have two modules with the same name. In this case you can rename them -
-    // you just have to tell the module it's namespace:
+    // Note: Modules themselves will interact with the ECS, say by calling
+    // `.getComponent(.physics2d, .location)` and so the name here must match the module's
+    // expectation. You can't rename modules. Instead, we avoid collisions using some conventions:
     //
-    // .foo = renderer.Module(.foo),
-    // .bar = renderer.Module(.bar),
-    //
-    // This does mean, however, namespace-agnostic modules always need to be told where to find
-    // their dependencies. If renderer needed the ability to get physics2d component values, for
-    // example:
-    //
-    // .foo = renderer.Module(.foo, .physics2d),
-    // .bar = renderer.Module(.bar, .physics2d),
+    // * `mach` is always the Mach module.
+    // * One-word module names (`renderer`, `physics`, etc.) are reserved by Mach, you may use
+    //   one-word module names in your application but future versions of Mach may add modules with
+    //   that name and you'll have to rename yours to use that new functionality.
+    // * Two-word module names (`bullet_physics`, `ziglibs_box2d`) are encouraged for third-party
+    //   modules. If two conflict, you can't use them together without renaming one.
     //
 });
 
@@ -54,8 +52,8 @@ pub fn init(engine: *ecs.World(modules)) !void {
 
     // TODO: we could cut out the `.entities.` in this API to make it more brief:
     const player = try engine.entities.new();
-    try engine.entities.setComponent(player, .renderer, .location, .{.x = 0, .y = 0, .z = 0});
-    try engine.entities.setComponent(player, .physics2d, .location, .{.x = 0, .y = 0});
+    try engine.entities.setComponent(player, .renderer, .location, .{ .x = 0, .y = 0, .z = 0 });
+    try engine.entities.setComponent(player, .physics2d, .location, .{ .x = 0, .y = 0 });
     _ = player;
 
     // TODO: there could be an entities wrapper to interact with a single namespace so you don't

--- a/examples/ecs-app/main.zig
+++ b/examples/ecs-app/main.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const mach = @import("mach");
+const gpu = mach.gpu;
+const ecs = mach.ecs;
+
+const all_components = .{
+
+};
+
+pub const App = mach.App(all_components, init);
+
+pub fn init(engine: *mach.Engine, world: *ecs.World(all_components)) !void {
+    _ = engine;
+    _ = world;
+}

--- a/examples/ecs-app/main.zig
+++ b/examples/ecs-app/main.zig
@@ -3,13 +3,16 @@ const mach = @import("mach");
 const gpu = mach.gpu;
 const ecs = mach.ecs;
 
-const all_components = .{
-
+const modules = .{
+    .core = mach.module,
 };
 
-pub const App = mach.App(all_components, init);
+pub const App = mach.App(modules, init);
 
-pub fn init(engine: *mach.Engine, world: *ecs.World(all_components)) !void {
-    _ = engine;
-    _ = world;
+pub fn init(engine: *ecs.World(modules)) !void {
+    const core = engine.get(.core);
+    try core.setOptions(.{ .title = "Hello, ECS!" });
+
+    const device = core.device;
+    _ = device; // use the GPU device ...
 }

--- a/examples/ecs-app/main.zig
+++ b/examples/ecs-app/main.zig
@@ -3,8 +3,6 @@ const mach = @import("mach");
 const gpu = mach.gpu;
 const ecs = mach.ecs;
 
-// TODO: *mach.Engine would be renamed to *mach.Core
-// TODO: the "ecs" package would be renamed to "engine"
 // TODO: *ecs.World would be renamed to *engine.Engine
 
 const renderer = @import("renderer.zig");
@@ -38,7 +36,7 @@ pub const App = mach.App(modules, init);
 pub fn init(engine: *ecs.World(modules)) !void {
     // The engine *is* the ECS. That's where everything in Mach lives and operates.
 
-    // We can get the Mach core (previously called *Engine) to set window options, etc.:
+    // We can get the Mach core to set window options, etc.:
     const core = engine.get(.mach, .core);
     try core.setOptions(.{ .title = "Hello, ECS!" });
 

--- a/examples/ecs-app/physics2d.zig
+++ b/examples/ecs-app/physics2d.zig
@@ -9,6 +9,17 @@ pub const module = ecs.Module(.{
     },
     // TODO: there would be systems that we register here. Functions that iterate over entities
     // with physics2d components like `.velocity` and calculate physics updates for them!
+    .system = system,
 });
 
 pub const Vec2 = struct { x: f32, y: f32 };
+
+// TODO: there is a real problem here, we cannot access `modules`: dependency loop.
+// modules -> physics2d.module -> system -> modules
+fn system(engine: *ecs.World(modules)) !void {
+    _ = engine;
+
+    // A real system would query the ECS for entities with components. This is just an example.
+    const player = try engine.entities.new();
+    try engine.entities.setComponent(player, .physics2d, .location, .{ .x = 0, .y = 0 });
+}

--- a/examples/ecs-app/physics2d.zig
+++ b/examples/ecs-app/physics2d.zig
@@ -1,0 +1,12 @@
+const mach = @import("mach");
+const ecs = mach.ecs;
+
+pub const module = ecs.Module(.{
+    .components = .{
+        .location = Vec2,
+        .rotation = Vec2,
+        .velocity = Vec2,
+    },
+});
+
+pub const Vec2 = struct { x: f32, y: f32 };

--- a/examples/ecs-app/physics2d.zig
+++ b/examples/ecs-app/physics2d.zig
@@ -1,12 +1,19 @@
 const mach = @import("mach");
 const ecs = mach.ecs;
 
-pub const module = ecs.Module(.{
-    .components = .{
-        .location = Vec2,
-        .rotation = Vec2,
-        .velocity = Vec2,
-    },
-});
+pub const module = Module(.physics2d);
+
+pub fn Module(namespace: anytype) type {
+    _ = namespace;
+    return ecs.Module(.{
+        .components = .{
+            .location = Vec2,
+            .rotation = Vec2,
+            .velocity = Vec2,
+        },
+        // TODO: there would be systems that we register here. Functions that iterate over entities
+        // with physics2d components like `.velocity` and calculate physics updates for them!
+    });
+}
 
 pub const Vec2 = struct { x: f32, y: f32 };

--- a/examples/ecs-app/physics2d.zig
+++ b/examples/ecs-app/physics2d.zig
@@ -1,19 +1,14 @@
 const mach = @import("mach");
 const ecs = mach.ecs;
 
-pub const module = Module(.physics2d);
-
-pub fn Module(namespace: anytype) type {
-    _ = namespace;
-    return ecs.Module(.{
-        .components = .{
-            .location = Vec2,
-            .rotation = Vec2,
-            .velocity = Vec2,
-        },
-        // TODO: there would be systems that we register here. Functions that iterate over entities
-        // with physics2d components like `.velocity` and calculate physics updates for them!
-    });
-}
+pub const module = ecs.Module(.{
+    .components = .{
+        .location = Vec2,
+        .rotation = Vec2,
+        .velocity = Vec2,
+    },
+    // TODO: there would be systems that we register here. Functions that iterate over entities
+    // with physics2d components like `.velocity` and calculate physics updates for them!
+});
 
 pub const Vec2 = struct { x: f32, y: f32 };

--- a/examples/ecs-app/physics2d.zig
+++ b/examples/ecs-app/physics2d.zig
@@ -1,5 +1,10 @@
 const mach = @import("mach");
 const ecs = mach.ecs;
+const std = @import("std");
+
+pub const Message = ecs.Messages(.{
+    .tick = void,
+});
 
 pub const module = ecs.Module(.{
     .components = .{
@@ -7,19 +12,15 @@ pub const module = ecs.Module(.{
         .rotation = Vec2,
         .velocity = Vec2,
     },
-    // TODO: there would be systems that we register here. Functions that iterate over entities
-    // with physics2d components like `.velocity` and calculate physics updates for them!
+    .messages = Message,
     .system = system,
 });
 
 pub const Vec2 = struct { x: f32, y: f32 };
 
-// TODO: there is a real problem here, we cannot access `modules`: dependency loop.
-// modules -> physics2d.module -> system -> modules
-fn system(engine: *ecs.World(modules)) !void {
-    _ = engine;
-
-    // A real system would query the ECS for entities with components. This is just an example.
-    const player = try engine.entities.new();
-    try engine.entities.setComponent(player, .physics2d, .location, .{ .x = 0, .y = 0 });
+fn system(msg: Message) !void {
+    switch (msg) {
+        // TODO: implement queries, ability to set components, etc.
+        .tick => std.debug.print("\nphysics tick!\n", .{}),
+    }
 }

--- a/examples/ecs-app/renderer.zig
+++ b/examples/ecs-app/renderer.zig
@@ -1,11 +1,29 @@
 const mach = @import("mach");
 const ecs = mach.ecs;
 
-pub const module = ecs.Module(.{
-    .components = .{
-        .location = Vec3,
-        .rotation = Vec3,
-    },
-});
+pub const module = Module(.renderer);
+
+pub fn Module(namespace: anytype) type {
+    _ = namespace;
+    return ecs.Module(.{
+        .components = .{
+            .location = Vec3,
+            .rotation = Vec3,
+        },
+        // TODO: there would be systems that we register here. Functions that iterate over entities
+        // with renderer components like `.geometry` and render them for example!
+        //
+        // When calling ECS APIs, we would write this:
+        //
+        // .getComponent(namespace, .geometry);
+        //
+        // Not this:
+        //
+        // .getComponent(.renderer, .geometry);
+        //
+        // So as to be namespace-agonistic, letting the consumer of our module change the namespace
+        // name where we access our components if needed.
+    });
+}
 
 pub const Vec3 = struct { x: f32, y: f32, z: f32 };

--- a/examples/ecs-app/renderer.zig
+++ b/examples/ecs-app/renderer.zig
@@ -1,29 +1,13 @@
 const mach = @import("mach");
 const ecs = mach.ecs;
 
-pub const module = Module(.renderer);
-
-pub fn Module(namespace: anytype) type {
-    _ = namespace;
-    return ecs.Module(.{
-        .components = .{
-            .location = Vec3,
-            .rotation = Vec3,
-        },
-        // TODO: there would be systems that we register here. Functions that iterate over entities
-        // with renderer components like `.geometry` and render them for example!
-        //
-        // When calling ECS APIs, we would write this:
-        //
-        // .getComponent(namespace, .geometry);
-        //
-        // Not this:
-        //
-        // .getComponent(.renderer, .geometry);
-        //
-        // So as to be namespace-agonistic, letting the consumer of our module change the namespace
-        // name where we access our components if needed.
-    });
-}
+pub const module = ecs.Module(.{
+    .components = .{
+        .location = Vec3,
+        .rotation = Vec3,
+    },
+    // TODO: there would be systems that we register here. Functions that iterate over entities
+    // with renderer components like `.geometry` and render them for example!
+});
 
 pub const Vec3 = struct { x: f32, y: f32, z: f32 };

--- a/examples/ecs-app/renderer.zig
+++ b/examples/ecs-app/renderer.zig
@@ -1,0 +1,11 @@
+const mach = @import("mach");
+const ecs = mach.ecs;
+
+pub const module = ecs.Module(.{
+    .components = .{
+        .location = Vec3,
+        .rotation = Vec3,
+    },
+});
+
+pub const Vec3 = struct { x: f32, y: f32, z: f32 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,38 +6,42 @@ pub const ResourceManager = @import("resource/ResourceManager.zig");
 pub const gpu = @import("gpu");
 pub const ecs = @import("ecs");
 
+// TODO: rename Engine -> Core
+
+/// The core module of Mach engine. This enables access to *Core APIs, such as
+/// to `.setOptions(.{.title = "foobar"})`, or to access the GPU `.device`.
+pub const module = ecs.Singleton(*Engine);
+
 pub fn App(
-    all_components: anytype,
-    init: fn(
-        engine: *Engine,
-        world: *ecs.World(all_components),
-    ) error{OutOfMemory}!void,
+    modules: anytype,
+    init: anytype, // fn (engine: *ecs.World(modules)) !void
 ) type {
     return struct {
-        world: ecs.World(all_components),
+        engine: ecs.World(modules),
 
-        pub fn init(app: *@This(), engine: *Engine) !void {
+        pub fn init(app: *@This(), core: *Engine) !void {
             app.* = .{
-                .world = try ecs.World(all_components).init(engine.allocator),
+                .engine = try ecs.World(modules).init(core.allocator),
             };
-            try init(engine, &app.world);
+            app.*.engine.singletons.core = core;
+            try init(&app.engine);
         }
-        
-        pub fn deinit(app: *@This(), engine: *Engine) void {
+
+        pub fn deinit(app: *@This(), core: *Engine) void {
             _ = app;
-            _ = engine;
+            _ = core;
             // TODO
         }
-        
-        pub fn update(app: *@This(), engine: *Engine) !void {
+
+        pub fn update(app: *@This(), core: *Engine) !void {
             _ = app;
-            _ = engine;
+            _ = core;
             // TODO
         }
-        
-        pub fn resize(app: *@This(), engine: *Engine, width: u32, height: u32) !void {
+
+        pub fn resize(app: *@This(), core: *Engine, width: u32, height: u32) !void {
             _ = app;
-            _ = engine;
+            _ = core;
             _ = width;
             _ = height;
             // TODO

--- a/src/main.zig
+++ b/src/main.zig
@@ -24,6 +24,11 @@ pub fn App(
 ) type {
     // TODO: validate modules.mach is the expected type.
     // TODO: validate init has the right function signature
+
+    // Other modules would always allow the consumer to specify the selector, so they can rename the
+    // module in the global namespace. The mach.module is special, though, its name is reserved.
+    const selector = .mach;
+
     return struct {
         engine: ecs.World(modules),
 
@@ -31,8 +36,8 @@ pub fn App(
             app.* = .{
                 .engine = try ecs.World(modules).init(core.allocator),
             };
-            app.*.engine.globals.mach.core = core;
-            app.*.engine.globals.mach.device = core.device;
+            app.*.engine.set(selector, .core, core);
+            app.*.engine.set(selector, .device, core.device);
             try init(&app.engine);
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,9 +42,8 @@ pub fn App(
         }
 
         pub fn deinit(app: *@This(), core: *Engine) void {
-            _ = app;
+            app.engine.deinit();
             _ = core;
-            // TODO
         }
 
         pub fn update(app: *@This(), core: *Engine) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -6,14 +6,12 @@ pub const ResourceManager = @import("resource/ResourceManager.zig");
 pub const gpu = @import("gpu");
 pub const ecs = @import("ecs");
 
-// TODO: rename Engine -> Core
-
 /// The Mach engine ECS module. This enables access to `engine.get(.mach, .core)` `*Core` APIs, as
 /// to for example `.setOptions(.{.title = "foobar"})`, or to access the GPU device via
 /// `engine.get(.mach, .device)`
 pub const module = ecs.Module(.{
     .globals = struct {
-        core: *Engine,
+        core: *Core,
         device: gpu.Device,
     },
 });
@@ -32,7 +30,7 @@ pub fn App(
     return struct {
         engine: ecs.World(modules),
 
-        pub fn init(app: *@This(), core: *Engine) !void {
+        pub fn init(app: *@This(), core: *Core) !void {
             app.* = .{
                 .engine = try ecs.World(modules).init(core.allocator),
             };
@@ -41,18 +39,18 @@ pub fn App(
             try init(&app.engine);
         }
 
-        pub fn deinit(app: *@This(), core: *Engine) void {
+        pub fn deinit(app: *@This(), core: *Core) void {
             app.engine.deinit();
             _ = core;
         }
 
-        pub fn update(app: *@This(), core: *Engine) !void {
+        pub fn update(app: *@This(), core: *Core) !void {
             _ = app;
             _ = core;
             // TODO
         }
 
-        pub fn resize(app: *@This(), core: *Engine, width: u32, height: u32) !void {
+        pub fn resize(app: *@This(), core: *Core, width: u32, height: u32) !void {
             _ = app;
             _ = core;
             _ = width;

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,10 +8,11 @@ pub const ecs = @import("ecs");
 
 // TODO: rename Engine -> Core
 
-/// The core module of Mach engine. This enables access to *Core APIs, such as
-/// to `.setOptions(.{.title = "foobar"})`, or to access the GPU `.device`.
+/// The Mach engine ECS module. This enables access to `engine.get(.mach, .core)` `*Core` APIs, as
+/// to for example `.setOptions(.{.title = "foobar"})`, or to access the GPU device via
+/// `engine.get(.mach, .device)`
 pub const module = ecs.Module(.{
-    .absolute_globals = struct{
+    .globals = struct {
         core: *Engine,
         device: gpu.Device,
     },
@@ -21,6 +22,8 @@ pub fn App(
     modules: anytype,
     init: anytype, // fn (engine: *ecs.World(modules)) !void
 ) type {
+    // TODO: validate modules.mach is the expected type.
+    // TODO: validate init has the right function signature
     return struct {
         engine: ecs.World(modules),
 
@@ -28,8 +31,8 @@ pub fn App(
             app.* = .{
                 .engine = try ecs.World(modules).init(core.allocator),
             };
-            app.*.engine.globals.core = core;
-            app.*.engine.globals.device = core.device;
+            app.*.engine.globals.mach.core = core;
+            app.*.engine.globals.mach.device = core.device;
             try init(&app.engine);
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,3 +3,44 @@ pub usingnamespace @import("enums.zig");
 pub const Core = @import("Core.zig");
 pub const Timer = @import("Timer.zig");
 pub const ResourceManager = @import("resource/ResourceManager.zig");
+pub const gpu = @import("gpu");
+pub const ecs = @import("ecs");
+
+pub fn App(
+    all_components: anytype,
+    init: fn(
+        engine: *Engine,
+        world: *ecs.World(all_components),
+    ) error{OutOfMemory}!void,
+) type {
+    return struct {
+        world: ecs.World(all_components),
+
+        pub fn init(app: *@This(), engine: *Engine) !void {
+            app.* = .{
+                .world = try ecs.World(all_components).init(engine.allocator),
+            };
+            try init(engine, &app.world);
+        }
+        
+        pub fn deinit(app: *@This(), engine: *Engine) void {
+            _ = app;
+            _ = engine;
+            // TODO
+        }
+        
+        pub fn update(app: *@This(), engine: *Engine) !void {
+            _ = app;
+            _ = engine;
+            // TODO
+        }
+        
+        pub fn resize(app: *@This(), engine: *Engine, width: u32, height: u32) !void {
+            _ = app;
+            _ = engine;
+            _ = width;
+            _ = height;
+            // TODO
+        }
+    };
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,7 +10,12 @@ pub const ecs = @import("ecs");
 
 /// The core module of Mach engine. This enables access to *Core APIs, such as
 /// to `.setOptions(.{.title = "foobar"})`, or to access the GPU `.device`.
-pub const module = ecs.Singleton(*Engine);
+pub const module = ecs.Module(.{
+    .absolute_globals = struct{
+        core: *Engine,
+        device: gpu.Device,
+    },
+});
 
 pub fn App(
     modules: anytype,
@@ -23,7 +28,8 @@ pub fn App(
             app.* = .{
                 .engine = try ecs.World(modules).init(core.allocator),
             };
-            app.*.engine.singletons.core = core;
+            app.*.engine.globals.core = core;
+            app.*.engine.globals.device = core.device;
             try init(&app.engine);
         }
 


### PR DESCRIPTION
# Context

I've been thinking non-stop about, and exploring, a lot of overlapping questions:

* What does integrating `mach/ecs` into the higher-level `mach/src/` API look like?
* What should a 'typical' Mach application look like? We had [this discussion](https://github.com/hexops/mach/issues/309) but the ECS integration side was largely "we'll figure it out"
* How do we handle type-safety in our ECS? At runtime? At comptime?
* How do we handle namespacing in our ECS? e.g. if `renderer` and `physics2d` modules both want to provide a "location" component of a different type (`vec3` vs `vec2`) - how do we handle that? Is there a convention of prefixing component names like "renderer.vec3", or do we do something else?
* And more: What does order-of-execution for ECS systems look like? How can ECS modules talk to eachother to signal events? Where do we store globals/singletons? Where do end-user applications store their own state? How do we handle serialization?

# Painting the whole picture (or at least 60% of it)

The thing that hit me like an overwhelming bag of bricks is that there are just _so many different ways_ we can tackle these problems. Like, literally, hundreds if not thousands of combinations. And each choice has far-reaching implications for other parts of the system. If we don't consider them in total, all combined together, we're not seeing the whole picture we're painting.

Two good examples of this:

1. In https://github.com/hexops/mach/issues/309#issuecomment-1140479760 we agreed upon a high-level application API, but in doing so we didn't realize at the time that our choice of API would actually prevent **anyone** (not just us) from passing a comptime parameter to their code through the ECS without type-erasure. There's not a place in the type system of that example that one *could* pass a comptime parameter to say their own ECS module. We only noticed this because it later came to light that we couldn't pass comptime parameters to `ecs.Entities(T)` if we were to try and tackle type-safety that way.
2. If we tackle type-safety in the ECS as runtime-type-safety, you can add whatever component type at any point in time, then we introduce a serialization problem: we would know say the type ID of a component, but we wouldn't have a way to say call a method on that type to serialize it. We could require components register a `fn serialize(component: *anyopaque, writer: anytype) !void` function - but do we want that?

# This PR

This is an exploratory PR, if we're happy with how this looks/feels generally, then I'll work on sending separate smaller/cleaner PRs to land this same idea into `main`. It's not 100% thought out, and so it wouldn't be merged directly.

This PR takes several ideas from everyone I've talked to: Levy, MasterQ32, Ayush, Ali, Zargio, and more into account.

## A standard high-level Mach application

Now looks like this:

```zig
const std = @import("std");
const mach = @import("mach");
const gpu = mach.gpu;
const ecs = mach.ecs;

const renderer = @import("renderer.zig");
const physics2d = @import("physics2d.zig");

const modules = ecs.Modules(.{
    .mach = mach.module,
    .renderer = renderer.module,
    .physics2d = physics2d.module,
});

pub const App = mach.App(modules, init);

pub fn init(engine: *ecs.World(modules)) !void {
    const core = engine.get(.mach, .core);
    try core.setOptions(.{ .title = "Hello, ECS!" });

    const device = engine.get(.mach, .device);
    _ = device; // use the GPU device ...

    const player = try engine.entities.new();
    try engine.entities.setComponent(player, .renderer, .location, .{.x = 0, .y = 0, .z = 0});
    try engine.entities.setComponent(player, .physics2d, .location, .{.x = 0, .y = 0});
    _ = player;
}
```

Where `physics2d.module` looks like this:

```zig
pub const module = Module(.physics2d);

pub fn Module(namespace: anytype) type {
    _ = namespace;
    return ecs.Module(.{
        .components = .{
            .location = Vec2,
            .rotation = Vec2,
            .velocity = Vec2,
        },
        // ...systems/state/etc...
    });
}

pub const Vec2 = struct { x: f32, y: f32 };
```

## First impressions

The first thing you'll notice is that:

1. We declare `modules` up-front, at compile-time. You'll have to write out all of the modules you intend to use in your application, and each module has to write out all of the ECS components it intends to use.
2. We've brought back the semi-magical `pub const App = mach.App(modules, init);`, more on this below.
3. Components live in a namespace, API calls like `.setComponent(player, .renderer, .location, .{.x = 0, .y = 0, .z = 0})` find a component called `.location` in the `.renderer` module and set that component on the entity.
4. The ECS is fully type-safe: based on the `.renderer, .location` parameters it knows the exact type the component must be at comptime. Similarly, `.getComponent(player, .renderer, .location)` returns the concrete type.

I highly encourage reading the [examples/ecs-app](https://github.com/hexops/mach/pull/349/files#diff-d09c4186fcdaeeefd52c5637846f6a0b033c391c0d954d737c0c3cb1d4a6e0ea) source as it explains in greater detail some other concepts like namespacing of modules.

## The type-safety/explicitness vs. flexibility tradeoff

There is a very real tradeoff here around type-safety: requiring modules to be declared up-front, requiring components you might use to be enumerated by modules, etc. can be tedious, it adds some real overhead.

For example, modules must live in a namespace. And if two modules have the same namespace, we need to let the consumer of them rename them. This is fine, it's just a comptime parameter `namespace: anytype` but it means all of your module code that intends to work with the ECS needs to have that `namespace: anytype` parameter so it can pass it to `.setComponent`, `.getComponent`, etc.:

```zig
pub const module = Module(.physics2d); // The default namespace for this module

// Lets you rename the module.
pub fn Module(namespace: anytype) type {
    //
    _ = namespace;
    return ecs.Module(.{
        .components = .{
            .location = Vec2,
            .rotation = Vec2,
            .velocity = Vec2,
        },
        // A system function which iterates entities with physics here would need to use e.g.
        // `.getComponent(entity, namespace, .velocity)` and not
        // `.getComponent(entity, .physics2d, .velocity)` so the user can rename it.
        // ...systems/state/etc...
    });
}

pub const Vec2 = struct { x: f32, y: f32 };
```

All of this adds a real level of mental overhead for the programmer. It will be stuff to learn, and will make writing a Mach application out-of-the-box harder. Is it worth it?

Initially, my impression was no. I actually set out to create this PR as evidence and proof that it is **not worth it** for when anyone complains in the future. But, after implementing and reflecting on all aspects it actually seems quite nice.

It's possible I change my mind again later, but it seems fair to go with the most restrictive approach first (you have to define all modules/components globally), try and push that as far as we can and make it as nice an API as we can, and go to a less restrictive one later if we truly need to.

## Unimplemented aspects

Not implemented in this PR is a few important things:

#### Initialization

Module initialization is something I haven't implemented yet. This would be easy to handle, though, because we have all the type information. For example, we could call an `init` function defined in the module and require it return a valid type to us.

#### Systems

* How ECS systems get defined in a module (it would just be a function basically, so pretty much a solved problem)
* System state: the idea here is that when an ECS system function is called, it gets a pointer to it's own state struct where it can store information over time if it desires. This is a get-out-of-jail-free card, where if you don't care about ECS much and just want local variables you can shove them in here.

#### Order of system execution, multi-threading, communication

None of these are solved problems, but I have some ideas I plan to explore. The fact of this PR having us declare modules at comptime globally gives us the widest range of possibilities here in general. What I will explore is mapping the Elm data model (which I recently learned was used in the PSVR Dreams game, apparently?!) into ECS a bit.

#### Serialization

We have full type information with this approach, and so we could serialize ECS components as we see fit using that information. How exactly we do that is not settled, but I am [leaning towards a custom binary format](https://twitter.com/slimsag/status/1532049174643953666). The important part here is how this interacts with the future editor, which one can imagine talking to your game over a socket as it runs. In this scenario, the editor and the game need to speak the same serialization format in order for the editor to instruct the game to e.g. change a components value.

# Other learning: high-level vs low-level apps

This might at first appear to be a thing I am going back on after our discussion in https://github.com/hexops/mach/issues/309#issuecomment-1140479760:

```zig
pub const App = mach.App(modules, init);
```

It's important to note that this is **just** "mach uses the low-level API to provide the high-level API". The only change from our agreed upon API earlier is that there is no special 'high level' API:

* I think this makes a *ton* of sense in fact, the more I thought about it the weirder it seemed: Mach would have a special-cased "high level" API, but if you don't want to use that (our ECS) then you would have no choice but to use the "uglier" low-level API and require all of your users make use of that too. (for example, if someone uses the low-level mach API to create a UI application framework of their own on top of WebGPU.)
* By doing this, we're just saying "Mach's high-level API is just a struct which implements that low-level API, you provide an init function that interacts with the ECS only and we provide the `update`, `deinit`, etc. low-level functions."

Additionally, there is no "I forgot `pub`" issue either like before, because we can always assert that `App` is defined - which we were already going to require in low-level applications.

In short, I think it'll be a "eh that's a little weird, but OK" by anyone initially looking at it. But "with this you get android/ios/webassembly" seems a reasonable answer to a one-line oddity.

# Thoughts?

I'd love to hear them. Overall I'm convinced this is the right path forward, at least as an idea to try out for now, but if others object heavily I might reconsider.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.