### PR TITLE
glfw: submodule path fix for subrepo

### DIFF
--- a/glfw/.gitmodules
+++ b/glfw/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "glfw/upstream"]
-	path = glfw/upstream
+[submodule "upstream"]
+	path = upstream
 	url = https://github.com/hexops/glfw
 


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

I've been using the mach-glfw sub(cloned)-repo and the recent submodule path change from https://github.com/hexops/mach/pull/346 doesn't match up with what mach-glfw expects as a standalone repo. This should be reproducible with the example vulkan triangle repo: https://github.com/hexops/mach-glfw-vulkan-example.

