### PR TITLE
Use `log_level` and `scope_levels` pub decls from App

### DIFF
--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -8,6 +8,9 @@ const enums = @import("../enums.zig");
 const util = @import("util.zig");
 const c = @import("c.zig").c;
 
+pub const scope_levels = if (@hasDecl(App, "scope_levels")) App.scope_levels else [0]std.log.ScopeLevel{};
+pub const log_level = if (@hasDecl(App, "log_level")) App.log_level else std.log.default_level;
+
 pub const Platform = struct {
     window: glfw.Window,
     backend_type: gpu.Adapter.BackendType,

--- a/src/platform/wasm.zig
+++ b/src/platform/wasm.zig
@@ -231,7 +231,8 @@ export fn wasmDeinit() void {
     app.deinit(&engine);
 }
 
-pub const log_level = .info;
+pub const log_level = if (@hasDecl(App, "log_level")) App.log_level else .info;
+pub const scope_levels = if (@hasDecl(App, "scope_levels")) App.scope_levels else [0]std.log.ScopeLevel{};
 
 const LogError = error{};
 const LogWriter = std.io.Writer(void, LogError, writeLog);


### PR DESCRIPTION
This PR makes `src/platform/native.zig` re-export logging declarations from the `"app"` package. As mentioned in #360, these are the magical declarations `std` uses that I think should clearly be re-exported.

I'm not sure at the moment to handle a custom `log` function for wasm as I haven't used it, so this PR only deals with the native target.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.