### PR TITLE
Fixed segfault in `getPhysicalDevicePresentationSupport`

### DIFF
--- a/glfw/src/vulkan.zig
+++ b/glfw/src/vulkan.zig
@@ -176,7 +176,7 @@ pub inline fn getPhysicalDevicePresentationSupport(
     internal_debug.assertInitialized();
     const v = c.glfwGetPhysicalDevicePresentationSupport(
         @ptrCast(c.VkInstance, vk_instance),
-        @ptrCast(*c.VkPhysicalDevice, @alignCast(@alignOf(*c.VkPhysicalDevice), vk_physical_device)).*,
+        @ptrCast(c.VkPhysicalDevice, vk_physical_device),
         queue_family,
     );
     getError() catch |err| return switch (err) {


### PR DESCRIPTION
Fixed an issue in the GLFW bindings where `getPhysicalDevicePresentationSupport` in `vulkan.zig` would segfault due to dereferencing an opaque handle. Note that I'm using https://github.com/Snektron/vulkan-zig. It might be better to use anytype and check if it's an enum or not like done in `createWindowSurface`:
https://github.com/hexops/mach/blob/fa5afee5bce4be815d7a69926bcdec54d26a4889/glfw/src/vulkan.zig#L246-L251

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.