### PR TITLE
Store pointer to WorkDoneCallback in gpu.Queue

### DIFF
--- a/gpu/src/NativeInstance.zig
+++ b/gpu/src/NativeInstance.zig
@@ -902,7 +902,7 @@ const queue_vtable = Queue.VTable{
                     wgpu_queue,
                     signal_value,
                     cCallback,
-                    &queue.on_submitted_work_done,
+                    queue.on_submitted_work_done,
                 );
             }
 

--- a/gpu/src/Queue.zig
+++ b/gpu/src/Queue.zig
@@ -8,7 +8,10 @@ const Texture = @import("Texture.zig");
 
 const Queue = @This();
 
-on_submitted_work_done: ?WorkDoneCallback = null,
+/// Callback to executed when all work has been done
+/// This field must be set before calling `submit()` on the commands the callback waits for.
+/// Note that the address stored must be valid when the callback is executed.
+on_submitted_work_done: ?*WorkDoneCallback = null,
 
 /// The type erased pointer to the Queue implementation
 /// Equal to c.WGPUQueue for NativeInstance.


### PR DESCRIPTION
This change removes a footgun where the queue used to submit with a callback must be valid when the callback is run.  This change makes it clear (hopefully) to the user that the queue does not need to be valid, only the `WorkDoneCallback` does, when the callback gets run.

Helps hexops/mach#183

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.