### PR TITLE
mach: Use math.inf instead of math.floatMax for indefinite wait of events

### DIFF
--- a/src/Engine.zig
+++ b/src/Engine.zig
@@ -62,7 +62,7 @@ pub fn setShouldClose(engine: *Engine, value: bool) void {
 // again.
 //
 // timeout is in seconds (<= 0.0 disables waiting)
-// - pass std.math.floatMax(f64) to wait with no timeout
+// - pass std.math.inf(f64) to wait with no timeout
 //
 // update() can be called earlier than timeout if an event happens (key press,
 // mouse motion, etc.)

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -556,16 +556,15 @@ pub fn main() !void {
     const window = engine.internal.window;
     while (!window.shouldClose()) {
         if (engine.internal.wait_event_timeout > 0.0) {
-            // wait for an event
-            if (engine.internal.wait_event_timeout == std.math.floatMax(f64)) {
-                // no timeout
+            if (engine.internal.wait_event_timeout == std.math.inf(f64)) {
+                // Wait for an event
                 try glfw.waitEvents();
             } else {
-                // with a timeout
+                // Wait for an event with a timeout
                 try glfw.waitEventsTimeout(engine.internal.wait_event_timeout);
             }
         } else {
-            // don't wait
+            // Don't wait for events
             try glfw.pollEvents();
         }
 


### PR DESCRIPTION
Fixes #367 

This only makes changes to native because wasm doen't need any changes here.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.