### PR TITLE
{ecs,mach}: fix some memory issues

### DIFF
--- a/ecs/src/entities.zig
+++ b/ecs/src/entities.zig
@@ -166,6 +166,9 @@ pub const ArchetypeStorage = struct {
             offset += new_capacity * column.size;
         }
 
+        if (storage.capacity > 0) {
+            gpa.free(storage.block);
+        }
         storage.block = new_block;
         storage.capacity = @intCast(u32, new_capacity);
     }

--- a/ecs/src/entities.zig
+++ b/ecs/src/entities.zig
@@ -572,9 +572,11 @@ pub const Entities = struct {
         // Update the storage/column for the new component.
         current_archetype_storage.set(entities.allocator, new_row, name, component);
 
-        var swapped_entity_id = archetype.get(entities.allocator, old_ptr.row_index, "id", EntityID).?;
         archetype.remove(old_ptr.row_index);
+        const swapped_entity_id = archetype.get(entities.allocator, old_ptr.row_index, "id", EntityID).?;
         // TODO: try is wrong here and below?
+        // if we removed the last entry from archetype, then swapped_entity_id == entity
+        // so the second entities.put will clobber this one
         try entities.entities.put(entities.allocator, swapped_entity_id, old_ptr);
 
         try entities.entities.put(entities.allocator, entity, Pointer{
@@ -666,9 +668,11 @@ pub const Entities = struct {
             }
         }
 
-        var swapped_entity_id = archetype.get(entities.allocator, old_ptr.row_index, "id", EntityID).?;
         archetype.remove(old_ptr.row_index);
+        const swapped_entity_id = archetype.get(entities.allocator, old_ptr.row_index, "id", EntityID).?;
         // TODO: try is wrong here and below?
+        // if we removed the last entry from archetype, then swapped_entity_id == entity
+        // so the second entities.put will clobber this one
         try entities.entities.put(entities.allocator, swapped_entity_id, old_ptr);
 
         try entities.entities.put(entities.allocator, entity, Pointer{

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -541,6 +541,7 @@ comptime {
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     var engine = try Engine.init(allocator);


### PR DESCRIPTION
The `swapped_entity_id` was getting the id of the row _before_ the swap remove. This meant the position of the swapped entity was not updated in the `EntityID` -> `Pointer` hash map.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.