### PR TITLE
The great rename: Engine->Core

### DIFF
--- a/examples/boids/main.zig
+++ b/examples/boids/main.zig
@@ -26,13 +26,13 @@ var sim_params = [_]f32{
     0.005, // .rule_3_scale
 };
 
-pub fn init(app: *App, engine: *mach.Engine) !void {
-    const sprite_shader_module = engine.device.createShaderModule(&.{
+pub fn init(app: *App, core: *mach.Core) !void {
+    const sprite_shader_module = core.device.createShaderModule(&.{
         .label = "sprite shader module",
         .code = .{ .wgsl = @embedFile("sprite.wgsl") },
     });
 
-    const update_sprite_shader_module = engine.device.createShaderModule(&.{
+    const update_sprite_shader_module = core.device.createShaderModule(&.{
         .label = "update sprite shader module",
         .code = .{ .wgsl = @embedFile("updateSprites.wgsl") },
     });
@@ -61,7 +61,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     };
 
-    const render_pipeline = engine.device.createRenderPipeline(&gpu.RenderPipeline.Descriptor{
+    const render_pipeline = core.device.createRenderPipeline(&gpu.RenderPipeline.Descriptor{
         .vertex = .{
             .module = sprite_shader_module,
             .entry_point = "vert_main",
@@ -84,12 +84,12 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
         .fragment = &gpu.FragmentState{ .module = sprite_shader_module, .entry_point = "frag_main", .targets = &[_]gpu.ColorTargetState{
             .{
-                .format = engine.swap_chain_format,
+                .format = core.swap_chain_format,
             },
         } },
     });
 
-    const compute_pipeline = engine.device.createComputePipeline(&gpu.ComputePipeline.Descriptor{ .compute = gpu.ProgrammableStageDescriptor{
+    const compute_pipeline = core.device.createComputePipeline(&gpu.ComputePipeline.Descriptor{ .compute = gpu.ProgrammableStageDescriptor{
         .module = update_sprite_shader_module,
         .entry_point = "main",
     } });
@@ -99,17 +99,17 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         -0.02, 0.0,   0.02,
     };
 
-    const sprite_vertex_buffer = engine.device.createBuffer(&gpu.Buffer.Descriptor{
+    const sprite_vertex_buffer = core.device.createBuffer(&gpu.Buffer.Descriptor{
         .usage = .{ .vertex = true, .copy_dst = true },
         .size = vert_buffer_data.len * @sizeOf(f32),
     });
-    engine.device.getQueue().writeBuffer(sprite_vertex_buffer, 0, f32, &vert_buffer_data);
+    core.device.getQueue().writeBuffer(sprite_vertex_buffer, 0, f32, &vert_buffer_data);
 
-    const sim_param_buffer = engine.device.createBuffer(&gpu.Buffer.Descriptor{
+    const sim_param_buffer = core.device.createBuffer(&gpu.Buffer.Descriptor{
         .usage = .{ .uniform = true, .copy_dst = true },
         .size = sim_params.len * @sizeOf(f32),
     });
-    engine.device.getQueue().writeBuffer(sim_param_buffer, 0, f32, &sim_params);
+    core.device.getQueue().writeBuffer(sim_param_buffer, 0, f32, &sim_params);
 
     var initial_particle_data: [num_particle * 4]f32 = undefined;
     var rng = std.rand.DefaultPrng.init(0);
@@ -126,7 +126,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     var particle_bind_groups: [2]gpu.BindGroup = undefined;
     i = 0;
     while (i < 2) : (i += 1) {
-        particle_buffers[i] = engine.device.createBuffer(&gpu.Buffer.Descriptor{
+        particle_buffers[i] = core.device.createBuffer(&gpu.Buffer.Descriptor{
             .usage = .{
                 .vertex = true,
                 .copy_dst = true,
@@ -134,12 +134,12 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
             },
             .size = initial_particle_data.len * @sizeOf(f32),
         });
-        engine.device.getQueue().writeBuffer(particle_buffers[i], 0, f32, &initial_particle_data);
+        core.device.getQueue().writeBuffer(particle_buffers[i], 0, f32, &initial_particle_data);
     }
 
     i = 0;
     while (i < 2) : (i += 1) {
-        particle_bind_groups[i] = engine.device.createBindGroup(&gpu.BindGroup.Descriptor{ .layout = compute_pipeline.getBindGroupLayout(0), .entries = &[_]gpu.BindGroup.Entry{
+        particle_bind_groups[i] = core.device.createBindGroup(&gpu.BindGroup.Descriptor{ .layout = compute_pipeline.getBindGroupLayout(0), .entries = &[_]gpu.BindGroup.Entry{
             gpu.BindGroup.Entry.buffer(0, sim_param_buffer, 0, sim_params.len * @sizeOf(f32)),
             gpu.BindGroup.Entry.buffer(1, particle_buffers[i], 0, initial_particle_data.len * @sizeOf(f32)),
             gpu.BindGroup.Entry.buffer(2, particle_buffers[(i + 1) % 2], 0, initial_particle_data.len * @sizeOf(f32)),
@@ -155,10 +155,10 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     app.frame_counter = 0;
 }
 
-pub fn deinit(_: *App, _: *mach.Engine) void {}
+pub fn deinit(_: *App, _: *mach.Core) void {}
 
-pub fn update(app: *App, engine: *mach.Engine) !void {
-    const back_buffer_view = engine.swap_chain.?.getCurrentTextureView();
+pub fn update(app: *App, core: *mach.Core) !void {
+    const back_buffer_view = core.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,
         .resolve_target = null,
@@ -171,10 +171,10 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
         color_attachment,
     } };
 
-    sim_params[0] = @floatCast(f32, engine.delta_time);
-    engine.device.getQueue().writeBuffer(app.sim_param_buffer, 0, f32, &sim_params);
+    sim_params[0] = @floatCast(f32, core.delta_time);
+    core.device.getQueue().writeBuffer(app.sim_param_buffer, 0, f32, &sim_params);
 
-    const command_encoder = engine.device.createCommandEncoder(null);
+    const command_encoder = core.device.createCommandEncoder(null);
     {
         const pass_encoder = command_encoder.beginComputePass(null);
         pass_encoder.setPipeline(app.compute_pipeline);
@@ -200,9 +200,9 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
 
     var command = command_encoder.finish(null);
     command_encoder.release();
-    engine.device.getQueue().submit(&.{command});
+    core.device.getQueue().submit(&.{command});
     command.release();
 
-    engine.swap_chain.?.present();
+    core.swap_chain.?.present();
     back_buffer_view.release();
 }

--- a/examples/fractal-cube/main.zig
+++ b/examples/fractal-cube/main.zig
@@ -4,8 +4,8 @@
 //! We also need a second texture to use on the cube, that after the render pass
 //! needs to copy the other texture. We can't use the same texture since
 //! it would interfere with the sincronization on the gpu during the render pass.
-//! This demo currently does not work on opengl, because engine.current_desc.width/height,
-//! are set to 0 after engine.init() and because webgpu does not implement copyTextureToTexture,
+//! This demo currently does not work on opengl, because core.current_desc.width/height,
+//! are set to 0 after core.init() and because webgpu does not implement copyTextureToTexture,
 //! for opengl
 
 const std = @import("std");
@@ -38,14 +38,14 @@ cube_texture_view_render: gpu.TextureView,
 sampler: gpu.Sampler,
 bgl: gpu.BindGroupLayout,
 
-pub fn init(app: *App, engine: *mach.Engine) !void {
+pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();
 
-    try engine.setOptions(.{
+    try core.setOptions(.{
         .size_min = .{ .width = 20, .height = 20 },
     });
 
-    const vs_module = engine.device.createShaderModule(&.{
+    const vs_module = core.device.createShaderModule(&.{
         .label = "my vertex shader",
         .code = .{ .wgsl = @embedFile("vert.wgsl") },
     });
@@ -61,7 +61,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         .attributes = &vertex_attributes,
     };
 
-    const fs_module = engine.device.createShaderModule(&.{
+    const fs_module = core.device.createShaderModule(&.{
         .label = "my fragment shader",
         .code = .{ .wgsl = @embedFile("frag.wgsl") },
     });
@@ -79,7 +79,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     };
     const color_target = gpu.ColorTargetState{
-        .format = engine.swap_chain_format,
+        .format = core.swap_chain_format,
         .blend = &blend,
         .write_mask = gpu.ColorWriteMask.all,
     };
@@ -93,14 +93,14 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     const bgle_buffer = gpu.BindGroupLayout.Entry.buffer(0, .{ .vertex = true }, .uniform, true, 0);
     const bgle_sampler = gpu.BindGroupLayout.Entry.sampler(1, .{ .fragment = true }, .filtering);
     const bgle_textureview = gpu.BindGroupLayout.Entry.texture(2, .{ .fragment = true }, .float, .dimension_2d, false);
-    const bgl = engine.device.createBindGroupLayout(
+    const bgl = core.device.createBindGroupLayout(
         &gpu.BindGroupLayout.Descriptor{
             .entries = &.{ bgle_buffer, bgle_sampler, bgle_textureview },
         },
     );
 
     const bind_group_layouts = [_]gpu.BindGroupLayout{bgl};
-    const pipeline_layout = engine.device.createPipelineLayout(&.{
+    const pipeline_layout = core.device.createPipelineLayout(&.{
         .bind_group_layouts = &bind_group_layouts,
     });
 
@@ -130,7 +130,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     };
 
-    const vertex_buffer = engine.device.createBuffer(&.{
+    const vertex_buffer = core.device.createBuffer(&.{
         .usage = .{ .vertex = true },
         .size = @sizeOf(Vertex) * vertices.len,
         .mapped_at_creation = true,
@@ -139,44 +139,44 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     std.mem.copy(Vertex, vertex_mapped, vertices[0..]);
     vertex_buffer.unmap();
 
-    const uniform_buffer = engine.device.createBuffer(&.{
+    const uniform_buffer = core.device.createBuffer(&.{
         .usage = .{ .copy_dst = true, .uniform = true },
         .size = @sizeOf(UniformBufferObject),
         .mapped_at_creation = false,
     });
 
     // The texture to put on the cube
-    const cube_texture = engine.device.createTexture(&gpu.Texture.Descriptor{
+    const cube_texture = core.device.createTexture(&gpu.Texture.Descriptor{
         .usage = .{ .texture_binding = true, .copy_dst = true },
-        .size = .{ .width = engine.current_desc.width, .height = engine.current_desc.height },
-        .format = engine.swap_chain_format,
+        .size = .{ .width = core.current_desc.width, .height = core.current_desc.height },
+        .format = core.swap_chain_format,
     });
     // The texture on which we render
-    const cube_texture_render = engine.device.createTexture(&gpu.Texture.Descriptor{
+    const cube_texture_render = core.device.createTexture(&gpu.Texture.Descriptor{
         .usage = .{ .render_attachment = true, .copy_src = true },
-        .size = .{ .width = engine.current_desc.width, .height = engine.current_desc.height },
-        .format = engine.swap_chain_format,
+        .size = .{ .width = core.current_desc.width, .height = core.current_desc.height },
+        .format = core.swap_chain_format,
     });
 
-    const sampler = engine.device.createSampler(&gpu.Sampler.Descriptor{
+    const sampler = core.device.createSampler(&gpu.Sampler.Descriptor{
         .mag_filter = .linear,
         .min_filter = .linear,
     });
 
     const cube_texture_view = cube_texture.createView(&gpu.TextureView.Descriptor{
-        .format = engine.swap_chain_format,
+        .format = core.swap_chain_format,
         .dimension = .dimension_2d,
         .mip_level_count = 1,
         .array_layer_count = 1,
     });
     const cube_texture_view_render = cube_texture_render.createView(&gpu.TextureView.Descriptor{
-        .format = engine.swap_chain_format,
+        .format = core.swap_chain_format,
         .dimension = .dimension_2d,
         .mip_level_count = 1,
         .array_layer_count = 1,
     });
 
-    const bind_group = engine.device.createBindGroup(
+    const bind_group = core.device.createBindGroup(
         &gpu.BindGroup.Descriptor{
             .layout = bgl,
             .entries = &.{
@@ -187,8 +187,8 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     );
 
-    app.pipeline = engine.device.createRenderPipeline(&pipeline_descriptor);
-    app.queue = engine.device.getQueue();
+    app.pipeline = core.device.createRenderPipeline(&pipeline_descriptor);
+    app.queue = core.device.getQueue();
     app.vertex_buffer = vertex_buffer;
     app.uniform_buffer = uniform_buffer;
     app.bind_group = bind_group;
@@ -206,7 +206,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     pipeline_layout.release();
 }
 
-pub fn deinit(app: *App, _: *mach.Engine) void {
+pub fn deinit(app: *App, _: *mach.Core) void {
     app.bgl.release();
     app.vertex_buffer.release();
     app.uniform_buffer.release();
@@ -220,19 +220,19 @@ pub fn deinit(app: *App, _: *mach.Engine) void {
     app.depth_texture_view.release();
 }
 
-pub fn update(app: *App, engine: *mach.Engine) !void {
-    while (engine.pollEvent()) |event| {
+pub fn update(app: *App, core: *mach.Core) !void {
+    while (core.pollEvent()) |event| {
         switch (event) {
             .key_press => |ev| {
                 if (ev.key == .space)
-                    engine.setShouldClose(true);
+                    core.setShouldClose(true);
             },
             else => {},
         }
     }
 
     const cube_view = app.cube_texture_view_render;
-    const back_buffer_view = engine.swap_chain.?.getCurrentTextureView();
+    const back_buffer_view = core.swap_chain.?.getCurrentTextureView();
 
     const cube_color_attachment = gpu.RenderPassColorAttachment{
         .view = cube_view,
@@ -258,7 +258,7 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
         .stencil_store_op = .none,
     };
 
-    const encoder = engine.device.createCommandEncoder(null);
+    const encoder = core.device.createCommandEncoder(null);
     const cube_render_pass_info = gpu.RenderPassEncoder.Descriptor{
         .color_attachments = &.{cube_color_attachment},
         .depth_stencil_attachment = &depth_stencil_attachment,
@@ -278,7 +278,7 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
         );
         const proj = zm.perspectiveFovRh(
             (std.math.pi * 2.0 / 5.0),
-            @intToFloat(f32, engine.current_desc.width) / @intToFloat(f32, engine.current_desc.height),
+            @intToFloat(f32, core.current_desc.width) / @intToFloat(f32, core.current_desc.height),
             1,
             100,
         );
@@ -303,7 +303,7 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
         &gpu.ImageCopyTexture{
             .texture = app.cube_texture,
         },
-        &.{ .width = engine.current_desc.width, .height = engine.current_desc.height },
+        &.{ .width = core.current_desc.width, .height = core.current_desc.height },
     );
 
     const cube_pass = encoder.beginRenderPass(&cube_render_pass_info);
@@ -319,30 +319,30 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
 
     app.queue.submit(&.{command});
     command.release();
-    engine.swap_chain.?.present();
+    core.swap_chain.?.present();
     back_buffer_view.release();
 }
 
-pub fn resize(app: *App, engine: *mach.Engine, width: u32, height: u32) !void {
+pub fn resize(app: *App, core: *mach.Core, width: u32, height: u32) !void {
     if (app.depth_texture != null) {
         app.depth_texture.?.release();
-        app.depth_texture = engine.device.createTexture(&gpu.Texture.Descriptor{
+        app.depth_texture = core.device.createTexture(&gpu.Texture.Descriptor{
             .usage = .{ .render_attachment = true },
             .size = .{ .width = width, .height = height },
             .format = .depth24_plus,
         });
 
         app.cube_texture.release();
-        app.cube_texture = engine.device.createTexture(&gpu.Texture.Descriptor{
+        app.cube_texture = core.device.createTexture(&gpu.Texture.Descriptor{
             .usage = .{ .texture_binding = true, .copy_dst = true },
             .size = .{ .width = width, .height = height },
-            .format = engine.swap_chain_format,
+            .format = core.swap_chain_format,
         });
         app.cube_texture_render.release();
-        app.cube_texture_render = engine.device.createTexture(&gpu.Texture.Descriptor{
+        app.cube_texture_render = core.device.createTexture(&gpu.Texture.Descriptor{
             .usage = .{ .render_attachment = true, .copy_src = true },
             .size = .{ .width = width, .height = height },
-            .format = engine.swap_chain_format,
+            .format = core.swap_chain_format,
         });
 
         app.depth_texture_view.release();
@@ -355,21 +355,21 @@ pub fn resize(app: *App, engine: *mach.Engine, width: u32, height: u32) !void {
 
         app.cube_texture_view.release();
         app.cube_texture_view = app.cube_texture.createView(&gpu.TextureView.Descriptor{
-            .format = engine.swap_chain_format,
+            .format = core.swap_chain_format,
             .dimension = .dimension_2d,
             .mip_level_count = 1,
             .array_layer_count = 1,
         });
         app.cube_texture_view_render.release();
         app.cube_texture_view_render = app.cube_texture_render.createView(&gpu.TextureView.Descriptor{
-            .format = engine.swap_chain_format,
+            .format = core.swap_chain_format,
             .dimension = .dimension_2d,
             .mip_level_count = 1,
             .array_layer_count = 1,
         });
 
         app.bind_group.release();
-        app.bind_group = engine.device.createBindGroup(
+        app.bind_group = core.device.createBindGroup(
             &gpu.BindGroup.Descriptor{
                 .layout = app.bgl,
                 .entries = &.{
@@ -380,7 +380,7 @@ pub fn resize(app: *App, engine: *mach.Engine, width: u32, height: u32) !void {
             },
         );
     } else {
-        app.depth_texture = engine.device.createTexture(&gpu.Texture.Descriptor{
+        app.depth_texture = core.device.createTexture(&gpu.Texture.Descriptor{
             .usage = .{ .render_attachment = true },
             .size = .{ .width = width, .height = height },
             .format = .depth24_plus,

--- a/examples/gkurve/main.zig
+++ b/examples/gkurve/main.zig
@@ -31,21 +31,21 @@ update_frag_uniform_buffer: bool,
 bind_group: gpu.BindGroup,
 texture_atlas_data: AtlasRGB8,
 
-pub fn init(app: *App, engine: *mach.Engine) !void {
-    try engine.setOptions(.{
+pub fn init(app: *App, core: *mach.Core) !void {
+    try core.setOptions(.{
         .width = 640,
         .height = 480,
         .size_min = .{ .width = 20, .height = 20 },
     });
 
-    const queue = engine.device.getQueue();
+    const queue = core.device.getQueue();
 
     // TODO: Refactor texture atlas size number
-    app.texture_atlas_data = try AtlasRGB8.init(engine.allocator, 1280);
+    app.texture_atlas_data = try AtlasRGB8.init(core.allocator, 1280);
     const atlas_size = gpu.Extent3D{ .width = app.texture_atlas_data.size, .height = app.texture_atlas_data.size };
     const atlas_float_size = @intToFloat(f32, app.texture_atlas_data.size);
 
-    const texture = engine.device.createTexture(&.{
+    const texture = core.device.createTexture(&.{
         .size = atlas_size,
         .format = .rgba8_unorm,
         .usage = .{
@@ -59,35 +59,35 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         .rows_per_image = @intCast(u32, atlas_size.height),
     };
 
-    const img = try zigimg.Image.fromMemory(engine.allocator, @embedFile("../assets/gotta-go-fast.png"));
+    const img = try zigimg.Image.fromMemory(core.allocator, @embedFile("../assets/gotta-go-fast.png"));
     defer img.deinit();
 
-    const atlas_img_region = try app.texture_atlas_data.reserve(engine.allocator, @truncate(u32, img.width), @truncate(u32, img.height));
+    const atlas_img_region = try app.texture_atlas_data.reserve(core.allocator, @truncate(u32, img.width), @truncate(u32, img.height));
     const img_uv_data = atlas_img_region.getUVData(atlas_float_size);
 
     switch (img.pixels.?) {
         .Rgba32 => |pixels| app.texture_atlas_data.set(atlas_img_region, pixels),
         .Rgb24 => |pixels| {
-            const data = try rgb24ToRgba32(engine.allocator, pixels);
-            defer data.deinit(engine.allocator);
+            const data = try rgb24ToRgba32(core.allocator, pixels);
+            defer data.deinit(core.allocator);
             app.texture_atlas_data.set(atlas_img_region, data.Rgba32);
         },
         else => @panic("unsupported image color format"),
     }
 
     const white_tex_scale = 80;
-    var atlas_white_region = try app.texture_atlas_data.reserve(engine.allocator, white_tex_scale, white_tex_scale);
+    var atlas_white_region = try app.texture_atlas_data.reserve(core.allocator, white_tex_scale, white_tex_scale);
     atlas_white_region.x += 1;
     atlas_white_region.y += 1;
     atlas_white_region.width -= 2;
     atlas_white_region.height -= 2;
     const white_texture_uv_data = atlas_white_region.getUVData(atlas_float_size);
-    var white_tex_data = try engine.allocator.alloc(zigimg.color.Rgba32, white_tex_scale * white_tex_scale);
+    var white_tex_data = try core.allocator.alloc(zigimg.color.Rgba32, white_tex_scale * white_tex_scale);
     std.mem.set(zigimg.color.Rgba32, white_tex_data, zigimg.color.Rgba32.initRGB(0xff, 0xff, 0xff));
     app.texture_atlas_data.set(atlas_white_region, white_tex_data);
 
-    app.vertices = try std.ArrayList(draw.Vertex).initCapacity(engine.allocator, 9);
-    app.fragment_uniform_list = try std.ArrayList(draw.FragUniform).initCapacity(engine.allocator, 3);
+    app.vertices = try std.ArrayList(draw.Vertex).initCapacity(core.allocator, 9);
+    app.fragment_uniform_list = try std.ArrayList(draw.FragUniform).initCapacity(core.allocator, 3);
 
     // Quick test for using freetype
     const lib = try ft.Library.init();
@@ -95,13 +95,13 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
 
     const size_multiplier = 5;
     const character = "è";
-    var label = try Label.init(lib, "freetype/upstream/assets/FiraSans-Regular.ttf", 0, 110 * size_multiplier, engine.allocator);
+    var label = try Label.init(lib, "freetype/upstream/assets/FiraSans-Regular.ttf", 0, 110 * size_multiplier, core.allocator);
     defer label.deinit();
     // try label.print(app, "All your game's bases are belong to us èçòà", .{}, @Vector(2, f32){ 0, 420 }, @Vector(4, f32){ 1, 1, 1, 1 });
     try label.print(app, character, .{}, @Vector(2, f32){ 50 * size_multiplier, 40 }, @Vector(4, f32){ 1, 1, 1, 1 });
 
     var resizable_label: ResizableLabel = undefined;
-    try resizable_label.init(lib, "freetype/upstream/assets/FiraSans-Regular.ttf", 0, engine.allocator, white_texture_uv_data);
+    try resizable_label.init(lib, "freetype/upstream/assets/FiraSans-Regular.ttf", 0, core.allocator, white_texture_uv_data);
     defer resizable_label.deinit();
     try resizable_label.print(app, character, .{}, @Vector(4, f32){ 0, 40, 0, 0 }, @Vector(4, f32){ 1, 1, 1, 1 }, 80 * size_multiplier);
 
@@ -113,7 +113,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         app.texture_atlas_data.data,
     );
 
-    const wsize = engine.getWindowSize();
+    const wsize = core.getWindowSize();
     const window_width = @intToFloat(f32, wsize.width);
     const window_height = @intToFloat(f32, wsize.height);
     const triangle_scale = 250;
@@ -128,12 +128,12 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     // try draw.quad(app, .{ 0, 0 }, .{ 480, 480 }, .{}, .{ .bottom_left = .{ 0, 0 }, .width_and_height = .{ 1, 1 } });
     // try draw.circle(app, .{ window_width / 2, window_height / 2 }, window_height / 2 - 10, .{ 0, 0.5, 0.75, 1.0 }, white_texture_uv_data);
 
-    const vs_module = engine.device.createShaderModule(&.{
+    const vs_module = core.device.createShaderModule(&.{
         .label = "my vertex shader",
         .code = .{ .wgsl = @embedFile("vert.wgsl") },
     });
 
-    const fs_module = engine.device.createShaderModule(&.{
+    const fs_module = core.device.createShaderModule(&.{
         .label = "my fragment shader",
         .code = .{ .wgsl = @embedFile("frag.wgsl") },
     });
@@ -152,7 +152,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     };
 
     const color_target = gpu.ColorTargetState{
-        .format = engine.swap_chain_format,
+        .format = core.swap_chain_format,
         .blend = &blend,
         .write_mask = gpu.ColorWriteMask.all,
     };
@@ -167,13 +167,13 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     const fbgle = gpu.BindGroupLayout.Entry.buffer(1, .{ .fragment = true }, .read_only_storage, true, 0);
     const sbgle = gpu.BindGroupLayout.Entry.sampler(2, .{ .fragment = true }, .filtering);
     const tbgle = gpu.BindGroupLayout.Entry.texture(3, .{ .fragment = true }, .float, .dimension_2d, false);
-    const bgl = engine.device.createBindGroupLayout(
+    const bgl = core.device.createBindGroupLayout(
         &gpu.BindGroupLayout.Descriptor{
             .entries = &.{ vbgle, fbgle, sbgle, tbgle },
         },
     );
     const bind_group_layouts = [_]gpu.BindGroupLayout{bgl};
-    const pipeline_layout = engine.device.createPipelineLayout(&.{
+    const pipeline_layout = core.device.createPipelineLayout(&.{
         .bind_group_layouts = &bind_group_layouts,
     });
 
@@ -199,30 +199,30 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     };
 
-    const vertex_buffer = engine.device.createBuffer(&.{
+    const vertex_buffer = core.device.createBuffer(&.{
         .usage = .{ .copy_dst = true, .vertex = true },
         .size = @sizeOf(draw.Vertex) * app.vertices.items.len,
         .mapped_at_creation = false,
     });
 
-    const vertex_uniform_buffer = engine.device.createBuffer(&.{
+    const vertex_uniform_buffer = core.device.createBuffer(&.{
         .usage = .{ .copy_dst = true, .uniform = true },
         .size = @sizeOf(draw.VertexUniform),
         .mapped_at_creation = false,
     });
 
-    const frag_uniform_buffer = engine.device.createBuffer(&.{
+    const frag_uniform_buffer = core.device.createBuffer(&.{
         .usage = .{ .copy_dst = true, .storage = true },
         .size = @sizeOf(draw.FragUniform) * app.fragment_uniform_list.items.len,
         .mapped_at_creation = false,
     });
 
-    const sampler = engine.device.createSampler(&.{
+    const sampler = core.device.createSampler(&.{
         // .mag_filter = .linear,
         // .min_filter = .linear,
     });
 
-    const bind_group = engine.device.createBindGroup(
+    const bind_group = core.device.createBindGroup(
         &gpu.BindGroup.Descriptor{
             .layout = bgl,
             .entries = &.{
@@ -234,7 +234,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     );
 
-    app.pipeline = engine.device.createRenderPipeline(&pipeline_descriptor);
+    app.pipeline = core.device.createRenderPipeline(&pipeline_descriptor);
     app.queue = queue;
     app.vertex_buffer = vertex_buffer;
     app.vertex_uniform_buffer = vertex_uniform_buffer;
@@ -250,28 +250,28 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     bgl.release();
 }
 
-pub fn deinit(app: *App, engine: *mach.Engine) void {
+pub fn deinit(app: *App, core: *mach.Core) void {
     app.vertex_buffer.release();
     app.vertex_uniform_buffer.release();
     app.frag_uniform_buffer.release();
     app.bind_group.release();
     app.vertices.deinit();
     app.fragment_uniform_list.deinit();
-    app.texture_atlas_data.deinit(engine.allocator);
+    app.texture_atlas_data.deinit(core.allocator);
 }
 
-pub fn update(app: *App, engine: *mach.Engine) !void {
-    while (engine.pollEvent()) |event| {
+pub fn update(app: *App, core: *mach.Core) !void {
+    while (core.pollEvent()) |event| {
         switch (event) {
             .key_press => |ev| {
                 if (ev.key == .space)
-                    engine.setShouldClose(true);
+                    core.setShouldClose(true);
             },
             else => {},
         }
     }
 
-    const back_buffer_view = engine.swap_chain.?.getCurrentTextureView();
+    const back_buffer_view = core.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,
         .resolve_target = null,
@@ -280,7 +280,7 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
         .store_op = .store,
     };
 
-    const encoder = engine.device.createCommandEncoder(null);
+    const encoder = core.device.createCommandEncoder(null);
     const render_pass_info = gpu.RenderPassEncoder.Descriptor{
         .color_attachments = &.{color_attachment},
     };
@@ -295,7 +295,7 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
             app.update_frag_uniform_buffer = false;
         }
         if (app.update_vertex_uniform_buffer) {
-            encoder.writeBuffer(app.vertex_uniform_buffer, 0, draw.VertexUniform, &.{try getVertexUniformBufferObject(engine)});
+            encoder.writeBuffer(app.vertex_uniform_buffer, 0, draw.VertexUniform, &.{try getVertexUniformBufferObject(core)});
             app.update_vertex_uniform_buffer = false;
         }
     }
@@ -313,11 +313,11 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
 
     app.queue.submit(&.{command});
     command.release();
-    engine.swap_chain.?.present();
+    core.swap_chain.?.present();
     back_buffer_view.release();
 }
 
-pub fn resize(app: *App, _: *mach.Engine, _: u32, _: u32) !void {
+pub fn resize(app: *App, _: *mach.Core, _: u32, _: u32) !void {
     app.update_vertex_uniform_buffer = true;
 }
 
@@ -331,12 +331,12 @@ fn rgb24ToRgba32(allocator: std.mem.Allocator, in: []zigimg.color.Rgb24) !zigimg
 }
 
 // Move to draw.zig
-pub fn getVertexUniformBufferObject(engine: *mach.Engine) !draw.VertexUniform {
+pub fn getVertexUniformBufferObject(core: *mach.Core) !draw.VertexUniform {
     // Note: We use window width/height here, not framebuffer width/height.
     // On e.g. macOS, window size may be 640x480 while framebuffer size may be
     // 1280x960 (subpixels.) Doing this lets us use a pixel, not subpixel,
     // coordinate system.
-    const window_size = engine.getWindowSize();
+    const window_size = core.getWindowSize();
     const proj = zm.orthographicRh(
         @intToFloat(f32, window_size.width),
         @intToFloat(f32, window_size.height),

--- a/examples/rotating-cube/main.zig
+++ b/examples/rotating-cube/main.zig
@@ -20,14 +20,14 @@ vertex_buffer: gpu.Buffer,
 uniform_buffer: gpu.Buffer,
 bind_group: gpu.BindGroup,
 
-pub fn init(app: *App, engine: *mach.Engine) !void {
+pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();
 
-    try engine.setOptions(.{
+    try core.setOptions(.{
         .size_min = .{ .width = 20, .height = 20 },
     });
 
-    const vs_module = engine.device.createShaderModule(&.{
+    const vs_module = core.device.createShaderModule(&.{
         .label = "my vertex shader",
         .code = .{ .wgsl = @embedFile("vert.wgsl") },
     });
@@ -43,7 +43,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         .attributes = &vertex_attributes,
     };
 
-    const fs_module = engine.device.createShaderModule(&.{
+    const fs_module = core.device.createShaderModule(&.{
         .label = "my fragment shader",
         .code = .{ .wgsl = @embedFile("frag.wgsl") },
     });
@@ -61,7 +61,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     };
     const color_target = gpu.ColorTargetState{
-        .format = engine.swap_chain_format,
+        .format = core.swap_chain_format,
         .blend = &blend,
         .write_mask = gpu.ColorWriteMask.all,
     };
@@ -73,14 +73,14 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     };
 
     const bgle = gpu.BindGroupLayout.Entry.buffer(0, .{ .vertex = true }, .uniform, true, 0);
-    const bgl = engine.device.createBindGroupLayout(
+    const bgl = core.device.createBindGroupLayout(
         &gpu.BindGroupLayout.Descriptor{
             .entries = &.{bgle},
         },
     );
 
     const bind_group_layouts = [_]gpu.BindGroupLayout{bgl};
-    const pipeline_layout = engine.device.createPipelineLayout(&.{
+    const pipeline_layout = core.device.createPipelineLayout(&.{
         .bind_group_layouts = &bind_group_layouts,
     });
 
@@ -106,7 +106,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     };
 
-    const vertex_buffer = engine.device.createBuffer(&.{
+    const vertex_buffer = core.device.createBuffer(&.{
         .usage = .{ .vertex = true },
         .size = @sizeOf(Vertex) * vertices.len,
         .mapped_at_creation = true,
@@ -115,12 +115,12 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     std.mem.copy(Vertex, vertex_mapped, vertices[0..]);
     vertex_buffer.unmap();
 
-    const uniform_buffer = engine.device.createBuffer(&.{
+    const uniform_buffer = core.device.createBuffer(&.{
         .usage = .{ .copy_dst = true, .uniform = true },
         .size = @sizeOf(UniformBufferObject),
         .mapped_at_creation = false,
     });
-    const bind_group = engine.device.createBindGroup(
+    const bind_group = core.device.createBindGroup(
         &gpu.BindGroup.Descriptor{
             .layout = bgl,
             .entries = &.{
@@ -129,8 +129,8 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     );
 
-    app.pipeline = engine.device.createRenderPipeline(&pipeline_descriptor);
-    app.queue = engine.device.getQueue();
+    app.pipeline = core.device.createRenderPipeline(&pipeline_descriptor);
+    app.queue = core.device.getQueue();
     app.vertex_buffer = vertex_buffer;
     app.uniform_buffer = uniform_buffer;
     app.bind_group = bind_group;
@@ -141,24 +141,24 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
     bgl.release();
 }
 
-pub fn deinit(app: *App, _: *mach.Engine) void {
+pub fn deinit(app: *App, _: *mach.Core) void {
     app.vertex_buffer.release();
     app.uniform_buffer.release();
     app.bind_group.release();
 }
 
-pub fn update(app: *App, engine: *mach.Engine) !void {
-    while (engine.pollEvent()) |event| {
+pub fn update(app: *App, core: *mach.Core) !void {
+    while (core.pollEvent()) |event| {
         switch (event) {
             .key_press => |ev| {
                 if (ev.key == .space)
-                    engine.setShouldClose(true);
+                    core.setShouldClose(true);
             },
             else => {},
         }
     }
 
-    const back_buffer_view = engine.swap_chain.?.getCurrentTextureView();
+    const back_buffer_view = core.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,
         .resolve_target = null,
@@ -167,7 +167,7 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
         .store_op = .store,
     };
 
-    const encoder = engine.device.createCommandEncoder(null);
+    const encoder = core.device.createCommandEncoder(null);
     const render_pass_info = gpu.RenderPassEncoder.Descriptor{
         .color_attachments = &.{color_attachment},
         .depth_stencil_attachment = null,
@@ -183,7 +183,7 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
         );
         const proj = zm.perspectiveFovRh(
             (std.math.pi / 4.0),
-            @intToFloat(f32, engine.current_desc.width) / @intToFloat(f32, engine.current_desc.height),
+            @intToFloat(f32, core.current_desc.width) / @intToFloat(f32, core.current_desc.height),
             0.1,
             10,
         );
@@ -207,6 +207,6 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
 
     app.queue.submit(&.{command});
     command.release();
-    engine.swap_chain.?.present();
+    core.swap_chain.?.present();
     back_buffer_view.release();
 }

--- a/examples/triangle/main.zig
+++ b/examples/triangle/main.zig
@@ -7,13 +7,13 @@ const App = @This();
 pipeline: gpu.RenderPipeline,
 queue: gpu.Queue,
 
-pub fn init(app: *App, engine: *mach.Engine) !void {
-    const vs_module = engine.device.createShaderModule(&.{
+pub fn init(app: *App, core: *mach.Core) !void {
+    const vs_module = core.device.createShaderModule(&.{
         .label = "my vertex shader",
         .code = .{ .wgsl = @embedFile("vert.wgsl") },
     });
 
-    const fs_module = engine.device.createShaderModule(&.{
+    const fs_module = core.device.createShaderModule(&.{
         .label = "my fragment shader",
         .code = .{ .wgsl = @embedFile("frag.wgsl") },
     });
@@ -32,7 +32,7 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     };
     const color_target = gpu.ColorTargetState{
-        .format = engine.swap_chain_format,
+        .format = core.swap_chain_format,
         .blend = &blend,
         .write_mask = gpu.ColorWriteMask.all,
     };
@@ -64,17 +64,17 @@ pub fn init(app: *App, engine: *mach.Engine) !void {
         },
     };
 
-    app.pipeline = engine.device.createRenderPipeline(&pipeline_descriptor);
-    app.queue = engine.device.getQueue();
+    app.pipeline = core.device.createRenderPipeline(&pipeline_descriptor);
+    app.queue = core.device.getQueue();
 
     vs_module.release();
     fs_module.release();
 }
 
-pub fn deinit(_: *App, _: *mach.Engine) void {}
+pub fn deinit(_: *App, _: *mach.Core) void {}
 
-pub fn update(app: *App, engine: *mach.Engine) !void {
-    const back_buffer_view = engine.swap_chain.?.getCurrentTextureView();
+pub fn update(app: *App, core: *mach.Core) !void {
+    const back_buffer_view = core.swap_chain.?.getCurrentTextureView();
     const color_attachment = gpu.RenderPassColorAttachment{
         .view = back_buffer_view,
         .resolve_target = null,
@@ -83,7 +83,7 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
         .store_op = .store,
     };
 
-    const encoder = engine.device.createCommandEncoder(null);
+    const encoder = core.device.createCommandEncoder(null);
     const render_pass_info = gpu.RenderPassEncoder.Descriptor{
         .color_attachments = &.{color_attachment},
         .depth_stencil_attachment = null,
@@ -99,6 +99,6 @@ pub fn update(app: *App, engine: *mach.Engine) !void {
 
     app.queue.submit(&.{command});
     command.release();
-    engine.swap_chain.?.present();
+    core.swap_chain.?.present();
     back_buffer_view.release();
 }

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -8,7 +8,7 @@ const structs = @import("structs.zig");
 const enums = @import("enums.zig");
 const Timer = @import("Timer.zig");
 
-const Engine = @This();
+const Core = @This();
 
 allocator: Allocator,
 
@@ -18,7 +18,7 @@ options: structs.Options,
 ///
 /// For example, if you are animating a cube which should rotate 360 degrees every second,
 /// instead of writing (360.0 / 60.0) and assuming the frame rate is 60hz, write
-/// (360.0 * engine.delta_time)
+/// (360.0 * core.delta_time)
 delta_time: f32 = 0,
 delta_time_ns: u64 = 0,
 timer: Timer,
@@ -34,28 +34,28 @@ target_desc: gpu.SwapChain.Descriptor,
 
 internal: platform.Type,
 
-pub fn init(allocator: std.mem.Allocator) !Engine {
-    var engine: Engine = undefined;
-    engine.allocator = allocator;
-    engine.options = structs.Options{};
-    engine.timer = try Timer.start();
+pub fn init(allocator: std.mem.Allocator) !Core {
+    var core: Core = undefined;
+    core.allocator = allocator;
+    core.options = structs.Options{};
+    core.timer = try Timer.start();
 
-    engine.internal = try platform.Type.init(allocator, &engine);
+    core.internal = try platform.Type.init(allocator, &core);
 
-    return engine;
+    return core;
 }
 
 /// Set runtime options for application, like title, window size etc.
 ///
 /// See mach.Options for details
-pub fn setOptions(engine: *Engine, options: structs.Options) !void {
-    try engine.internal.setOptions(options);
-    engine.options = options;
+pub fn setOptions(core: *Core, options: structs.Options) !void {
+    try core.internal.setOptions(options);
+    core.options = options;
 }
 
 // Signals mach to stop the update loop.
-pub fn setShouldClose(engine: *Engine, value: bool) void {
-    engine.internal.setShouldClose(value);
+pub fn setShouldClose(core: *Core, value: bool) void {
+    core.internal.setShouldClose(value);
 }
 
 // Sets seconds to wait for an event with timeout before calling update()
@@ -69,32 +69,32 @@ pub fn setShouldClose(engine: *Engine, value: bool) void {
 //
 // update() can be called a bit later than timeout due to timer precision and
 // process scheduling.
-pub fn setWaitEvent(engine: *Engine, timeout: f64) void {
-    engine.internal.setWaitEvent(timeout);
+pub fn setWaitEvent(core: *Core, timeout: f64) void {
+    core.internal.setWaitEvent(timeout);
 }
 
 // Returns the framebuffer size, in subpixel units.
 //
 // e.g. returns 1280x960 on macOS for a window that is 640x480
-pub fn getFramebufferSize(engine: *Engine) structs.Size {
-    return engine.internal.getFramebufferSize();
+pub fn getFramebufferSize(core: *Core) structs.Size {
+    return core.internal.getFramebufferSize();
 }
 
 // Returns the widow size, in pixel units.
 //
 // e.g. returns 1280x960 on macOS for a window that is 640x480
-pub fn getWindowSize(engine: *Engine) structs.Size {
-    return engine.internal.getWindowSize();
+pub fn getWindowSize(core: *Core) structs.Size {
+    return core.internal.getWindowSize();
 }
 
-pub fn setMouseCursor(engine: *Engine, cursor: enums.MouseCursor) !void {
-    try engine.internal.setMouseCursor(cursor);
+pub fn setMouseCursor(core: *Core, cursor: enums.MouseCursor) !void {
+    try core.internal.setMouseCursor(cursor);
 }
 
-pub fn hasEvent(engine: *Engine) bool {
-    return engine.internal.hasEvent();
+pub fn hasEvent(core: *Core) bool {
+    return core.internal.hasEvent();
 }
 
-pub fn pollEvent(engine: *Engine) ?structs.Event {
-    return engine.internal.pollEvent();
+pub fn pollEvent(core: *Core) ?structs.Event {
+    return core.internal.pollEvent();
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,5 @@
 pub usingnamespace @import("structs.zig");
 pub usingnamespace @import("enums.zig");
-pub const Engine = @import("Engine.zig");
+pub const Core = @import("Core.zig");
 pub const Timer = @import("Timer.zig");
 pub const ResourceManager = @import("resource/ResourceManager.zig");

--- a/src/platform/common.zig
+++ b/src/platform/common.zig
@@ -1,27 +1,27 @@
-const Engine = @import("../Engine.zig");
+const Core = @import("../Core.zig");
 
 pub fn checkApplication(comptime App: type) void {
     if (@hasDecl(App, "init")) {
         const InitFn = @TypeOf(@field(App, "init"));
-        if (InitFn != fn (app: *App, engine: *Engine) @typeInfo(@typeInfo(InitFn).Fn.return_type.?).ErrorUnion.error_set!void)
-            @compileError("expected 'pub fn init(app: *App, engine: *mach.Engine) !void' found '" ++ @typeName(InitFn) ++ "'");
+        if (InitFn != fn (app: *App, core: *Core) @typeInfo(@typeInfo(InitFn).Fn.return_type.?).ErrorUnion.error_set!void)
+            @compileError("expected 'pub fn init(app: *App, core: *mach.Core) !void' found '" ++ @typeName(InitFn) ++ "'");
     } else {
-        @compileError("App must export 'pub fn init(app: *App, engine: *mach.Engine) !void'");
+        @compileError("App must export 'pub fn init(app: *App, core: *mach.Core) !void'");
     }
 
     if (@hasDecl(App, "update")) {
         const UpdateFn = @TypeOf(@field(App, "update"));
-        if (UpdateFn != fn (app: *App, engine: *Engine) @typeInfo(@typeInfo(UpdateFn).Fn.return_type.?).ErrorUnion.error_set!void)
-            @compileError("expected 'pub fn update(app: *App, engine: *mach.Engine) !void' found '" ++ @typeName(UpdateFn) ++ "'");
+        if (UpdateFn != fn (app: *App, core: *Core) @typeInfo(@typeInfo(UpdateFn).Fn.return_type.?).ErrorUnion.error_set!void)
+            @compileError("expected 'pub fn update(app: *App, core: *mach.Core) !void' found '" ++ @typeName(UpdateFn) ++ "'");
     } else {
-        @compileError("App must export 'pub fn update(app: *App, engine: *mach.Engine) !void'");
+        @compileError("App must export 'pub fn update(app: *App, core: *mach.Core) !void'");
     }
 
     if (@hasDecl(App, "deinit")) {
         const DeinitFn = @TypeOf(@field(App, "deinit"));
-        if (DeinitFn != fn (app: *App, engine: *Engine) void)
-            @compileError("expected 'pub fn deinit(app: *App, engine: *mach.Engine) void' found '" ++ @typeName(DeinitFn) ++ "'");
+        if (DeinitFn != fn (app: *App, core: *Core) void)
+            @compileError("expected 'pub fn deinit(app: *App, core: *mach.Core) void' found '" ++ @typeName(DeinitFn) ++ "'");
     } else {
-        @compileError("App must export 'pub fn deinit(app: *App, engine: *mach.Engine) void'");
+        @compileError("App must export 'pub fn deinit(app: *App, core: *mach.Core) void'");
     }
 }

--- a/src/platform/wasm.zig
+++ b/src/platform/wasm.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const App = @import("app");
-const Engine = @import("../Engine.zig");
+const Core = @import("../Core.zig");
 const structs = @import("../structs.zig");
 const enums = @import("../enums.zig");
 
@@ -41,7 +41,7 @@ pub const Platform = struct {
     last_cursor_position: structs.WindowPos,
     last_key_mods: structs.KeyMods,
 
-    pub fn init(allocator: std.mem.Allocator, eng: *Engine) !Platform {
+    pub fn init(allocator: std.mem.Allocator, eng: *Core) !Platform {
         var selector = [1]u8{0} ** 15;
         const id = js.machCanvasInit(&selector[0]);
 
@@ -279,28 +279,28 @@ comptime {
 }
 
 var app: App = undefined;
-var engine: Engine = undefined;
+var core: Core = undefined;
 
 export fn wasmInit() void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     const allocator = gpa.allocator();
 
-    engine = Engine.init(allocator) catch unreachable;
-    app.init(&engine) catch {};
+    core = Core.init(allocator) catch unreachable;
+    app.init(&core) catch {};
 }
 
 export fn wasmUpdate() void {
     // Poll internal events, like resize
-    engine.internal.pollChanges();
+    core.internal.pollChanges();
 
-    engine.delta_time_ns = engine.timer.lapPrecise();
-    engine.delta_time = @intToFloat(f32, engine.delta_time_ns) / @intToFloat(f32, std.time.ns_per_s);
+    core.delta_time_ns = core.timer.lapPrecise();
+    core.delta_time = @intToFloat(f32, core.delta_time_ns) / @intToFloat(f32, std.time.ns_per_s);
 
-    app.update(&engine) catch engine.setShouldClose(true);
+    app.update(&core) catch core.setShouldClose(true);
 }
 
 export fn wasmDeinit() void {
-    app.deinit(&engine);
+    app.deinit(&core);
 }
 
 pub const log_level = if (@hasDecl(App, "log_level")) App.log_level else .info;

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -17,7 +17,7 @@ pub const StartupOptions = struct {};
 /// Application options that can be configured at run time.
 pub const Options = struct {
     /// The title of the window.
-    title: [*:0]const u8 = "Mach engine",
+    title: [*:0]const u8 = "Mach core",
 
     /// The width of the window.
     width: u32 = 640,


### PR DESCRIPTION
This PR renames `mach.Engine` -> `mach.Core`, and prepares to make _ECS_ the "Engine"

This originates from https://github.com/hexops/mach/pull/349, the TL;DR is that there are two types of Mach apps:

* **Mach core**: "I want a window, input, and WebGPU graphics that work on any OS - that's it."
* **Mach engine**: Higher-level APIs built on top of _Mach core_, using ECS. Everything not in core is implemented and connected via ECS patterns, and hence ECS is literally _the engine_ - it's what ties everything together!

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.