### PR TITLE
mach: require a 'pub const App' to be exposed

### DIFF
--- a/examples/advanced-gen-texture-light/main.zig
+++ b/examples/advanced-gen-texture-light/main.zig
@@ -16,7 +16,7 @@ const Vec = zm.Vec;
 const Mat = zm.Mat;
 const Quat = zm.Quat;
 
-const App = @This();
+pub const App = @This();
 
 queue: gpu.Queue,
 cube: Cube,

--- a/examples/boids/main.zig
+++ b/examples/boids/main.zig
@@ -12,7 +12,7 @@ particle_bind_groups: [2]gpu.BindGroup,
 sim_param_buffer: gpu.Buffer,
 frame_counter: usize,
 
-const App = @This();
+pub const App = @This();
 
 const num_particle = 1500;
 

--- a/examples/fractal-cube/main.zig
+++ b/examples/fractal-cube/main.zig
@@ -16,7 +16,7 @@ const zm = @import("zmath");
 const Vertex = @import("cube_mesh.zig").Vertex;
 const vertices = @import("cube_mesh.zig").vertices;
 
-const App = @This();
+pub const App = @This();
 
 const UniformBufferObject = struct {
     mat: zm.Mat,

--- a/examples/instanced-cube/main.zig
+++ b/examples/instanced-cube/main.zig
@@ -18,7 +18,7 @@ vertex_buffer: gpu.Buffer,
 uniform_buffer: gpu.Buffer,
 bind_group: gpu.BindGroup,
 
-const App = @This();
+pub const App = @This();
 
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();

--- a/examples/rotating-cube/main.zig
+++ b/examples/rotating-cube/main.zig
@@ -6,7 +6,7 @@ const zm = @import("zmath");
 const Vertex = @import("cube_mesh.zig").Vertex;
 const vertices = @import("cube_mesh.zig").vertices;
 
-const App = @This();
+pub const App = @This();
 
 const UniformBufferObject = struct {
     mat: zm.Mat,

--- a/examples/textured-cube/main.zig
+++ b/examples/textured-cube/main.zig
@@ -21,7 +21,7 @@ bind_group: gpu.BindGroup,
 depth_texture: ?gpu.Texture,
 depth_texture_view: gpu.TextureView,
 
-const App = @This();
+pub const App = @This();
 
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();

--- a/examples/triangle/main.zig
+++ b/examples/triangle/main.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const mach = @import("mach");
 const gpu = @import("gpu");
 
-const App = @This();
+pub const App = @This();
 
 pipeline: gpu.RenderPipeline,
 queue: gpu.Queue,

--- a/examples/two-cubes/main.zig
+++ b/examples/two-cubes/main.zig
@@ -19,7 +19,7 @@ uniform_buffer: gpu.Buffer,
 bind_group1: gpu.BindGroup,
 bind_group2: gpu.BindGroup,
 
-const App = @This();
+pub const App = @This();
 
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();

--- a/shaderexp/main.zig
+++ b/shaderexp/main.zig
@@ -3,7 +3,7 @@ const mach = @import("mach");
 const gpu = @import("gpu");
 const glfw = @import("glfw");
 
-const App = @This();
+pub const App = @This();
 
 const Vertex = struct {
     pos: @Vector(4, f32),

--- a/src/platform/common.zig
+++ b/src/platform/common.zig
@@ -1,6 +1,11 @@
 const Core = @import("../Core.zig");
 
-pub fn checkApplication(comptime App: type) void {
+pub fn checkApplication(comptime app_pkg: type) void {
+    if (!@hasDecl(app_pkg, "App")) {
+        @compileError("expected e.g. `pub const App = mach.App(modules, init)' (App definition missing in your main Zig file)");
+    }
+    const App = app_pkg.App;
+
     if (@hasDecl(App, "init")) {
         const InitFn = @TypeOf(@field(App, "init"));
         if (InitFn != fn (app: *App, core: *Core) @typeInfo(@typeInfo(InitFn).Fn.return_type.?).ErrorUnion.error_set!void)

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -1,12 +1,18 @@
 const std = @import("std");
 const glfw = @import("glfw");
 const gpu = @import("gpu");
-const App = @import("app");
+const app_pkg = @import("app");
 const Core = @import("../Core.zig");
 const structs = @import("../structs.zig");
 const enums = @import("../enums.zig");
 const util = @import("util.zig");
 const c = @import("c.zig").c;
+
+const common = @import("common.zig");
+comptime {
+    common.checkApplication(app_pkg);
+}
+const App = app_pkg.App;
 
 pub const scope_levels = if (@hasDecl(App, "scope_levels")) App.scope_levels else [0]std.log.ScopeLevel{};
 pub const log_level = if (@hasDecl(App, "log_level")) App.log_level else std.log.default_level;
@@ -580,11 +586,6 @@ pub const Platform = struct {
 };
 
 pub const BackingTimer = std.time.Timer;
-
-const common = @import("common.zig");
-comptime {
-    common.checkApplication(App);
-}
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};

--- a/src/platform/wasm.zig
+++ b/src/platform/wasm.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const App = @import("app");
+const app_pkg = @import("app");
 const Core = @import("../Core.zig");
 const structs = @import("../structs.zig");
 const enums = @import("../enums.zig");
@@ -28,6 +28,12 @@ const js = struct {
     extern fn machLogFlush() void;
     extern fn machPanic(str: [*]const u8, len: u32) void;
 };
+
+const common = @import("common.zig");
+comptime {
+    common.checkApplication(app_pkg);
+}
+const App = app_pkg.App;
 
 pub const CanvasId = u32;
 
@@ -272,11 +278,6 @@ pub const BackingTimer = struct {
         return @floatToInt(u64, t) * 1000000;
     }
 };
-
-const common = @import("common.zig");
-comptime {
-    common.checkApplication(App);
-}
 
 var app: App = undefined;
 var core: Core = undefined;


### PR DESCRIPTION
This requires apps expose a `pub const App` from their `main.zig`, effectively adopting the high-level/low-level application API outlined in https://github.com/hexops/mach/pull/349

If `pub const App` does not exist, a clear compiler error is produced:

```
./src/platform/common.zig:5:9: error: expected e.g. `pub const App = mach.App(modules, init)' (App definition missing in your main Zig file)
        @CompileError("expected e.g. `pub const App = mach.App(modules, init)' (App definition missing in your main Zig file)");
        ^
./src/platform/native.zig:13:28: note: called from here
    common.checkApplication(app_pkg);
                           ^
./src/platform/native.zig:12:10: note: called from here
comptime {
         ^
./src/platform/native.zig:15:20: error: container '.app' has no member called 'App'
const App = app_pkg.App;
                   ^
```

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.