### PR TITLE
mach: wasm: Stage2 and ecs changes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -41,9 +41,10 @@ pub fn build(b: *std.build.Builder) void {
         .{ .name = "instanced-cube", .packages = &[_]Pkg{Packages.zmath} },
         .{ .name = "advanced-gen-texture-light", .packages = &[_]Pkg{Packages.zmath} },
         .{ .name = "fractal-cube", .packages = &[_]Pkg{Packages.zmath} },
-        .{ .name = "gkurve", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg, freetype.pkg }, .std_platform_only = true },
         .{ .name = "textured-cube", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg } },
         .{ .name = "ecs-app", .packages = &[_]Pkg{} },
+        // NOTE: examples with std_platform_only should be placed at last
+        .{ .name = "gkurve", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg, freetype.pkg }, .std_platform_only = true },
     }) |example| {
         // FIXME: this is workaround for a problem that some examples (having the std_platform_only=true field) as
         // well as zigimg uses IO which is not supported in freestanding environments. So break out of this loop

--- a/build.zig
+++ b/build.zig
@@ -201,6 +201,7 @@ pub const App = struct {
             app.getInstallStep().?.step.dependOn(&install_mach_js.step);
 
             const html_generator = app.b.addExecutable("html-generator", thisDir() ++ "/tools/html-generator.zig");
+            html_generator.main_pkg_path = thisDir();
             const run_html_generator = html_generator.run();
             run_html_generator.addArgs(&.{ std.mem.concat(
                 app.b.allocator,

--- a/examples/ecs-app/physics2d.zig
+++ b/examples/ecs-app/physics2d.zig
@@ -21,6 +21,6 @@ pub const Vec2 = struct { x: f32, y: f32 };
 fn update(msg: Message) void {
     switch (msg) {
         // TODO: implement queries, ability to set components, etc.
-        .tick => std.debug.print("\nphysics tick!\n", .{}),
+        .tick => std.log.debug("physics tick!", .{}),
     }
 }

--- a/src/platform/wasm.zig
+++ b/src/platform/wasm.zig
@@ -304,7 +304,7 @@ export fn wasmDeinit() void {
     app.deinit(&core);
 }
 
-pub const log_level = if (@hasDecl(App, "log_level")) App.log_level else .info;
+pub const log_level = if (@hasDecl(App, "log_level")) App.log_level else std.log.default_level;
 pub const scope_levels = if (@hasDecl(App, "scope_levels")) App.scope_levels else [0]std.log.ScopeLevel{};
 
 const LogError = error{};


### PR DESCRIPTION
Covers up all the recent progress for wasm

- html_generator is now stage2 ready
- Make ecs-app example build on wasm
- Change log level of wasm to default (there was no real reason to have a custom value)
- Fix order of examples in build.zig and added a note about it.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.