### PR TITLE
js-runtime: add/upstream new js-runtime library inspired by Go's syscall/js package

### DIFF
--- a/js-runtime/.gitignore
+++ b/js-runtime/.gitignore
@@ -1,0 +1,2 @@
+zig-out/
+zig-cache/

--- a/js-runtime/LICENSE
+++ b/js-runtime/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2021, Hexops Contributors (given via the Git commit history).
+
+All documentation, image, sound, font, and 2D/3D model files are CC-BY-4.0 licensed unless
+otherwise noted. You may get a copy of this license at https://creativecommons.org/licenses/by/4.0
+
+Files in a directory with a separate LICENSE file may contain files under different license terms,
+described within that LICENSE file.
+
+All other files are licensed under the Apache License, Version 2.0 (see LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+or the MIT license (see LICENSE-MIT or http://opensource.org/licenses/MIT), at your option.
+
+All files in the project without exclusions may not be copied, modified, or distributed except
+according to the terms above.

--- a/js-runtime/LICENSE-APACHE
+++ b/js-runtime/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/js-runtime/LICENSE-MIT
+++ b/js-runtime/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2021 Hexops Contributors (given via the Git commit history).
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/js-runtime/README.md
+++ b/js-runtime/README.md
@@ -1,0 +1,1 @@
+# mach-js-runtime

--- a/js-runtime/build.zig
+++ b/js-runtime/build.zig
@@ -1,0 +1,22 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    const mode = b.standardReleaseOptions();
+
+    const main_tests = b.addTest("src/main.zig");
+    main_tests.addPackage(pkg);
+    main_tests.setBuildMode(mode);
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&main_tests.step);
+}
+
+pub const pkg = std.build.Pkg{
+    .name = "js-runtime",
+    .source = .{ .path = thisDir() ++ "/src/main.zig" },
+    .dependencies = &[_]std.build.Pkg{},
+};
+
+fn thisDir() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
+}

--- a/js-runtime/src/js-runtime.js
+++ b/js-runtime/src/js-runtime.js
@@ -1,0 +1,338 @@
+let text_decoder = new TextDecoder();
+let text_encoder = new TextEncoder();
+let log_buf = "";
+
+let uindex = 0;
+let indices = [];
+let values = [];
+let value_map = {};
+
+class MemoryBlock {
+  constructor(mem, offset = 0) {
+    this.mem = mem;
+    this.offset = offset;
+  }
+
+  slice(offset) {
+    return new MemoryBlock(this.mem, offset);
+  }
+
+  getMemory() {
+    return new DataView(this.mem, this.offset);
+  }
+
+  getU8(offset) {
+    return this.getMemory().getUint8(offset, true);
+  }
+
+  getU32(offset) {
+    return this.getMemory().getUint32(offset, true);
+  }
+
+  getU64(offset) {
+    const ls = this.getU32(offset);
+    const ms = this.getU32(offset + 4);
+
+    return ls + ms * 4294967296;
+  }
+
+  getF64(offset) {
+    return this.getMemory().getFloat64(offset, true);
+  }
+
+  getString(offset, len) {
+    return text_decoder.decode(new Uint8Array(this.mem, offset, len));
+  }
+
+  setU8(offset, data) {
+    this.getMemory().setUint8(offset, data, true);
+  }
+
+  setU32(offset, data) {
+    this.getMemory().setUint32(offset, data, true);
+  }
+
+  setU64(offset, data) {
+    this.getMemory().setUint32(offset, data, true);
+    this.getMemory().setUint32(offset + 4, Math.floor(data / 4294967296), true);
+  }
+
+  setF64(offset, data) {
+    this.getMemory().setFloat64(offset, data, true);
+  }
+
+  setString(offset, str) {
+    const string = text_encoder.encode(str);
+    const buffer = new Uint8Array(this.mem, offset, string.length);
+    for (let i = 0; i < string.length; i += 1) {
+      buffer[i] = string[i];
+    }
+  }
+}
+
+const zig = {
+  wasm: undefined,
+  buffer: undefined,
+
+  init(wasm) {
+    this.wasm = wasm;
+
+    values = [];
+    value_map = [];
+    this.addValue(globalThis);
+  },
+
+  addValue(value) {
+    value.__proto__.__uindex = uindex;
+    let idx = indices.pop();
+    if (idx !== undefined) {
+      values[idx] = value;
+    } else {
+      idx = values.push(value) - 1;
+    }
+    value_map[uindex] = idx;
+    uindex += 1;
+    return idx;
+  },
+
+  zigCreateMap() {
+    return zig.addValue(new Map());
+  },
+
+  zigCreateArray() {
+    return zig.addValue(new Array());
+  },
+
+  zigCreateString(str, len) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    return zig.addValue(memory.getString(str, len));
+  },
+
+  zigCreateFunction(id) {
+    return zig.addValue(function () {
+      const args = zig.addValue(arguments);
+      zig.wasm.exports.wasmCallFunction(id, args, arguments.length);
+      const return_value = values[args]["return_value"];
+      zig.zigCleanupObject(args);
+      return return_value;
+    });
+  },
+
+  getType(value) {
+    switch (typeof value) {
+      case "object":
+        switch (value) {
+          case null:
+            return 4;
+          default:
+            return 0;
+        }
+        break;
+      case "number":
+        return 1;
+      case "boolean":
+        return 2;
+      case "string":
+        return 3;
+      case "undefined":
+        return 5;
+      case "function":
+        return 6;
+    }
+  },
+
+  writeObject(block, data, type) {
+    switch (type) {
+      case 0:
+      case 6:
+        block.setU8(0, type);
+        block.setU64(8, data);
+        break;
+      case 1:
+        block.setU8(0, 1);
+        block.setF64(8, data);
+        break;
+      case 2:
+        block.setU8(0, 2);
+        block.setU8(8, data);
+        break;
+      case 3:
+        block.setU8(0, 3);
+        block.setU64(8, data);
+        break;
+      case 4:
+        block.setU8(0, 4);
+        break;
+      case 5:
+        block.setU8(0, 5);
+        break;
+    }
+  },
+
+  readObject(block, memory) {
+    switch (block.getU8(0)) {
+      case 0:
+      case 7:
+        return values[block.getU64(8)];
+        break;
+      case 1:
+        return block.getF64(8);
+        break;
+      case 2:
+        return Boolean(block.getU8(8));
+        break;
+      case 3:
+        return values[block.getU64(8)];
+        break;
+      case 4:
+        return null;
+        break;
+      case 5:
+        return undefined;
+        break;
+    }
+  },
+
+  getPropertyEx(prop, ret_ptr, offset) {
+    let len = undefined;
+    const type = this.getType(prop);
+    switch (type) {
+      case 3:
+        len = prop.length;
+      case 0:
+      case 6:
+        if (prop in value_map) {
+          prop = value_map[prop.__uindex];
+        } else {
+          prop = zig.addValue(prop);
+        }
+        break;
+    }
+
+    if (len !== undefined) prop.__proto__.length = len;
+
+    let memory = new MemoryBlock(ret_ptr, offset);
+    zig.writeObject(memory, prop, type);
+  },
+
+  getProperty(prop, ret_ptr) {
+    return zig.getPropertyEx(prop, zig.wasm.exports.memory.buffer, ret_ptr);
+  },
+
+  zigGetProperty(id, name, len, ret_ptr) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    let prop = values[id][memory.getString(name, len)];
+    zig.getProperty(prop, ret_ptr);
+  },
+
+  zigSetProperty(id, name, len, set_ptr) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    values[id][memory.getString(name, len)] = zig.readObject(
+      memory.slice(set_ptr),
+      memory
+    );
+  },
+
+  zigDeleteProperty(id, name, len) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    delete values[id][memory.getString(name, len)];
+  },
+
+  zigGetIndex(id, index, ret_ptr) {
+    let prop = values[id][index];
+    zig.getProperty(prop, ret_ptr);
+  },
+
+  zigSetIndex(id, index, set_ptr) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    values[id][index] = zig.readObject(memory.slice(set_ptr), memory);
+  },
+
+  zigDeleteIndex(id, index) {
+    delete values[id][index];
+  },
+
+  zigCleanupObject(id) {
+    const idx = Number(id);
+    delete value_map[values[idx].__uindex];
+    delete values[idx];
+    indices.push(idx);
+  },
+
+  zigGetStringLength(val_id) {
+    return values[value_map[val_id]].length;
+  },
+
+  zigGetString(val_id, ptr) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    memory.setString(ptr, values[value_map[val_id]]);
+  },
+
+  zigFunctionCall(id, name, len, args, args_len, ret_ptr) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    let argv = [];
+    for (let i = 0; i < args_len; i += 1) {
+      argv.push(zig.readObject(memory.slice(args + i * 16), memory));
+    }
+    let result = values[id][memory.getString(name, len)].apply(
+      values[id],
+      argv
+    );
+
+    let length = undefined;
+    const type = zig.getType(result);
+    switch (type) {
+      case 3:
+        length = result.length;
+      case 0:
+      case 6:
+        result = zig.addValue(result);
+        break;
+    }
+
+    if (length !== undefined) result.__proto__.length = length;
+
+    zig.writeObject(memory.slice(ret_ptr), result, type);
+  },
+
+  zigFunctionInvoke(id, args, args_len, ret_ptr) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    let argv = [];
+    for (let i = 0; i < args_len; i += 1) {
+      argv.push(zig.readObject(memory.slice(args + i * 16), memory));
+    }
+    let result = values[id].apply(undefined, argv);
+
+    let length = undefined;
+    const type = zig.getType(result);
+    switch (type) {
+      case 3:
+        length = result.length;
+      case 0:
+      case 6:
+        result = zig.addValue(result);
+        break;
+    }
+
+    if (length !== undefined) result.__proto__.length = length;
+
+    zig.writeObject(memory.slice(ret_ptr), result, type);
+  },
+
+  wzLogWrite(str, len) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    log_buf += memory.getString(str, len);
+  },
+
+  wzLogFlush() {
+    console.log(log_buf);
+    log_buf = "";
+  },
+
+  wzPanic(str, len) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    throw Error(memory.getString(str, len));
+  },
+};
+
+export { zig };

--- a/js-runtime/src/main.zig
+++ b/js-runtime/src/main.zig
@@ -1,0 +1,204 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const builtin = @import("builtin");
+
+const js = struct {
+    extern fn zigCreateMap() u32;
+    extern fn zigCreateArray() u32;
+    extern fn zigCreateString(str: [*]const u8, len: u32) u32;
+    extern fn zigCreateFunction(id: *const anyopaque) u32;
+    extern fn zigGetProperty(id: u64, name: [*]const u8, len: u32, ret_ptr: *anyopaque) void;
+    extern fn zigSetProperty(id: u64, name: [*]const u8, len: u32, set_ptr: *const anyopaque) void;
+    extern fn zigDeleteProperty(id: u64, name: [*]const u8, len: u32) void;
+    extern fn zigGetIndex(id: u64, index: u32, ret_ptr: *anyopaque) void;
+    extern fn zigSetIndex(id: u64, index: u32, set_ptr: *const anyopaque) void;
+    extern fn zigGetString(val_id: u64, ptr: [*]const u8) void;
+    extern fn zigGetStringLength(val_id: u64) u32;
+    extern fn zigDeleteIndex(id: u64, index: u32) void;
+    extern fn zigFunctionCall(id: u64, name: [*]const u8, len: u32, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
+    extern fn zigFunctionInvoke(id: u64, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
+    extern fn zigCleanupObject(id: u64) void;
+};
+
+pub const Value = extern struct {
+    tag: ValueTag,
+    val: extern union {
+        ref: u64,
+        num: f64,
+        bool: bool,
+    },
+
+    const ValueTag = enum(u8) {
+        ref,
+        num,
+        bool,
+        str,
+        nulled,
+        undef,
+        func_js,
+        func_zig,
+    };
+
+    pub const Tag = enum {
+        object,
+        num,
+        bool,
+        str,
+        nulled,
+        undef,
+        func,
+    };
+
+    pub fn is(val: *const Value, comptime tag: Tag) bool {
+        return switch (tag) {
+            .object => val.tag == .object,
+            .num => val.tag == .num,
+            .bool => val.tag == .bool,
+            .str => val.tag == .str,
+            .nulled => val.tag == .nulled,
+            .undef => val.tag == .undef,
+            .func => val.tag == .func_js or val.tag == .func_zig,
+        };
+    }
+
+    pub fn value(val: *const Value, comptime tag: Tag, allocator: ?std.mem.Allocator) switch (tag) {
+        .object => Object,
+        .num => f64,
+        .bool => bool,
+        .str => std.mem.Allocator.Error![]const u8,
+        .func => Function,
+        .nulled, .undef => @compileError("Cannot get null or undefined as a value"),
+    } {
+        return switch (tag) {
+            .object => Object{ .ref = val.val.ref },
+            .num => val.val.num,
+            .bool => val.val.bool,
+            .str => blk: {
+                const len = js.zigGetStringLength(val.val.ref);
+                var slice = try allocator.?.alloc(u8, len);
+                js.zigGetString(val.val.ref, slice.ptr);
+                break :blk slice;
+            },
+            .func => Function{ .ref = val.val.ref },
+            else => unreachable,
+        };
+    }
+};
+
+pub const Object = struct {
+    ref: u64,
+
+    pub fn deinit(obj: *const Object) void {
+        js.zigCleanupObject(obj.ref);
+    }
+
+    pub fn toValue(obj: *const Object) Value {
+        return .{ .tag = .ref, .val = .{ .ref = obj.ref } };
+    }
+
+    pub fn get(obj: *const Object, prop: []const u8) Value {
+        var ret: Value = undefined;
+        js.zigGetProperty(obj.ref, prop.ptr, @intCast(u32, prop.len), &ret);
+        return ret;
+    }
+
+    pub fn set(obj: *const Object, prop: []const u8, value: Value) void {
+        js.zigSetProperty(obj.ref, prop.ptr, @intCast(u32, prop.len), &value);
+    }
+
+    pub fn delete(obj: *const Object, prop: []const u8) void {
+        js.zigDeleteProperty(obj.ref, prop.ptr, @intCast(u32, prop.len));
+    }
+
+    pub fn getIndex(obj: *const Object, index: u32) Value {
+        var ret: Value = undefined;
+        js.zigGetIndex(obj.ref, index, &ret);
+        return ret;
+    }
+
+    pub fn setIndex(obj: *const Object, index: u32, value: Value) void {
+        js.zigSetIndex(obj.ref, index, &value);
+    }
+
+    pub fn deleteIndex(obj: *const Object, index: u32) void {
+        js.zigDeleteIndex(obj.ref, index);
+    }
+
+    pub fn call(obj: *const Object, fun: []const u8, args: []const Value) Value {
+        var ret: Value = undefined;
+        js.zigFunctionCall(obj.ref, fun.ptr, fun.len, args.ptr, args.len, &ret);
+        return ret;
+    }
+};
+
+pub const Function = struct {
+    ref: u64,
+
+    pub fn deinit(func: *const Function) void {
+        js.zigCleanupObject(func.ref);
+    }
+
+    pub fn toValue(func: *const Function) Value {
+        return .{ .tag = .func_zig, .val = .{ .ref = func.ref } };
+    }
+
+    pub fn invoke(func: *const Function, args: []const Value) Value {
+        var ret: Value = undefined;
+        js.zigFunctionInvoke(func.ref, args.ptr, args.len, &ret);
+        return ret;
+    }
+};
+
+export fn wasmCallFunction(id: *anyopaque, args: u32, len: u32) void {
+    const obj = Object{ .ref = args };
+    if (builtin.zig_backend == .stage1) {
+        obj.set("return_value", functions.items[@ptrToInt(id) - 1](obj, len));
+    } else {
+        var func = @ptrCast(*FunType, @alignCast(std.meta.alignment(*FunType), id));
+        obj.set("return_value", func(obj, len));
+    }
+}
+
+pub fn global() Object {
+    return Object{ .ref = 0 };
+}
+
+pub fn createMap() Object {
+    return .{ .ref = js.zigCreateMap() };
+}
+
+pub fn createArray() Object {
+    return .{ .ref = js.zigCreateArray() };
+}
+
+pub fn createString(string: []const u8) Value {
+    return .{ .tag = .str, .val = .{ .ref = js.zigCreateString(string.ptr, string.len) } };
+}
+
+pub fn createNumber(num: f64) Value {
+    return .{ .tag = .num, .val = .{ .num = num } };
+}
+
+pub fn createBool(val: bool) Value {
+    return .{ .tag = .bool, .val = .{ .bool = val } };
+}
+
+pub fn createNull() Value {
+    return .{ .tag = .nulled, .val = undefined };
+}
+
+pub fn createUndefined() Value {
+    return .{ .tag = .undef, .val = undefined };
+}
+
+const FunType = fn (args: Object, args_len: u32) Value;
+
+var functions: std.ArrayListUnmanaged(FunType) = .{};
+
+pub fn createFunction(fun: FunType) Function {
+    if (builtin.zig_backend == .stage1) {
+        functions.append(std.heap.page_allocator, fun) catch unreachable;
+        return .{ .ref = js.zigCreateFunction(@intToPtr(*anyopaque, functions.items.len)) };
+    }
+    return .{ .ref = js.zigCreateFunction(&fun) };
+}

--- a/www/template.html
+++ b/www/template.html
@@ -6,9 +6,10 @@
   <body>
     <script type="module">
       import {{ mach }} from "./mach.js";
+      import {{ zig }} from "./js-runtime.js";
 
       let imports = {{
-        env: mach,
+        env: {{  ...mach, ...zig }},
       }};
 
 	  fetch("{s}.wasm")
@@ -16,6 +17,7 @@
         .then(buffer => WebAssembly.instantiate(buffer, imports))
         .then(results => results.instance)
         .then(instance => {{
+          zig.init(instance);
           mach.init(instance);
           instance.exports.wasmInit();
 


### PR DESCRIPTION
Upstreams js-runtime from https://github.com/iddev5/zig-js-runtime. This module should be considered experimental and its API is not final. It is inspired from Go's syscall/js module. It is not a reimplementation, but rather an independent implementation.

There is also a workaround for a limitation right now. The html-generator has no way to dynamically add JS sources (and that can't be done without using a preprocessor library) so we hardcode js-runtime in it.

In the future, I think the correct behavior would be to move tools/ inside js-runtime along with a wasm application building SDK and get rid of any direct JS access we have today (which is just src/platform/wasm.zig and src/platform/mach.js).

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.