### PR TITLE
glfw: respect negative coordinates in window

### DIFF
--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -551,8 +551,8 @@ pub inline fn setIcon(self: Window, allocator: mem.Allocator, images: ?[]Image) 
 }
 
 pub const Pos = struct {
-    x: u32,
-    y: u32,
+    x: i64,
+    y: i64,
 };
 
 /// Retrieves the position of the content area of the specified window.
@@ -578,7 +578,7 @@ pub inline fn getPos(self: Window) error{FeatureUnavailable}!Pos {
         Error.FeatureUnavailable => |e| e,
         else => unreachable,
     };
-    return Pos{ .x = @intCast(u32, x), .y = @intCast(u32, y) };
+    return Pos{ .x = @intCast(i64, x), .y = @intCast(i64, y) };
 }
 
 /// Sets the position of the content area of the specified window.


### PR DESCRIPTION
While attempting to run the mach examples on WSLg, I ran into an issue using the OpenGL backend:
```
thread 11857 panic: attempt to cast negative value to unsigned integer
/home/jane/mach/glfw/src/Window.zig:581:22 0x4af643 in Platform.init (example-boids)
    return Pos{ .x = @intCast(u32, x), .y = @intCast(u32, y) };
                     ^
```

the simplest solution, to use a signed integer instead of an unsigned one, worked perfectly fine to resolve this issue and the example built and ran without issue afterwards.

---

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.