### PR TITLE
js-runtime: More functional improvements

### DIFF
--- a/js-runtime/src/js-runtime.js
+++ b/js-runtime/src/js-runtime.js
@@ -268,6 +268,13 @@ const zig = {
     memory.setString(ptr, values[value_map[val_id]]);
   },
 
+  zigValueEqual(val, other) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    const val_js = zig.readObject(memory.slice(val), memory);
+    const other_js = zig.readObject(memory.slice(other), memory);
+    return val_js === other_js;
+  },
+
   functionCall(func, this_param, args, args_len, ret_ptr) {
     let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
     let argv = [];

--- a/js-runtime/src/js-runtime.js
+++ b/js-runtime/src/js-runtime.js
@@ -327,6 +327,10 @@ const zig = {
     zig.functionCall(values[id], undefined, args, args_len, ret_ptr);
   },
 
+  zigGetParamCount(id) {
+    return values[id].length;
+  },
+
   zigConstructType(id, args, args_len, ret_ptr) {
     let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
     let argv = [];

--- a/js-runtime/src/js-runtime.js
+++ b/js-runtime/src/js-runtime.js
@@ -172,6 +172,7 @@ const zig = {
   readObject(block, memory) {
     switch (block.getU8(0)) {
       case 0:
+      case 6:
       case 7:
         return values[block.getU64(8)];
         break;

--- a/js-runtime/src/js-runtime.js
+++ b/js-runtime/src/js-runtime.js
@@ -173,7 +173,6 @@ const zig = {
     switch (block.getU8(0)) {
       case 0:
       case 6:
-      case 7:
         return values[block.getU64(8)];
         break;
       case 1:

--- a/js-runtime/src/js-runtime.js
+++ b/js-runtime/src/js-runtime.js
@@ -276,6 +276,13 @@ const zig = {
     return val_js === other_js;
   },
 
+  zigValueInstanceOf(val, other) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    const val_js = zig.readObject(memory.slice(val), memory);
+    const other_js = zig.readObject(memory.slice(other), memory);
+    return val_js instanceof other_js;
+  },
+
   functionCall(func, this_param, args, args_len, ret_ptr) {
     let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
     let argv = [];

--- a/js-runtime/src/js-runtime.js
+++ b/js-runtime/src/js-runtime.js
@@ -252,6 +252,11 @@ const zig = {
     delete values[id][index];
   },
 
+  zigGetAttributeCount(id) {
+    let obj = values[id];
+    return Object.keys(obj).length;
+  },
+
   zigCleanupObject(id) {
     const idx = Number(id);
     delete value_map[values[idx].__uindex];

--- a/js-runtime/src/main.zig
+++ b/js-runtime/src/main.zig
@@ -7,6 +7,7 @@ const js = struct {
     extern fn zigCreateArray() u32;
     extern fn zigCreateString(str: [*]const u8, len: u32) u32;
     extern fn zigCreateFunction(id: *const anyopaque) u32;
+    extern fn zigGetAttributeCount(id: u64) u32;
     extern fn zigGetProperty(id: u64, name: [*]const u8, len: u32, ret_ptr: *anyopaque) void;
     extern fn zigSetProperty(id: u64, name: [*]const u8, len: u32, set_ptr: *const anyopaque) void;
     extern fn zigDeleteProperty(id: u64, name: [*]const u8, len: u32) void;
@@ -89,6 +90,10 @@ pub const Object = struct {
 
     pub fn toValue(obj: *const Object) Value {
         return .{ .tag = .object, .val = .{ .ref = obj.ref } };
+    }
+
+    pub fn attributeCount(obj: *const Object) usize {
+        return js.zigGetAttributeCount(obj.ref);
     }
 
     pub fn get(obj: *const Object, prop: []const u8) Value {

--- a/js-runtime/src/main.zig
+++ b/js-runtime/src/main.zig
@@ -15,6 +15,7 @@ const js = struct {
     extern fn zigGetString(val_id: u64, ptr: [*]const u8) void;
     extern fn zigGetStringLength(val_id: u64) u32;
     extern fn zigValueEqual(val: *const anyopaque, other: *const anyopaque) bool;
+    extern fn zigValueInstanceOf(val: *const anyopaque, other: *const anyopaque) bool;
     extern fn zigDeleteIndex(id: u64, index: u32) void;
     extern fn zigFunctionCall(id: u64, name: [*]const u8, len: u32, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
     extern fn zigFunctionInvoke(id: u64, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
@@ -91,6 +92,10 @@ pub const Value = extern struct {
             // Using JS equality (===) is better here since lets say a ref can be dangling
             else => js.zigValueEqual(val, &other),
         };
+    }
+
+    pub fn instanceOf(val: *const Value, other: Value) bool {
+        return js.zigValueInstanceOf(val, &other);
     }
 };
 

--- a/js-runtime/src/main.zig
+++ b/js-runtime/src/main.zig
@@ -24,25 +24,14 @@ const js = struct {
 };
 
 pub const Value = extern struct {
-    tag: ValueTag,
+    tag: Tag,
     val: extern union {
         ref: u64,
         num: f64,
         bool: bool,
     },
 
-    const ValueTag = enum(u8) {
-        ref,
-        num,
-        bool,
-        str,
-        nulled,
-        undef,
-        func_js,
-        func_zig,
-    };
-
-    pub const Tag = enum {
+    pub const Tag = enum(u8) {
         object,
         num,
         bool,
@@ -53,15 +42,7 @@ pub const Value = extern struct {
     };
 
     pub fn is(val: *const Value, comptime tag: Tag) bool {
-        return switch (tag) {
-            .object => val.tag == .object,
-            .num => val.tag == .num,
-            .bool => val.tag == .bool,
-            .str => val.tag == .str,
-            .nulled => val.tag == .nulled,
-            .undef => val.tag == .undef,
-            .func => val.tag == .func_js or val.tag == .func_zig,
-        };
+        return val.tag == tag;
     }
 
     pub fn view(val: *const Value, comptime tag: Tag) switch (tag) {
@@ -107,7 +88,7 @@ pub const Object = struct {
     }
 
     pub fn toValue(obj: *const Object) Value {
-        return .{ .tag = .ref, .val = .{ .ref = obj.ref } };
+        return .{ .tag = .object, .val = .{ .ref = obj.ref } };
     }
 
     pub fn get(obj: *const Object, prop: []const u8) Value {
@@ -153,7 +134,7 @@ pub const Function = struct {
     }
 
     pub fn toValue(func: *const Function) Value {
-        return .{ .tag = .func_zig, .val = .{ .ref = func.ref } };
+        return .{ .tag = .func, .val = .{ .ref = func.ref } };
     }
 
     pub fn construct(func: *const Function, args: []const Value) Value {

--- a/js-runtime/src/main.zig
+++ b/js-runtime/src/main.zig
@@ -14,6 +14,7 @@ const js = struct {
     extern fn zigSetIndex(id: u64, index: u32, set_ptr: *const anyopaque) void;
     extern fn zigGetString(val_id: u64, ptr: [*]const u8) void;
     extern fn zigGetStringLength(val_id: u64) u32;
+    extern fn zigValueEqual(val: *const anyopaque, other: *const anyopaque) bool;
     extern fn zigDeleteIndex(id: u64, index: u32) void;
     extern fn zigFunctionCall(id: u64, name: [*]const u8, len: u32, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
     extern fn zigFunctionInvoke(id: u64, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
@@ -77,6 +78,18 @@ pub const Value = extern struct {
             .str => String{ .ref = val.val.ref },
             .func => Function{ .ref = val.val.ref },
             else => unreachable,
+        };
+    }
+
+    pub fn eql(val: *const Value, other: Value) bool {
+        if (val.tag != other.tag)
+            return false;
+
+        return switch (val.tag) {
+            .num => val.val.num == other.val.num,
+            .bool => val.val.bool == other.val.bool,
+            // Using JS equality (===) is better here since lets say a ref can be dangling
+            else => js.zigValueEqual(val, &other),
         };
     }
 };

--- a/js-runtime/src/main.zig
+++ b/js-runtime/src/main.zig
@@ -20,6 +20,7 @@ const js = struct {
     extern fn zigDeleteIndex(id: u64, index: u32) void;
     extern fn zigFunctionCall(id: u64, name: [*]const u8, len: u32, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
     extern fn zigFunctionInvoke(id: u64, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
+    extern fn zigGetParamCount(id: u64) u32;
     extern fn zigConstructType(id: u64, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
     extern fn zigCleanupObject(id: u64) void;
 };
@@ -140,6 +141,11 @@ pub const Function = struct {
 
     pub fn toValue(func: *const Function) Value {
         return .{ .tag = .func, .val = .{ .ref = func.ref } };
+    }
+
+    pub fn paramCount(func: *const Function) usize {
+        // FIXME: native functions would always return 0
+        return js.zigGetParamCount(func.ref);
     }
 
     pub fn construct(func: *const Function, args: []const Value) Value {

--- a/js-runtime/src/main.zig
+++ b/js-runtime/src/main.zig
@@ -80,6 +80,21 @@ pub const Value = extern struct {
     pub fn instanceOf(val: *const Value, other: Value) bool {
         return js.zigValueInstanceOf(val, &other);
     }
+
+    pub fn format(val: *const Value, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        switch (val.tag) {
+            .object => try writer.print("Object@{}({})", .{ val.val.ref, val.view(.object).attributeCount() }),
+            .num => if (val.val.num > 10000)
+                try writer.print("{e}", .{val.val.num})
+            else
+                try writer.print("{d}", .{val.val.num}),
+            .bool => try writer.writeAll(if (val.view(.bool)) "true" else "false"),
+            .str => try writer.print("String@{}({})", .{ val.val.ref, val.view(.str).getLength() }),
+            .func => try writer.print("Function@{}({})", .{ val.val.ref, val.view(.func).paramCount() }),
+            .nulled => try writer.writeAll("null"),
+            .undef => try writer.writeAll("undefined"),
+        }
+    }
 };
 
 pub const Object = struct {


### PR DESCRIPTION
Adds the following new functions: 
- ``js.Value.eql``
- ``js.Value,instanceOf``
- ``js.Value.format`` to be used with stdlib formatting
- ``js.Object.attributeCount``
- ``js.Function.paramCount`` (note: doesn't works for native functions, yet)

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.