### PR TITLE
{mach, glfw}: Fix broken build due to using u32 inplace of i32

### DIFF
--- a/glfw/src/Window.zig
+++ b/glfw/src/Window.zig
@@ -1197,7 +1197,7 @@ pub inline fn getMonitor(self: Window) ?Monitor {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: window_monitor, window_full_screen, glfw.Window.getMonitor, glfw.Window.setSize
-pub inline fn setMonitor(self: Window, monitor: ?Monitor, xpos: u32, ypos: u32, width: u32, height: u32, refresh_rate: ?u32) error{PlatformError}!void {
+pub inline fn setMonitor(self: Window, monitor: ?Monitor, xpos: i32, ypos: i32, width: u32, height: u32, refresh_rate: ?u32) error{PlatformError}!void {
     internal_debug.assertInitialized();
     c.glfwSetWindowMonitor(
         self.handle,

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -359,7 +359,7 @@ pub const Platform = struct {
             try platform.window.setMonitor(monitor, 0, 0, video_mode.getWidth(), video_mode.getHeight(), null);
         } else {
             const position = platform.last_position;
-            try platform.window.setMonitor(null, position.x, position.y, options.width, options.height, null);
+            try platform.window.setMonitor(null, @intCast(i32, position.x), @intCast(i32, position.y), options.width, options.height, null);
         }
     }
 


### PR DESCRIPTION
This regression was introduced with https://github.com/hexops/mach/commit/04013379db7fe2d1d33e54792647c933435bb30f and also partially reverts https://github.com/hexops/mach/commit/d3feaed383f9a7f8f8d5fa4d9e1d496ea7fbebc5

Instead of doing the intCast, the other way to solve the problem is this suggestion: https://github.com/hexops/mach/pull/393#issuecomment-1178655298 (which is to use i32 for pos instead of i64), if it is an accepted solution.

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.