### PR TITLE
ecs: fix pointer invalidation in get/setComponent

### DIFF
--- a/ecs/src/entities.zig
+++ b/ecs/src/entities.zig
@@ -523,11 +523,12 @@ pub fn Entities(all_components: anytype) type {
             // new component was added), or the same archetype storage table (if just updating the
             // value of a component.)
             var archetype_entry = try entities.archetypes.getOrPut(entities.allocator, new_hash);
-            if (!archetype_entry.found_existing) {
-                // getOrPut allocated, so the archetype we retrieved earlier may no longer be a valid
-                // pointer. Refresh it now:
-                archetype = entities.archetypeByID(entity);
 
+            // getOrPut allocated, so the archetype we retrieved earlier may no longer be a valid
+            // pointer. Refresh it now:
+            archetype = entities.archetypeByID(entity);
+
+            if (!archetype_entry.found_existing) {
                 const columns = entities.allocator.alloc(Column, archetype.columns.len + 1) catch |err| {
                     assert(entities.archetypes.swapRemove(new_hash));
                     return err;
@@ -653,11 +654,12 @@ pub fn Entities(all_components: anytype) type {
             // guarantee that archetype (A, C) exists - and so removing a component sometimes does
             // require creating a new archetype table!
             var archetype_entry = try entities.archetypes.getOrPut(entities.allocator, new_hash);
-            if (!archetype_entry.found_existing) {
-                // getOrPut allocated, so the archetype we retrieved earlier may no longer be a valid
-                // pointer. Refresh it now:
-                archetype = entities.archetypeByID(entity);
 
+            // getOrPut allocated, so the archetype we retrieved earlier may no longer be a valid
+            // pointer. Refresh it now:
+            archetype = entities.archetypeByID(entity);
+
+            if (!archetype_entry.found_existing) {
                 const columns = entities.allocator.alloc(Column, archetype.columns.len - 1) catch |err| {
                     assert(entities.archetypes.swapRemove(new_hash));
                     return err;


### PR DESCRIPTION
The reference to the old archetype is invalidated by getOrPut() calls of
std.ArrayHashMap. The implementation of std.ArrayHashMap means that
pointers can be invalidated on getOrPut() calls _even if the key exists
in the map_. This means that the reference to the old archetype needs to
be refreshed unconditionally (i.e. not only if the new archetype didn't
exist previously).

Maybe it's worth suggesting upstream that `std.ArrayHashMap` changes so `getOrPut()` doesn't invalidate pointers if the key exists. The issue is that `getOrPut()` calls `ensureTotalCapacity()` to make sure there is a free element, thus invalidating pointers if the map is full.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.