### PR TITLE
{mach, js-runtime}: Changes for future audio backend

### DIFF
--- a/js-runtime/src/js-runtime.js
+++ b/js-runtime/src/js-runtime.js
@@ -331,15 +331,14 @@ const zig = {
     return values[id].length;
   },
 
-  zigConstructType(id, args, args_len, ret_ptr) {
+  zigConstructType(id, args, args_len) {
     let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
     let argv = [];
     for (let i = 0; i < args_len; i += 1) {
       argv.push(zig.readObject(memory.slice(args + i * 16), memory));
     }
 
-    const result = zig.addValue(new values[id](argv));
-    zig.writeObject(memory.slice(ret_ptr), result, 0);
+    return zig.addValue(new values[id](argv));
   },
 
   wzLogWrite(str, len) {

--- a/js-runtime/src/main.zig
+++ b/js-runtime/src/main.zig
@@ -21,7 +21,7 @@ const js = struct {
     extern fn zigFunctionCall(id: u64, name: [*]const u8, len: u32, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
     extern fn zigFunctionInvoke(id: u64, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
     extern fn zigGetParamCount(id: u64) u32;
-    extern fn zigConstructType(id: u64, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
+    extern fn zigConstructType(id: u64, args: ?*const anyopaque, args_len: u32) u32;
     extern fn zigCleanupObject(id: u64) void;
 };
 
@@ -163,10 +163,8 @@ pub const Function = struct {
         return js.zigGetParamCount(func.ref);
     }
 
-    pub fn construct(func: *const Function, args: []const Value) Value {
-        var ret: Value = undefined;
-        js.zigConstructType(func.ref, args.ptr, args.len, &ret);
-        return ret;
+    pub fn construct(func: *const Function, args: []const Value) Object {
+        return .{ .ref = js.zigConstructType(func.ref, args.ptr, args.len) };
     }
 
     pub fn invoke(func: *const Function, args: []const Value) Value {
@@ -253,7 +251,7 @@ pub fn createFunction(fun: FunType) Function {
     return .{ .ref = js.zigCreateFunction(&fun) };
 }
 
-pub fn constructType(t: []const u8, args: []const Value) Value {
+pub fn constructType(t: []const u8, args: []const Value) Object {
     const constructor = global().get(t).view(.func);
     defer constructor.deinit();
 


### PR DESCRIPTION
- Expose js-runtime pkg to the final app file, while in the way, simplified some stuffs with mach.App (in build.zig). Now using a platform field for simplification instead of the old ``target.toTarget()....`` which is good partially because toTarget() is deprecated. The type can be made private in future but leaving it pub for now.
- ``js.constructType()`` and ``js.Function.construct()`` now returns a ``js.Object`` 

I will make the name change ``js-runtime -> sysjs`` PR after this is merged.

---

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.