### PR TITLE
{sysaudio,sysjs}: Implement playback with data_callback

### DIFF
--- a/sysaudio/src/webaudio.zig
+++ b/sysaudio/src/webaudio.zig
@@ -54,6 +54,7 @@ pub fn waitEvents(_: Audio) void {}
 
 const default_channel_count = 2;
 const default_sample_rate = 48000;
+const default_buffer_size = 512;
 
 pub fn requestDevice(audio: Audio, config: DeviceDescriptor) Error!Device {
     // NOTE: WebAudio only supports F32 audio format, so config.format is unused
@@ -71,7 +72,7 @@ pub fn requestDevice(audio: Audio, config: DeviceDescriptor) Error!Device {
     const input_channels = if (mode == .input) js.createNumber(@intToFloat(f64, channels)) else js.createUndefined();
     const output_channels = if (mode == .output) js.createNumber(@intToFloat(f64, channels)) else js.createUndefined();
 
-    const node = context.call("createScriptProcessor", &.{ js.createNumber(4096), input_channels, output_channels }).view(.object);
+    const node = context.call("createScriptProcessor", &.{ js.createNumber(default_buffer_size), input_channels, output_channels }).view(.object);
     defer node.deinit();
 
     context.set("node", node.toValue());
@@ -88,9 +89,7 @@ pub fn requestDevice(audio: Audio, config: DeviceDescriptor) Error!Device {
         _ = node.call("connect", &.{destination.toValue()});
     }
 
-    return Device{
-        .context = context,
-    };
+    return Device{ .context = context };
 }
 
 fn audioProcessEvent(args: js.Object, _: usize) js.Value {

--- a/sysjs/src/mach-sysjs.js
+++ b/sysjs/src/mach-sysjs.js
@@ -108,10 +108,10 @@ const zig = {
     return zig.addValue(memory.getString(str, len));
   },
 
-  zigCreateFunction(id) {
+  zigCreateFunction(id, captures, len) {
     return zig.addValue(function () {
       const args = zig.addValue(arguments);
-      zig.wasm.exports.wasmCallFunction(id, args, arguments.length);
+      zig.wasm.exports.wasmCallFunction(id, args, arguments.length, captures, len);
       const return_value = values[args]["return_value"];
       zig.zigCleanupObject(args);
       return return_value;

--- a/sysjs/src/mach-sysjs.js
+++ b/sysjs/src/mach-sysjs.js
@@ -338,7 +338,7 @@ const zig = {
       argv.push(zig.readObject(memory.slice(args + i * 16), memory));
     }
 
-    return zig.addValue(new values[id](argv));
+    return zig.addValue(new values[id](...argv));
   },
 
   wzLogWrite(str, len) {


### PR DESCRIPTION
Read individual commit messages for more info

The audio playback implementation itself is quite standard, and processing is done on per sample basis. Currently sample format in data callback is hard coded to f32. Even though WebAudio doesn't supports any other format, it should be a []u8 (probably) so that use can bit cast it as per they want. 

The callback itself along with user_data are stored on JS side. JS can technically store opaque pointers, but we dont have any custom function to handle it yet, so just cast to and fro f64, it should be cleaned up someday.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.