### PR TITLE
freetype: fix tests for stage2 and Face.getGlyphName()

### DIFF
--- a/freetype/src/freetype/Face.zig
+++ b/freetype/src/freetype/Face.zig
@@ -137,10 +137,8 @@ pub fn getTrackKerning(self: Face, point_size: i32, degree: i32) Error!i32 {
     return kerning;
 }
 
-pub fn getGlyphName(self: Face, index: u32) Error![]const u8 {
-    var buf: [32]u8 = undefined;
-    try intToError(c.FT_Get_Glyph_Name(self.handle, index, &buf, buf.len));
-    return std.mem.sliceTo(&buf, 0);
+pub fn getGlyphName(self: Face, index: u32, buf: []u8) Error!void {
+    try intToError(c.FT_Get_Glyph_Name(self.handle, index, buf.ptr, @intCast(c_uint, buf.len)));
 }
 
 pub fn getPostscriptName(self: Face) ?[:0]const u8 {

--- a/freetype/src/harfbuzz/main.zig
+++ b/freetype/src/harfbuzz/main.zig
@@ -9,6 +9,11 @@ pub const c = @import("c");
 
 const std = @import("std");
 
+// Remove once the stage2 compiler fixes pkg std not found
+comptime {
+    _ = @import("utils");
+}
+
 test {
     std.testing.refAllDeclsRecursive(@import("blob.zig"));
     std.testing.refAllDeclsRecursive(@import("buffer.zig"));

--- a/freetype/test/main.zig
+++ b/freetype/test/main.zig
@@ -1,4 +1,5 @@
-const testing = @import("std").testing;
+const std = @import("std");
+const testing = std.testing;
 const freetype = @import("freetype");
 
 const firasans_font_path = "upstream/assets/FiraSans-Regular.ttf";
@@ -79,5 +80,7 @@ test "get name index" {
 test "get index name" {
     const lib = try freetype.Library.init();
     const face = try lib.newFace(firasans_font_path, 0);
-    try testing.expectEqualStrings(try face.getGlyphName(1120), "summation");
+    var buf: [32]u8 = undefined;
+    try face.getGlyphName(1120, &buf);
+    try testing.expectEqualStrings(std.mem.sliceTo(&buf, 0), "summation");
 }


### PR DESCRIPTION

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

The harfbuzz tests randomly failed to compile with stage2. With the usual fix it doesn't fail anymore, but I wonder how it managed to compile before, and since the behaviour is random there must be some UB in the compiler regarding this. Should I write about this in the stage2 issue?

Also `Face.getGlyphName()` returned a slice from a buffer on the Stack. I decided to pass the slice to the function, so that memory management of the buffer is left to the user, though this means that the user still has to call `sliceTo()` on his buffer to get the actual string.