### PR TITLE
glfw: add shared option which builds glfw into it's own shared library

### DIFF
--- a/glfw/build.zig
+++ b/glfw/build.zig
@@ -8,15 +8,24 @@ pub fn build(b: *Builder) void {
     const target = b.standardTargetOptions(.{});
 
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&testStep(b, mode, target, "glfw_tests", .{}).step);
-    test_step.dependOn(&testStep(b, mode, target, "glfw_shared_tests", .{ .shared = true }).step);
+    test_step.dependOn(&testStep(b, mode, target).step);
+    test_step.dependOn(&testStepShared(b, mode, target).step);
 }
 
-pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, exe_name: []const u8, options: Options) *std.build.RunStep {
-    const main_tests = b.addTestExe(exe_name, thisDir() ++ "/src/main.zig");
+pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+    const main_tests = b.addTestExe("glfw_tests", thisDir() ++ "/src/main.zig");
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
-    link(b, main_tests, options);
+    link(b, main_tests, .{});
+    main_tests.install();
+    return main_tests.run();
+}
+
+fn testStepShared(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+    const main_tests = b.addTestExe("glfw_tests_shared", thisDir() ++ "/src/main.zig");
+    main_tests.setBuildMode(mode);
+    main_tests.setTarget(target);
+    link(b, main_tests, .{ .shared = true });
     main_tests.install();
     return main_tests.run();
 }


### PR DESCRIPTION
This adds the `shared` option, which builds GLFW into it's own shared library. 

The use case for this is as follows (in this setup, the exe loads the game dll at runtime using std.DynLib):
```
    // Engine launcher
    const exe = b.addExecutable("ion", "src/main.zig");
    {
         ... setup the exe build step ...
        exe.addPackage(glfw.pkg);
        glfw.link(b, exe, .{
            .shared = true
        });
    }

    // Game dll
    const game = b.addSharedLibrary("game", "game/src/game.zig", .unversioned);
    {
        ... setup the game build step ...
        game.addPackage(glfw.pkg);
        glfw.link(b, game, .{
            .shared = true
        });
    }
```

This way, both `game` and `exe` link with the shared library, so that there is one copy of the `_glfw` global state in the process. Static linking wouldn't work here, as the dll and exe would have separate copies of `_glfw`.

A couple things I'm not sure about:
- I opted to cache the shared library for each call (create it on the first `glfw.link` call and re-used the instance across calls). The other option would be a separate call (ie. `glfw.createSharedGlfw`) to create the shared lib, and you'd pass *that* as the option instead of a bool. I'm happy to change over to that, but I was trying to keep the API simple.
- Specifying `zig-out/bin` as the output dir - this works in the simple case, but may break if that directory has been changed on the parent step. The intention is to place the dll next to whatever exe/dll is linking with it, but I'm not familiar enough with the build system to know how to get that automatically.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.