### PR TITLE
gamemode: Fix gamemode package path in build.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -227,7 +227,7 @@ pub const App = struct {
                 exe.addPackage(glfw.pkg);
 
                 if (target.os.tag == .linux) {
-                    exe.addPackagePath("gamemode", "gamemode/gamemode.zig");
+                    exe.addPackagePath("gamemode", thisDir() ++ "/gamemode/gamemode.zig");
                 }
 
                 break :blk exe;


### PR DESCRIPTION

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

Forgot to use `thisDir() ++ "/gamemode/gamemode.zig` in build.zig