### PR TITLE
CI: remove unneeded builds on sub-projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - name: launch xvfb
         run: Xvfb :99 -screen 0 1680x720x24 > /dev/null 2>&1 &
       - name: test
+        if: matrix.project == '.'
         run: |
           sudo add-apt-repository -y ppa:kisak/kisak-mesa
           sudo apt-get update
@@ -49,9 +50,6 @@ jobs:
           cd ${{ matrix.project }} && zig build test
   x86_64-windows:
     runs-on: windows-latest
-    strategy:
-      matrix:
-        project: ['.', 'glfw', 'freetype']
     # We want to run on external PRs, but not on our own internal PRs as they'll be run by the push
     # to the branch.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -68,15 +66,11 @@ jobs:
           7z x zig.zip
           Add-Content $env:GITHUB_PATH 'C:\zig-windows-x86_64-0.10.0-dev.3027+0e26c6149\'
       - name: compile all examples
-        if: matrix.project == '.'
-        run: cd ${{ matrix.project }} && zig build compile-all
+        run: zig build compile-all
       - name: test
-        run: cd ${{ matrix.project }} && zig build test
+        run: zig build test
   x86_64-macos:
     runs-on: macos-latest
-    strategy:
-      matrix:
-        project: ['.', 'glfw', 'freetype']
     # We want to run on external PRs, but not on our own internal PRs as they'll be run by the push
     # to the branch.
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -89,6 +83,6 @@ jobs:
           brew install xz
           sudo sh -c 'wget -c https://ziglang.org/builds/zig-macos-x86_64-0.10.0-dev.3027+0e26c6149.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: test
-        run: cd ${{ matrix.project }} && zig build test
+        run: zig build test
         env:
           AGREE: true

--- a/.github/workflows/m1_ci.yml
+++ b/.github/workflows/m1_ci.yml
@@ -11,12 +11,9 @@ jobs:
   aarch64-macos:
     if: ${{ github.repository == 'hexops/mach' }}
     runs-on: [self-hosted, macOS, ARM64]
-    strategy:
-      matrix:
-        project: [".", "glfw", "freetype"]
     defaults:
       run:
-        shell: "/usr/bin/arch -arch arm64e /bin/bash --noprofile --norc -eo pipefail {0}"
+        shell: '/usr/bin/arch -arch arm64e /bin/bash --noprofile --norc -eo pipefail {0}'
     steps:
       - name: Clean repository submodules
         # See https://github.com/actions/checkout/issues/385
@@ -33,10 +30,8 @@ jobs:
         env:
           AGREE: true
       - name: compile all examples
-        if: matrix.project == '.'
-        run: cd ${{ matrix.project }} && zig build compile-all
+        run: zig build compile-all
         env:
           AGREE: true
       - name: compile all examples (WASM)
-        if: matrix.project == '.'
-        run: cd ${{ matrix.project }} && zig build compile-all -Dtarget=wasm32-freestanding-none
+        run: zig build compile-all -Dtarget=wasm32-freestanding-none

--- a/build.zig
+++ b/build.zig
@@ -29,7 +29,6 @@ pub fn build(b: *std.build.Builder) void {
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.run().step);
     test_step.dependOn(&gpu.testStep(b, mode, target, @bitCast(gpu.Options, options)).step);
-    test_step.dependOn(&gpu_dawn.testStep(b, mode, target).step);
     test_step.dependOn(&glfw.testStep(b, mode, target).step);
     test_step.dependOn(&ecs.testStep(b, mode, target).step);
     test_step.dependOn(&freetype.testStep(b, mode, target).step);


### PR DESCRIPTION
Fixes #448 

gpu-dawn testStep has been removed in https://github.com/hexops/mach/commit/fbfd2f336b33019bb4d5d5c5a4fea56183cb8c3d but you forgot to remove it from `build.zig`

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.