### PR TITLE
shaderexp: Use fullscreen triangle instead of quad, move vertex data into the shader

### DIFF
--- a/shaderexp/main.zig
+++ b/shaderexp/main.zig
@@ -139,7 +139,7 @@ pub fn update(app: *App, core: *mach.Core) !void {
     const pass = encoder.beginRenderPass(&render_pass_info);
     pass.setPipeline(app.pipeline);
     pass.setBindGroup(0, app.bind_group, &.{0});
-    pass.draw(6, 1, 0, 0);
+    pass.draw(3, 1, 0, 0);
     pass.end();
     pass.release();
 

--- a/shaderexp/vert.wgsl
+++ b/shaderexp/vert.wgsl
@@ -1,29 +1,23 @@
 struct VertexOut {
-     @builtin(position) position_clip : vec4<f32>,
-     @location(0) frag_uv : vec2<f32>,
+    @builtin(position) position_clip : vec4<f32>,
+    @location(0) frag_uv : vec2<f32>,
 }
 
 @vertex fn main(@builtin(vertex_index) index : u32) -> VertexOut {
-    var pos = array<vec2<f32>, 6>(
-      vec2<f32>(-1.0, -1.0),
-      vec2<f32>( 1.0, -1.0),
-      vec2<f32>( 1.0,  1.0),
-      vec2<f32>( 1.0,  1.0),
-      vec2<f32>(-1.0,  1.0),
-      vec2<f32>(-1.0, -1.0)
+    var pos = array<vec2<f32>, 3>(
+        vec2<f32>(-1.0, -1.0),
+        vec2<f32>( 3.0, -1.0),
+        vec2<f32>(-1.0,  3.0),
     );
 
-    var uv = array<vec2<f32>, 6>(
-      vec2<f32>(0.0, 0.0),
-      vec2<f32>(1.0, 0.0),
-      vec2<f32>(1.0, 1.0),
-      vec2<f32>(1.0, 1.0),
-      vec2<f32>(0.0, 1.0),
-      vec2<f32>(0.0, 0.0)
+    var uv = array<vec2<f32>, 3>(
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(2.0, 0.0),
+        vec2<f32>(0.0, 2.0),
     );
 
-     var output : VertexOut;
-     output.position_clip = vec4<f32>(pos[index], 0.0, 1.0);
-     output.frag_uv = uv[index];
-     return output;
+    var output : VertexOut;
+    output.position_clip = vec4<f32>(pos[index], 0.0, 1.0);
+    output.frag_uv = uv[index];
+    return output;
 }

--- a/shaderexp/vert.wgsl
+++ b/shaderexp/vert.wgsl
@@ -3,12 +3,27 @@ struct VertexOut {
      @location(0) frag_uv : vec2<f32>,
 }
 
-@vertex fn main(
-     @location(0) position : vec4<f32>,
-     @location(1) uv : vec2<f32>
-) -> VertexOut {
+@vertex fn main(@builtin(vertex_index) index : u32) -> VertexOut {
+    var pos = array<vec2<f32>, 6>(
+      vec2<f32>(-1.0, -1.0),
+      vec2<f32>( 1.0, -1.0),
+      vec2<f32>( 1.0,  1.0),
+      vec2<f32>( 1.0,  1.0),
+      vec2<f32>(-1.0,  1.0),
+      vec2<f32>(-1.0, -1.0)
+    );
+
+    var uv = array<vec2<f32>, 6>(
+      vec2<f32>(0.0, 0.0),
+      vec2<f32>(1.0, 0.0),
+      vec2<f32>(1.0, 1.0),
+      vec2<f32>(1.0, 1.0),
+      vec2<f32>(0.0, 1.0),
+      vec2<f32>(0.0, 0.0)
+    );
+
      var output : VertexOut;
-     output.position_clip = position;
-     output.frag_uv = uv;
+     output.position_clip = vec4<f32>(pos[index], 0.0, 1.0);
+     output.frag_uv = uv[index];
      return output;
 }


### PR DESCRIPTION
Using a fullscreen triangle is (very) marginally better than a quad because it avoids overdraw and isn't any more complicated. Moving the static vertex data for the fullscreen primitive into the shader simplifies command buffer recording and pipeline layout.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.