### PR TITLE
all: add sysaudio example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -72,6 +72,7 @@ pub fn build(b: *std.build.Builder) void {
         .{ .name = "ecs-app", .packages = &[_]Pkg{} },
         .{ .name = "image-blur", .packages = &[_]Pkg{Packages.zigimg}, .has_assets = true },
         .{ .name = "map-async", .packages = &[_]Pkg{} },
+        .{ .name = "sysaudio", .packages = &[_]Pkg{} },
         // NOTE: examples with std_platform_only should be placed at last
         .{ .name = "gkurve", .packages = &[_]Pkg{ Packages.zmath, Packages.zigimg, freetype.pkg }, .std_platform_only = true, .has_assets = true },
     }) |example| {
@@ -277,7 +278,7 @@ pub const App = struct {
             // Set install directory to '{prefix}/www'
             app.getInstallStep().?.dest_dir = web_install_dir;
 
-            inline for (.{ "/src/platform/mach.js", "/sysjs/src/mach-sysjs.js" }) |js| {
+            inline for (.{ "/src/platform/mach.js", "/libs/sysjs/src/mach-sysjs.js" }) |js| {
                 const install_js = app.b.addInstallFileWithDir(
                     .{ .path = (comptime thisDir()) ++ js },
                     web_install_dir,

--- a/examples/sysaudio/main.zig
+++ b/examples/sysaudio/main.zig
@@ -1,0 +1,170 @@
+const std = @import("std");
+const mach = @import("mach");
+const sysaudio = mach.sysaudio;
+const js = mach.sysjs;
+
+pub const App = @This();
+
+audio: sysaudio,
+device: sysaudio.Device,
+tone_engine: ToneEngine = .{},
+
+pub fn init(app: *App, _: *mach.Core) !void {
+    const audio = try sysaudio.init();
+    errdefer audio.deinit();
+
+    const device = try audio.requestDevice(.{ .mode = .output, .channels = 1 });
+    errdefer device.deinit();
+
+    device.setCallback(callback, app);
+    device.start();
+
+    app.audio = audio;
+    app.device = device;
+}
+
+fn callback(_: *sysaudio.Device, user_data: ?*anyopaque, buffer: []u8) void {
+    // TODO(sysaudio): should make user_data pointer type-safe
+    const app: *App = @ptrCast(*App, @alignCast(@alignOf(App), user_data));
+
+    // Where the magic happens: fill our audio buffer with PCM dat.
+    app.tone_engine.render(buffer);
+}
+
+pub fn deinit(app: *App, _: *mach.Core) void {
+    app.device.deinit();
+    app.audio.deinit();
+}
+
+pub fn update(app: *App, engine: *mach.Core) !void {
+    while (engine.pollEvent()) |event| {
+        switch (event) {
+            .key_press => |ev| {
+                app.device.start();
+                app.tone_engine.play(ToneEngine.keyToFrequency(ev.key));
+            },
+            else => {},
+        }
+    }
+    app.audio.waitEvents();
+}
+
+// A simple tone engine.
+//
+// It renders 2048 tones simultaneously, each with their own frequency and duration.
+//
+// `keyToFrequency` can be used to convert a keyboard key to a frequency, so that the
+// keys asdfghj on your QWERTY keyboard will map to the notes C/D/E/F/G/A/B[4], the
+// keys above qwertyu will map to C5 and the keys below zxcvbnm will map to C3.
+//
+// The duration is hard-coded to 1.5s. To prevent clicking, tones are faded in linearly over
+// the first 1/64th duration of the tone. To provide a cool sustained effect, tones are faded
+// out using 1-log10(x*10) (google it to see how it looks, it's strong for most of the duration of
+// the note then fades out slowly.)
+pub const ToneEngine = struct {
+    playing: [2048]Tone = std.mem.zeroes([2048]Tone),
+
+    const Tone = struct {
+        frequency: f32,
+        sample_counter: usize,
+        duration: usize,
+    };
+
+    pub fn render(engine: *ToneEngine, buffer: []u8) void {
+        // TODO(sysaudio): demonstrate how to properly handle format of the buffer here.
+        // Right now we blindly assume f32 format, which is wrong (but always right in WASM.)
+        //
+        // TODO(sysaudio): get sample rate from callback, don't hard-code it here.
+        const sample_rate = 44100.0;
+        const buf = @ptrCast([*]f32, @alignCast(@alignOf(f32), buffer.ptr))[0 .. buffer.len / @sizeOf(f32)];
+
+        for (buf) |_, i| {
+            var sample: f32 = 0;
+            for (engine.playing) |*tone| {
+                if (tone.sample_counter >= tone.duration) {
+                    continue;
+                }
+                tone.sample_counter += 1;
+                const sample_counter = @intToFloat(f32, tone.sample_counter);
+                const duration = @intToFloat(f32, tone.duration);
+
+                // The sine wave that plays the frequency.
+                const sine_wave = std.math.sin(tone.frequency * 2.0 * std.math.pi * sample_counter / sample_rate);
+
+                // A number ranging from 0.0 to 1.0 in the first 1/64th of the duration of the tone.
+                const fade_in = std.math.min(sample_counter / (duration / 64.0), 1.0);
+
+                // A number ranging from 1.0 to 0.0 over half the duration of the tone.
+                const progression = sample_counter / duration; // 0.0 (tone start) to 1.0 (tone end)
+                const fade_out = 1.0 - std.math.clamp(std.math.log10(progression * 10.0), 0.0, 1.0);
+
+                // Mix this tone into the sample we'll actually play on e.g. the speakers, reducing
+                // sine wave intensity if we're fading in or out over the entire duration of the
+                // tone.
+                sample += sine_wave * fade_in * fade_out;
+            }
+
+            buf[i] = sample;
+        }
+    }
+
+    pub fn play(engine: *ToneEngine, frequency: f32) void {
+        const sample_rate = 44100.0;
+
+        for (engine.playing) |*tone| {
+            if (tone.sample_counter >= tone.duration) {
+                tone.* = Tone{
+                    .frequency = frequency,
+                    .sample_counter = 0,
+                    .duration = 1.5 * sample_rate, // play the tone for 1.5s
+                };
+                return;
+            }
+        }
+    }
+
+    pub fn keyToFrequency(key: mach.Key) f32 {
+        // The frequencies here just come from a piano frequencies chart. You can google for them.
+        return switch (key) {
+            // First row of piano keys, the highest.
+            .q => 523.25, // C5
+            .w => 587.33, // D5
+            .e => 659.26, // E5
+            .r => 698.46, // F5
+            .t => 783.99, // G5
+            .y => 880.0, // A5
+            .u => 987.77, // B5
+            .i => 1046.5, // C6
+            .o => 1174.7, // D6
+            .p => 1318.5, // E6
+            .left_bracket => 1396.9, // F6
+            .right_bracket => 1568.0, // G6
+
+            // Second row of piano keys, the middle.
+            .a => 261.63, // C4
+            .s => 293.67, // D4
+            .d => 329.63, // E4
+            .f => 349.23, // F4
+            .g => 392.0, // G4
+            .h => 440.0, // A4
+            .j => 493.88, // B4
+            .k => 523.25, // C5
+            .l => 587.33, // D5
+            .semicolon => 659.26, // E5
+            .apostrophe => 698.46, // F5
+
+            // Third row of piano keys, the lowest.
+            .z => 130.81, // C3
+            .x => 146.83, // D3
+            .c => 164.81, // E3
+            .v => 174.61, // F3
+            .b => 196.00, // G3
+            .n => 220.0, // A3
+            .m => 246.94, // B3
+            .comma => 261.63, // C4
+            .period => 293.67, // D4
+            .slash => 329.63, // E5
+            else => 0.0,
+        };
+    }
+};

--- a/libs/sysaudio/build.zig
+++ b/libs/sysaudio/build.zig
@@ -7,7 +7,7 @@ const soundio_path = thisDir() ++ "/upstream/soundio";
 pub const pkg = std.build.Pkg{
     .name = "sysaudio",
     .source = .{ .path = thisDir() ++ "/src/main.zig" },
-    .dependencies = &.{sysjs.pkg},
+    .dependencies = &.{ sysjs.pkg, soundio_pkg },
 };
 
 const soundio_pkg = std.build.Pkg{

--- a/libs/sysaudio/soundio/InStream.zig
+++ b/libs/sysaudio/soundio/InStream.zig
@@ -25,6 +25,10 @@ pub fn start(self: InStream) Error!void {
     try intToError(c.soundio_instream_start(self.handle));
 }
 
+pub fn pause(self: InStream) Error!void {
+    try intToError(c.soundio_instream_pause(self.handle));
+}
+
 pub fn beginWrite(self: InStream, areas: [*]?[*]c.SoundIoChannelArea, frame_count: *i32) Error!void {
     try intToError(c.soundio_instream_begin_write(
         self.handle,

--- a/libs/sysaudio/soundio/OutStream.zig
+++ b/libs/sysaudio/soundio/OutStream.zig
@@ -25,6 +25,10 @@ pub fn start(self: OutStream) Error!void {
     try intToError(c.soundio_outstream_start(self.handle));
 }
 
+pub fn pause(self: OutStream) Error!void {
+    try intToError(c.soundio_outstream_pause(self.handle));
+}
+
 pub fn beginWrite(self: OutStream, areas: [*]?[*]c.SoundIoChannelArea, frame_count: *i32) Error!void {
     try intToError(c.soundio_outstream_begin_write(
         self.handle,

--- a/libs/sysaudio/src/main.zig
+++ b/libs/sysaudio/src/main.zig
@@ -55,8 +55,8 @@ pub fn waitEvents(self: Audio) void {
     self.backend.waitEvents();
 }
 
-pub fn requestDevice(self: Audio, config: DeviceDescriptor) Error!Device {
-    return self.backend.requestDevice(config);
+pub fn requestDevice(self: Audio, allocator: std.mem.Allocator, config: DeviceDescriptor) Error!*Device {
+    return self.backend.requestDevice(allocator, config);
 }
 
 pub fn inputDeviceIterator(self: Audio) DeviceIterator {

--- a/libs/sysaudio/src/soundio.zig
+++ b/libs/sysaudio/src/soundio.zig
@@ -7,6 +7,7 @@ const SoundIo = @import("soundio").SoundIo;
 const SoundIoDevice = @import("soundio").Device;
 const SoundIoInStream = @import("soundio").InStream;
 const SoundIoOutStream = @import("soundio").OutStream;
+
 const SoundIoStream = union(Mode) {
     input: SoundIoInStream,
     output: SoundIoOutStream,
@@ -15,27 +16,125 @@ const SoundIoStream = union(Mode) {
 const Audio = @This();
 
 pub const DataCallback = if (@import("builtin").zig_backend == .stage1)
-    fn (device: Device, frame_count: u32) void
+    fn (device: *Device, user_data: ?*anyopaque, buffer: []u8) void
 else
-    *const fn (device: Device, frame_count: u32) void;
+    *const fn (device: *Device, user_data: ?*anyopaque, buffer: []u8) void;
 
 pub const Device = struct {
+    descriptor: DeviceDescriptor,
+
+    // Internal fields.
     handle: SoundIoStream,
     data_callback: ?DataCallback = null,
     user_data: ?*anyopaque = null,
+    planar_buffer: [512000]u8 = undefined,
 
-    pub fn setCallback(self: Device, callback: DataCallback, data: *anyopaque) void {
-        self.data_callback = callback;
-        self.user_data = data;
-    }
-
-    pub fn deinit(self: Device) void {
-        return switch (self.handle) {
+    pub fn deinit(self: *Device, allocator: std.mem.Allocator) void {
+        switch (self.handle) {
             .input => |d| d.deinit(),
             .output => |d| d.deinit(),
+        }
+        allocator.destroy(self);
+    }
+
+    pub fn setCallback(self: *Device, callback: DataCallback, data: *anyopaque) void {
+        self.data_callback = callback;
+        self.user_data = data;
+        switch (self.handle) {
+            .input => |_| @panic("input not supported yet"),
+            .output => |d| {
+                // TODO(sysaudio): support other formats
+                d.setFormat(.float32LE);
+
+                d.setWriteCallback((struct {
+                    fn cCallback(
+                        c_outstream: ?[*]c.SoundIoOutStream,
+                        frame_count_min: c_int,
+                        frame_count_max: c_int,
+                    ) callconv(.C) void {
+                        _ = frame_count_min;
+                        const outstream = SoundIoOutStream{ .handle = @ptrCast(*c.SoundIoOutStream, c_outstream) };
+                        const device = @ptrCast(*Device, @alignCast(@alignOf(Device), outstream.handle.userdata));
+
+                        // TODO(sysaudio): provide callback with outstream.sampleRate()
+
+                        // TODO(sysaudio): according to issue tracker and PR from mason (did we include it?)
+                        // there may be issues with frame_count_max being way too large on Windows. May need
+                        // to artificially limit it or use Mason's PR.
+
+                        // The data callback gives us planar data, e.g. in AAAABBBB format for channels
+                        // A and B. WebAudio similarly requires data in planar format. libsoundio however
+                        // does not guarantee planar data format, it may be in interleaved format ABABABAB.
+                        // Invoke our data callback with a temporary buffer, this involves one copy later
+                        // but it's such a small amount of memory it is entirely negligible.
+                        const layout = outstream.layout();
+                        const total_frame_count = @intCast(usize, frame_count_max);
+                        const buffer_size: usize = @sizeOf(f32) * total_frame_count * @intCast(usize, layout.channelCount());
+                        const addr = @ptrToInt(&device.planar_buffer);
+                        const aligned_addr = std.mem.alignForward(addr, @alignOf(f32));
+                        const padding = aligned_addr - addr;
+                        const planar_buffer = device.planar_buffer[padding..buffer_size];
+                        device.data_callback.?(device, device.user_data.?, planar_buffer);
+
+                        var frames_left = total_frame_count;
+                        while (frames_left > 0) {
+                            var frame_count: i32 = @intCast(i32, frames_left);
+
+                            var areas: [*]c.SoundIoChannelArea = undefined;
+                            // TODO(sysaudio): improve error handling
+                            outstream.beginWrite(
+                                @ptrCast([*]?[*]c.SoundIoChannelArea, &areas),
+                                &frame_count,
+                            ) catch |err| std.debug.panic("write failed: {s}", .{@errorName(err)});
+
+                            if (frame_count == 0) break;
+
+                            var channel: usize = 0;
+                            while (channel < @intCast(usize, layout.channelCount())) : (channel += 1) {
+                                const channel_ptr = areas[channel].ptr;
+                                var frame: c_int = 0;
+                                while (frame < frame_count) : (frame += 1) {
+                                    const sample_start = (channel * total_frame_count * @sizeOf(f32)) + (@intCast(usize, frame) * @sizeOf(f32));
+                                    const src = @ptrCast(*f32, @alignCast(@alignOf(f32), &planar_buffer[sample_start]));
+                                    const dst = &channel_ptr[@intCast(usize, areas[channel].step * frame)];
+                                    @ptrCast(*f32, @alignCast(@alignOf(f32), dst)).* = src.*;
+                                }
+                            }
+                            // TODO(sysaudio): improve error handling
+                            outstream.endWrite() catch |err| std.debug.panic("end write failed: {s}", .{@errorName(err)});
+                            frames_left -= @intCast(usize, frame_count);
+                        }
+                    }
+                }).cCallback);
+            },
+        }
+    }
+
+    pub fn pause(device: *Device) Error!void {
+        return (switch (device.handle) {
+            .input => |d| d.pause(),
+            .output => |d| d.pause(),
+        }) catch |err| {
+            return switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                else => @panic(@errorName(err)),
+            };
+        };
+    }
+
+    pub fn start(device: *Device) Error!void {
+        return (switch (device.handle) {
+            .input => |d| d.start(),
+            .output => |d| d.start(),
+        }) catch |err| {
+            return switch (err) {
+                error.OutOfMemory => error.OutOfMemory,
+                else => @panic(@errorName(err)),
+            };
         };
     }
 };
+
 pub const DeviceIterator = struct {
     ctx: Audio,
     mode: Mode,
@@ -63,6 +162,7 @@ pub const DeviceIterator = struct {
     }
 };
 
+// TODO(sysaudio): standardize errors across backends
 pub const IteratorError = error{OutOfMemory};
 pub const Error = error{
     OutOfMemory,
@@ -74,6 +174,20 @@ pub const Error = error{
     UnsupportedOS,
     UnsupportedBackend,
     DeviceUnavailable,
+    Invalid,
+    OpeningDevice,
+    BackendDisconnected,
+    SystemResources,
+    NoSuchClient,
+    IncompatibleBackend,
+    IncompatibleDevice,
+    InitAudioBackend,
+    NoSuchDevice,
+    BackendUnavailable,
+    Streaming,
+    Interrupted,
+    Underflow,
+    EncodingString,
 };
 
 handle: SoundIo,
@@ -102,46 +216,71 @@ pub fn waitEvents(self: Audio) void {
     self.handle.waitEvents();
 }
 
-pub fn requestDevice(self: Audio, config: DeviceDescriptor) Error!Device {
-    return Device{
-        .handle = blk: {
-            var sio_device: SoundIoDevice = undefined;
+pub fn requestDevice(self: Audio, allocator: std.mem.Allocator, config: DeviceDescriptor) Error!*Device {
+    var sio_device: SoundIoDevice = undefined;
 
-            if (config.id) |id| {
-                if (config.mode == null or config.is_raw == null)
-                    return error.InvalidParameter;
+    if (config.id) |id| {
+        if (config.mode == null or config.is_raw == null)
+            return error.InvalidParameter;
 
-                sio_device = switch (config.mode.?) {
-                    .input => self.handle.getInputDeviceFromID(id, config.is_raw.?),
-                    .output => self.handle.getOutputDeviceFromID(id, config.is_raw.?),
-                } orelse {
-                    return if (switch (config.mode.?) {
-                        .input => self.handle.inputDeviceCount().?,
-                        .output => self.handle.outputDeviceCount().?,
-                    } == 0)
-                        error.NoDeviceFound
-                    else
-                        error.DeviceUnavailable;
-                };
-            } else {
-                if (config.mode == null) return error.InvalidParameter;
+        sio_device = switch (config.mode.?) {
+            .input => self.handle.getInputDeviceFromID(id, config.is_raw.?),
+            .output => self.handle.getOutputDeviceFromID(id, config.is_raw.?),
+        } orelse {
+            return if (switch (config.mode.?) {
+                .input => self.handle.inputDeviceCount().?,
+                .output => self.handle.outputDeviceCount().?,
+            } == 0)
+                error.NoDeviceFound
+            else
+                error.DeviceUnavailable;
+        };
+    } else {
+        if (config.mode == null) return error.InvalidParameter;
 
-                const id = switch (config.mode.?) {
-                    .input => self.handle.defaultInputDeviceIndex(),
-                    .output => self.handle.defaultOutputDeviceIndex(),
-                } orelse return error.NoDeviceFound;
-                sio_device = switch (config.mode.?) {
-                    .input => self.handle.getInputDevice(id),
-                    .output => self.handle.getOutputDevice(id),
-                } orelse return error.DeviceUnavailable;
-            }
+        const id = switch (config.mode.?) {
+            .input => self.handle.defaultInputDeviceIndex(),
+            .output => self.handle.defaultOutputDeviceIndex(),
+        } orelse return error.NoDeviceFound;
+        sio_device = switch (config.mode.?) {
+            .input => self.handle.getInputDevice(id),
+            .output => self.handle.getOutputDevice(id),
+        } orelse return error.DeviceUnavailable;
+    }
 
-            break :blk switch (config.mode.?) {
-                .input => SoundIoStream{ .input = try sio_device.createInStream() },
-                .output => SoundIoStream{ .output = try sio_device.createOutStream() },
-            };
-        },
+    const handle = switch (config.mode.?) {
+        .input => SoundIoStream{ .input = try sio_device.createInStream() },
+        .output => SoundIoStream{ .output = try sio_device.createOutStream() },
     };
+
+    switch (handle) {
+        .input => |d| try d.open(),
+        .output => |d| try d.open(),
+    }
+
+    const device = try allocator.create(Device);
+    switch (handle) {
+        .input => |d| d.handle.userdata = device,
+        .output => |d| d.handle.userdata = device,
+    }
+    var descriptor = config;
+    descriptor.mode = descriptor.mode orelse .output;
+    descriptor.channels = @intCast(u8, switch (handle) {
+        .input => |d| d.layout().channelCount(),
+        .output => |d| d.layout().channelCount(),
+    });
+    descriptor.sample_rate = @intCast(u32, switch (handle) {
+        .input => |d| d.sampleRate(),
+        .output => |d| d.sampleRate(),
+    });
+    std.log.info("channels {}", .{descriptor.channels.?});
+    std.log.info("sample_rate {}\n", .{descriptor.sample_rate.?});
+
+    device.* = .{
+        .descriptor = descriptor,
+        .handle = handle,
+    };
+    return device;
 }
 
 pub fn outputDeviceIterator(self: Audio) DeviceIterator {

--- a/libs/sysjs/src/mach-sysjs.js
+++ b/libs/sysjs/src/mach-sysjs.js
@@ -40,6 +40,10 @@ class MemoryBlock {
     return this.getMemory().getFloat64(offset, true);
   }
 
+  getSlice(offset, len) {
+    return new Uint8Array(this.mem, offset, len);
+  }
+
   getString(offset, len) {
     return text_decoder.decode(new Uint8Array(this.mem, offset, len));
   }
@@ -250,6 +254,16 @@ const zig = {
 
   zigDeleteIndex(id, index) {
     delete values[id][index];
+  },
+
+  zigCopyBytes(id, bytes, expected_length) {
+    let memory = new MemoryBlock(zig.wasm.exports.memory.buffer);
+    const array = values[id];
+    if (array.length != expected_length) {
+      throw Error("copyBytes given array of length " + expected_length + " but destination has length " + array.length);
+    }
+    const slice = memory.getSlice(bytes, array.length);
+    array.set(slice);
   },
 
   zigGetAttributeCount(id) {

--- a/libs/sysjs/src/main.zig
+++ b/libs/sysjs/src/main.zig
@@ -18,6 +18,7 @@ const js = struct {
     extern fn zigValueEqual(val: *const anyopaque, other: *const anyopaque) bool;
     extern fn zigValueInstanceOf(val: *const anyopaque, other: *const anyopaque) bool;
     extern fn zigDeleteIndex(id: u64, index: u32) void;
+    extern fn zigCopyBytes(id: u64, bytes: [*]u8, expected_len: u32) void;
     extern fn zigFunctionCall(id: u64, name: [*]const u8, len: u32, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
     extern fn zigFunctionInvoke(id: u64, args: ?*const anyopaque, args_len: u32, ret_ptr: *anyopaque) void;
     extern fn zigGetParamCount(id: u64) u32;
@@ -138,6 +139,10 @@ pub const Object = struct {
 
     pub fn deleteIndex(obj: *const Object, index: u32) void {
         js.zigDeleteIndex(obj.ref, index);
+    }
+
+    pub fn copyBytes(obj: *const Object, bytes: []u8) void {
+        js.zigCopyBytes(obj.ref, bytes.ptr, bytes.len);
     }
 
     pub fn call(obj: *const Object, fun: []const u8, args: []const Value) Value {

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,8 @@ pub const Timer = @import("Timer.zig");
 pub const ResourceManager = @import("resource/ResourceManager.zig");
 pub const gpu = @import("gpu");
 pub const ecs = @import("ecs");
+pub const sysaudio = @import("sysaudio");
+pub const sysjs = @import("sysjs");
 
 // Engine exports
 pub const App = @import("engine.zig").App;

--- a/src/platform/wasm.zig
+++ b/src/platform/wasm.zig
@@ -232,10 +232,7 @@ pub const Platform = struct {
     }
 
     inline fn sign(val: f64) f64 {
-        return switch (val) {
-            0.0 => 0.0,
-            else => -val,
-        };
+        return if (val == 0.0) 0.0 else -val;
     }
 
     fn toMachButton(button: i32) enums.MouseButton {


### PR DESCRIPTION
After this PR, `sysaudio` works enough to run a virtual piano example in both WASM and natively:

```
zig build run-example-sysaudio -Dtarget=wasm32-freestanding-musl
```

```
zig build run-example-sysaudio
```

I uploaded the WASM example really quick to http://slimsag.com/mach/piano/ but this link probably won't stay valid for long (it will move to machengine.org later, but it needs a proper GUI.)

Simply click on the window / border area, and then type on your keyboard. It assumes QWERTY keyboard layout for now.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.