### PR TITLE
gpu-dawn:build: fix incorrect capitalization

### DIFF
--- a/libs/gpu-dawn/sdk.zig
+++ b/libs/gpu-dawn/sdk.zig
@@ -1348,7 +1348,7 @@ pub fn Sdk(deps: anytype) type {
                     "libs/DirectXShaderCompiler/lib/IRReader",
                     "libs/DirectXShaderCompiler/lib/IR",
                     "libs/DirectXShaderCompiler/lib/Linker",
-                    "libs/DirectXShaderCompiler/lib/miniz",
+                    "libs/DirectXShaderCompiler/lib/Miniz",
                     "libs/DirectXShaderCompiler/lib/Option",
                     "libs/DirectXShaderCompiler/lib/PassPrinters",
                     "libs/DirectXShaderCompiler/lib/Passes",


### PR DESCRIPTION
This fixes an incorrectly capitalized library path for `DirectXShaderCompiler`, which makes the dawn build fail on linux.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.