### PR TITLE
freetype: correct return type of Face.availableSizes

### DIFF
--- a/libs/freetype/src/Face.zig
+++ b/libs/freetype/src/Face.zig
@@ -300,11 +300,11 @@ pub fn numFixedSizes(self: Face) u32 {
     return @intCast(u32, self.handle.*.num_fixed_sizes);
 }
 
-pub fn availableSizes(self: Face) ?BitmapSize {
+pub fn availableSizes(self: Face) []BitmapSize {
     return if (self.handle.*.available_sizes != null)
-        self.handle.*.available_sizes.*
+        self.handle.*.available_sizes[0..self.numFixedSizes()]
     else
-        null;
+        &.{};
 }
 
 pub fn getAdvance(self: Face, glyph_index: u32, load_flags: LoadFlags) Error!i32 {


### PR DESCRIPTION
Face.availableSizes previously only returned the first available size - this just makes it return a slice as you'd expect.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.