### PR TITLE
{sysaudio,examples}: get sysaudio running on linux, separate audio configuration and descriptor

### DIFF
--- a/examples/sysaudio/main.zig
+++ b/examples/sysaudio/main.zig
@@ -41,7 +41,7 @@ pub fn update(app: *App, engine: *mach.Core) !void {
     while (engine.pollEvent()) |event| {
         switch (event) {
             .key_press => |ev| {
-                if (builtin.cpu.arch == .wasm32) try app.device.start();
+                try app.device.start();
                 app.tone_engine.play(app.device.properties, ToneEngine.keyToFrequency(ev.key));
             },
             else => {},

--- a/examples/sysaudio/main.zig
+++ b/examples/sysaudio/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const mach = @import("mach");
 const sysaudio = mach.sysaudio;
 const js = mach.sysjs;
+const builtin = @import("builtin");
 
 pub const App = @This();
 
@@ -40,12 +41,17 @@ pub fn update(app: *App, engine: *mach.Core) !void {
     while (engine.pollEvent()) |event| {
         switch (event) {
             .key_press => |ev| {
-                try app.device.start();
+                if (builtin.cpu.arch == .wasm32) try app.device.start();
                 app.tone_engine.play(ToneEngine.keyToFrequency(ev.key));
             },
             else => {},
         }
     }
+
+    const back_buffer_view = engine.swap_chain.?.getCurrentTextureView();
+
+    engine.swap_chain.?.present();
+    back_buffer_view.release();
 }
 
 // A simple tone engine.

--- a/libs/sysaudio/src/main.zig
+++ b/libs/sysaudio/src/main.zig
@@ -27,7 +27,7 @@ pub const Format = enum {
     F32,
 };
 
-pub const DeviceConfig = struct {
+pub const DeviceOptions = struct {
     mode: Mode = .output,
     format: ?Format = null,
     is_raw: ?bool = null,
@@ -37,7 +37,7 @@ pub const DeviceConfig = struct {
     name: ?[]const u8 = null,
 };
 
-pub const DeviceDescriptor = struct {
+pub const DeviceProperties = struct {
     mode: Mode,
     format: Format,
     is_raw: bool,
@@ -46,15 +46,15 @@ pub const DeviceDescriptor = struct {
     id: [:0]const u8,
     name: []const u8,
 
-    pub fn intoConfig(descriptor: DeviceDescriptor) DeviceConfig {
+    pub fn intoConfig(properties: DeviceProperties) DeviceOptions {
         return .{
-            .mode = descriptor.mode,
-            .format = descriptor.format,
-            .is_raw = descriptor.is_raw,
-            .channels = descriptor.channels,
-            .sample_rate = descriptor.sample_rate,
-            .id = descriptor.id,
-            .name = descriptor.name,
+            .mode = properties.mode,
+            .format = properties.format,
+            .is_raw = properties.is_raw,
+            .channels = properties.channels,
+            .sample_rate = properties.sample_rate,
+            .id = properties.id,
+            .name = properties.name,
         };
     }
 };
@@ -77,7 +77,7 @@ pub fn waitEvents(self: Audio) void {
     self.backend.waitEvents();
 }
 
-pub fn requestDevice(self: Audio, allocator: std.mem.Allocator, config: DeviceConfig) Error!*Device {
+pub fn requestDevice(self: Audio, allocator: std.mem.Allocator, config: Device.Options) Error!*Device {
     return self.backend.requestDevice(allocator, config);
 }
 
@@ -123,7 +123,7 @@ test "requestDevice behavior: null is_raw" {
     var iter = a.outputDeviceIterator();
     var device_conf = (try iter.next()) orelse return error.NoDeviceFound;
 
-    const bad_conf = DeviceConfig{
+    const bad_conf = Device.Options{
         .is_raw = null,
         .mode = device_conf.mode,
         .id = device_conf.id,
@@ -139,7 +139,7 @@ test "requestDevice behavior: invalid id" {
     // var iter = a.outputDeviceIterator();
     // var device_conf = (try iter.next()) orelse return error.NoDeviceFound;
 
-    // const bad_conf = DeviceConfig{
+    // const bad_conf = Device.Options{
     //     .is_raw = device_conf.is_raw,
     //     .mode = device_conf.mode,
     //     .id = "wrong-id",


### PR DESCRIPTION
This started with the sysaudio example running, but not showing up on my screen. @leroycep gave me a patch that made it show up by clearing the screen. 

My system is using pipewire running at a sample rate of 48000 hertz, so I was getting a lot of clicking from buffer underruns. I haven't yet fixed that because I got distracted by separating the configuration from the descriptor.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.