### PR TITLE
sysaudio: fix compile for web

### DIFF
--- a/examples/sysaudio/main.zig
+++ b/examples/sysaudio/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const mach = @import("mach");
+const gpu = @import("gpu");
 const sysaudio = mach.sysaudio;
 const js = mach.sysjs;
 const builtin = @import("builtin");
@@ -48,10 +49,12 @@ pub fn update(app: *App, engine: *mach.Core) !void {
         }
     }
 
-    const back_buffer_view = engine.swap_chain.?.getCurrentTextureView();
+    if (builtin.cpu.arch != .wasm32) {
+        const back_buffer_view = engine.swap_chain.?.getCurrentTextureView();
 
-    engine.swap_chain.?.present();
-    back_buffer_view.release();
+        engine.swap_chain.?.present();
+        back_buffer_view.release();
+    }
 }
 
 // A simple tone engine.

--- a/libs/sysaudio/src/main.zig
+++ b/libs/sysaudio/src/main.zig
@@ -27,38 +27,6 @@ pub const Format = enum {
     F32,
 };
 
-pub const DeviceOptions = struct {
-    mode: Mode = .output,
-    format: ?Format = null,
-    is_raw: ?bool = null,
-    channels: ?u8 = null,
-    sample_rate: ?u32 = null,
-    id: ?[:0]const u8 = null,
-    name: ?[]const u8 = null,
-};
-
-pub const DeviceProperties = struct {
-    mode: Mode,
-    format: Format,
-    is_raw: bool,
-    channels: u8,
-    sample_rate: u32,
-    id: [:0]const u8,
-    name: []const u8,
-
-    pub fn intoConfig(properties: DeviceProperties) DeviceOptions {
-        return .{
-            .mode = properties.mode,
-            .format = properties.format,
-            .is_raw = properties.is_raw,
-            .channels = properties.channels,
-            .sample_rate = properties.sample_rate,
-            .id = properties.id,
-            .name = properties.name,
-        };
-    }
-};
-
 const Audio = @This();
 
 backend: Backend,

--- a/libs/sysaudio/src/soundio.zig
+++ b/libs/sysaudio/src/soundio.zig
@@ -1,7 +1,5 @@
 const std = @import("std");
 const Mode = @import("main.zig").Mode;
-const DeviceOptions = @import("main.zig").DeviceOptions;
-const DeviceProperties = @import("main.zig").DeviceProperties;
 const Format = @import("main.zig").Format;
 const c = @import("soundio").c;
 const Aim = @import("soundio").Aim;
@@ -33,8 +31,25 @@ pub const Device = struct {
     planar_buffer: [512000]u8 = undefined,
     started: bool = false,
 
-    pub const Options = DeviceOptions;
-    pub const Properties = DeviceProperties;
+    pub const Options = struct {
+        mode: Mode = .output,
+        format: ?Format = null,
+        is_raw: ?bool = null,
+        channels: ?u8 = null,
+        sample_rate: ?u32 = null,
+        id: ?[:0]const u8 = null,
+        name: ?[]const u8 = null,
+    };
+
+    pub const Properties = struct {
+        mode: Mode,
+        format: Format,
+        is_raw: bool,
+        channels: u8,
+        sample_rate: u32,
+        id: [:0]const u8,
+        name: []const u8,
+    };
 
     pub fn deinit(self: *Device, allocator: std.mem.Allocator) void {
         switch (self.handle) {
@@ -165,14 +180,14 @@ pub const DeviceIterator = struct {
     device_len: u16,
     index: u16,
 
-    pub fn next(self: *DeviceIterator) IteratorError!?DeviceOptions {
+    pub fn next(self: *DeviceIterator) IteratorError!?Device.Options {
         if (self.index < self.device_len) {
             const device_desc = switch (self.mode) {
                 .input => self.ctx.handle.getInputDevice(self.index) orelse return null,
                 .output => self.ctx.handle.getOutputDevice(self.index) orelse return null,
             };
             self.index += 1;
-            return DeviceOptions{
+            return Device.Options{
                 .mode = switch (@intToEnum(Aim, device_desc.handle.aim)) {
                     .input => .input,
                     .output => .output,
@@ -240,7 +255,7 @@ pub fn waitEvents(self: Audio) void {
     self.handle.waitEvents();
 }
 
-pub fn requestDevice(self: Audio, allocator: std.mem.Allocator, options: DeviceOptions) Error!*Device {
+pub fn requestDevice(self: Audio, allocator: std.mem.Allocator, options: Device.Options) Error!*Device {
     var sio_device: SoundIoDevice = undefined;
 
     if (options.id) |id| {
@@ -313,7 +328,7 @@ pub fn requestDevice(self: Audio, allocator: std.mem.Allocator, options: DeviceO
     // };
     // const name = std.mem.sliceTo(name_ptr, 0);
 
-    var properties = DeviceProperties{
+    var properties = Device.Properties{
         .is_raw = options.is_raw orelse false,
         .format = format,
         .mode = options.mode,

--- a/src/platform/wasm.zig
+++ b/src/platform/wasm.zig
@@ -3,6 +3,7 @@ const app_pkg = @import("app");
 const Core = @import("../Core.zig");
 const structs = @import("../structs.zig");
 const enums = @import("../enums.zig");
+const gpu = @import("gpu");
 
 const js = struct {
     extern fn machCanvasInit(selector_id: *u8) CanvasId;


### PR DESCRIPTION
Fix compile errors for web, and moves the Device and Properties declarations into the backend files. 

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.