### PR TITLE
all: remove ineffective `_ = variable` assignments

### DIFF
--- a/libs/ecs/src/entities.zig
+++ b/libs/ecs/src/entities.zig
@@ -342,7 +342,6 @@ pub const void_archetype_hash = std.math.maxInt(u64);
 /// * ComponentStorage(T) is a column of data within a table for a single type of component `T`.
 pub fn Entities(comptime all_components: anytype) type {
     // TODO: validate all_components is a namespaced component set in the form we expect
-    _ = all_components;
     return struct {
         allocator: Allocator,
 

--- a/libs/glfw/src/Joystick.zig
+++ b/libs/glfw/src/Joystick.zig
@@ -62,13 +62,11 @@ const GamepadState = extern struct {
 
     /// Returns the state of the specified gamepad button.
     pub fn getButton(self: @This(), which: GamepadButton) Action {
-        _ = self;
         return @intToEnum(Action, self.buttons[@intCast(u32, @enumToInt(which))]);
     }
 
     /// Returns the status of the specified gamepad axis, in the range -1.0 to 1.0 inclusive.
     pub fn getAxis(self: @This(), which: GamepadAxis) f32 {
-        _ = self;
         return self.axes[@intCast(u32, @enumToInt(which))];
     }
 };

--- a/libs/sysaudio/src/soundio.zig
+++ b/libs/sysaudio/src/soundio.zig
@@ -73,7 +73,6 @@ pub const Device = struct {
                         frame_count_min: c_int,
                         frame_count_max: c_int,
                     ) callconv(.C) void {
-                        _ = frame_count_min;
                         const outstream = SoundIoOutStream{ .handle = @ptrCast(*c.SoundIoOutStream, c_outstream) };
                         const device = @ptrCast(*Device, @alignCast(@alignOf(Device), outstream.handle.userdata));
 

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -290,8 +290,6 @@ pub const Platform = struct {
                     }),
                     else => {},
                 }
-
-                _ = mods;
             }
         }.callback;
         platform.window.setMouseButtonCallback(mouse_button_callback);


### PR DESCRIPTION
Lastest Zig complains about this, so I must remove it to compile examples.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.