### PR TITLE
glfw: fix implicit function declaration error on clang15

### DIFF
--- a/libs/glfw/build.zig
+++ b/libs/glfw/build.zig
@@ -155,6 +155,8 @@ fn addGLFWSources(b: *Builder, lib: *std.build.LibExeObjStep, options: Options) 
                 flags.append("-D_GLFW_WAYLAND") catch unreachable;
             }
             flags.append("-I" ++ thisDir() ++ "/upstream/glfw/src") catch unreachable;
+            // TODO(upstream): glfw can't compile on clang15 without this flag
+            flags.append("-Wno-implicit-function-declaration") catch unreachable;
 
             lib.addCSourceFiles(sources.items, flags.items);
         },


### PR DESCRIPTION
Discussed in the help channel, will spit `lld` warnings:
```
ld.lld: warning: /home/arias/dev/mach/zig-cache/mach/gpu-dawn/release-777728f/x86_64-linux-gnu/release-fast/libdawn.a: archive member '/home/runner/work/mach-gpu-dawn/mach-gpu-dawn/zig-cache/o/e3b9895e4258fa9e9d779c73d05e739a/libglfw.a' is neither ET_REL nor LLVM bitcode
ld.lld: warning: /home/arias/dev/mach/zig-cache/mach/gpu-dawn/release-777728f/x86_64-linux-gnu/release-fast/libdawn.a: archive member '/home/runner/work/mach-gpu-dawn/mach-gpu-dawn/zig-cache/o/e3b9895e4258fa9e9d779c73d05e739a/libglfw.a' is neither ET_REL nor LLVM bitcode
ld.lld: warning: /home/arias/dev/mach/zig-cache/mach/gpu-dawn/release-777728f/x86_64-linux-gnu/release-fast/libdawn.a: archive member '/home/runner/.local/share/hexops/sdk-linux-x86_64/root/usr/lib/x86_64-linux-gnu/libXau.a' is neither ET_REL nor LLVM bitcode
ld.lld: warning: /home/arias/dev/mach/zig-cache/mach/gpu-dawn/release-777728f/x86_64-linux-gnu/release-fast/libdawn.a: archive member '/home/runner/.local/share/hexops/sdk-linux-x86_64/root/usr/lib/x86_64-linux-gnu/libXdmcp.a' is neither ET_REL nor LLVM bitcode
```
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.