### PR TITLE
all: fix pointless discards; typo; fix libmach compilation on Linux

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -165,6 +165,10 @@ pub fn build(b: *std.build.Builder) void {
     lib.addPackage(gpu.pkg);
     lib.addPackage(glfw.pkg);
     lib.addPackage(sysaudio.pkg);
+    if (target.toTarget().os.tag == .linux) {
+        // TODO: add gamemode.pkg instead of using addPackagePath
+        lib.addPackagePath("gamemode", (comptime thisDir()) ++ "/libs/gamemode/gamemode.zig");
+    }
     glfw.link(b, lib, options.glfw_options);
     gpu.link(b, lib, options.gpuOptions());
     lib.setOutputDir("./libmach/build");

--- a/examples/ecs-app/main.zig
+++ b/examples/ecs-app/main.zig
@@ -47,7 +47,6 @@ pub fn init(engine: *ecs.World(modules)) !void {
     const player = try engine.entities.new();
     try engine.entities.setComponent(player, .renderer, .location, .{ .x = 0, .y = 0, .z = 0 });
     try engine.entities.setComponent(player, .physics2d, .location, .{ .x = 0, .y = 0 });
-    _ = player;
 
     // TODO: there could be an entities wrapper to interact with a single namespace so you don't
     // have to pass it in as a parameter always?

--- a/examples/gkurve/main.zig
+++ b/examples/gkurve/main.zig
@@ -121,7 +121,6 @@ pub fn init(app: *App, core: *mach.Core) !void {
     _ = window_height;
     _ = triangle_scale;
     _ = img_uv_data;
-    _ = white_texture_uv_data;
     // try draw.equilateralTriangle(app, .{ window_width / 2, window_height / 2 }, triangle_scale, .{}, img_uv_data);
     // try draw.equilateralTriangle(app, .{ window_width / 2, window_height / 2 - triangle_scale }, triangle_scale, .{ .type = .concave }, img_uv_data);
     // try draw.equilateralTriangle(app, .{ window_width / 2 - triangle_scale, window_height / 2 - triangle_scale / 2 }, triangle_scale, .{ .type = .convex }, white_texture_uv_data);

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -76,7 +76,7 @@ pub fn getFramebufferSize(core: *Core) structs.Size {
     return core.internal.getFramebufferSize();
 }
 
-// Returns the widow size, in pixel units.
+// Returns the window size, in pixel units.
 //
 // e.g. returns 1280x960 on macOS for a window that is 640x480
 pub fn getWindowSize(core: *Core) structs.Size {


### PR DESCRIPTION
some pointless discards, a typo, and adding gamemode to libmach because it was preventing a compile-all on linux.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.