### PR TITLE
{mach,examples,shaderexp}: fix default minimum window size

### DIFF
--- a/examples/advanced-gen-texture-light/main.zig
+++ b/examples/advanced-gen-texture-light/main.zig
@@ -33,10 +33,6 @@ const Dir = struct {
 };
 
 pub fn init(app: *App, core: *mach.Core) !void {
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const eye = vec3(5.0, 7.0, 5.0);
     const target = vec3(0.0, 0.0, 0.0);
 

--- a/examples/cubemap/main.zig
+++ b/examples/cubemap/main.zig
@@ -26,10 +26,6 @@ pub const App = @This();
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();
 
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const vs_module = core.device.createShaderModuleWGSL("vert.wgsl", @embedFile("vert.wgsl"));
 
     const vertex_attributes = [_]gpu.VertexAttribute{

--- a/examples/fractal-cube/main.zig
+++ b/examples/fractal-cube/main.zig
@@ -41,10 +41,6 @@ bgl: *gpu.BindGroupLayout,
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();
 
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const vs_module = core.device.createShaderModuleWGSL("vert.wgsl", @embedFile("vert.wgsl"));
 
     const vertex_attributes = [_]gpu.VertexAttribute{

--- a/examples/gkurve/main.zig
+++ b/examples/gkurve/main.zig
@@ -32,12 +32,6 @@ bind_group: *gpu.BindGroup,
 texture_atlas_data: AtlasRGB8,
 
 pub fn init(app: *App, core: *mach.Core) !void {
-    try core.setOptions(.{
-        .width = 640,
-        .height = 480,
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const queue = core.device.getQueue();
 
     // TODO: Refactor texture atlas size number

--- a/examples/image-blur/main.zig
+++ b/examples/image-blur/main.zig
@@ -30,10 +30,6 @@ var block_dimension: u32 = tile_dimension - (filter_size - 1);
 pub fn init(app: *App, core: *mach.Core) !void {
     const queue = core.device.getQueue();
 
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const blur_shader_module = core.device.createShaderModuleWGSL("blur.wgsl", @embedFile("blur.wgsl"));
 
     const blur_pipeline_descriptor = gpu.ComputePipeline.Descriptor{

--- a/examples/instanced-cube/main.zig
+++ b/examples/instanced-cube/main.zig
@@ -23,10 +23,6 @@ pub const App = @This();
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();
 
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const vs_module = core.device.createShaderModuleWGSL("vert.wgsl", @embedFile("vert.wgsl"));
 
     const vertex_attributes = [_]gpu.VertexAttribute{

--- a/examples/rotating-cube/main.zig
+++ b/examples/rotating-cube/main.zig
@@ -23,10 +23,6 @@ bind_group: *gpu.BindGroup,
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();
 
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const vs_module = core.device.createShaderModuleWGSL("vert.wgsl", @embedFile("vert.wgsl"));
 
     const vertex_attributes = [_]gpu.VertexAttribute{

--- a/examples/textured-cube/main.zig
+++ b/examples/textured-cube/main.zig
@@ -26,10 +26,6 @@ pub const App = @This();
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();
 
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const vs_module = core.device.createShaderModuleWGSL("vert.wgsl", @embedFile("vert.wgsl"));
 
     const vertex_attributes = [_]gpu.VertexAttribute{

--- a/examples/two-cubes/main.zig
+++ b/examples/two-cubes/main.zig
@@ -24,10 +24,6 @@ pub const App = @This();
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try mach.Timer.start();
 
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     const vs_module = core.device.createShaderModuleWGSL("vert.wgsl", @embedFile("vert.wgsl"));
 
     const vertex_attributes = [_]gpu.VertexAttribute{

--- a/shaderexp/main.zig
+++ b/shaderexp/main.zig
@@ -24,13 +24,6 @@ last_mtime: i128,
 pub fn init(app: *App, core: *mach.Core) !void {
     timer = try std.time.Timer.start();
 
-    // On linux if we don't set a minimum size, you can squish the window to 0 pixels of width and height,
-    // this makes some strange effects when that happens, so it's better to leave a minimum size to avoid that,
-    // this doesn't prevent you from minimizing the window.
-    try core.setOptions(.{
-        .size_min = .{ .width = 20, .height = 20 },
-    });
-
     var fragment_file: std.fs.File = undefined;
     var last_mtime: i128 = undefined;
 

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -28,7 +28,7 @@ pub const Options = struct {
     /// The minimum allowed size for the window. On Linux, if we don't set a minimum size,
     /// you can squish the window to 0 width and height with strange effects, so it's better to leave
     /// a minimum size to avoid that. This doesn't prevent you from minimizing the window.
-    size_min: SizeOptional = .{ .width = 1, .height = 1 },
+    size_min: SizeOptional = .{ .width = 350, .height = 350 },
 
     /// The maximum allowed size for the window.
     size_max: SizeOptional = .{ .width = null, .height = null },

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -25,8 +25,10 @@ pub const Options = struct {
     /// The height of the window.
     height: u32 = 480,
 
-    /// The minimum allowed size for the window.
-    size_min: SizeOptional = .{ .width = null, .height = null },
+    /// The minimum allowed size for the window. On Linux, if we don't set a minimum size,
+    /// you can squish the window to 0 width and height with strange effects, so it's better to leave
+    /// a minimum size to avoid that. This doesn't prevent you from minimizing the window.
+    size_min: SizeOptional = .{ .width = 1, .height = 1 },
 
     /// The maximum allowed size for the window.
     size_max: SizeOptional = .{ .width = null, .height = null },


### PR DESCRIPTION
set a saner default and moved the comment about zero window size on linux to the options struct.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.