### PR TITLE
mach: better compile error for missing fields in App.

### DIFF
--- a/src/platform/common.zig
+++ b/src/platform/common.zig
@@ -6,6 +6,19 @@ pub fn checkApplication(comptime app_pkg: type) void {
     }
     const App = app_pkg.App;
 
+    // If App has no fields, it gets interpretted as '*const App' when it should be '*App'
+    // This gives a more useful compiler error.
+    switch(@typeInfo(App)) {
+        .Struct => |app| {
+            if(app.fields.len == 0) {
+                @compileError("App must contain fields. Example: '_unused: i32,'");
+            }
+        },
+        else => {
+            @compileError("App must be a struct type. Found:" ++ @typeName(App));
+        }
+    }
+
     if (@hasDecl(App, "init")) {
         const InitFn = @TypeOf(@field(App, "init"));
         if (InitFn != fn (app: *App, core: *Core) @typeInfo(@typeInfo(InitFn).Fn.return_type.?).ErrorUnion.error_set!void)


### PR DESCRIPTION
Stage2 Zig ends up coercing structs without any fields into consts. The current error given is not entirely clear to the cause or how to fix the issue for users.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.