### PR TITLE
trimesh2d: add tesselator used for text rendering in SYCL 2022 talk

### DIFF
--- a/dev/ensure-standard-files.zig
+++ b/dev/ensure-standard-files.zig
@@ -16,6 +16,7 @@ const projects = [_][]const u8{
     "gpu-dawn",
     "sysaudio",
     "sysjs",
+    "trimesh2d",
 };
 
 pub fn main() !void {

--- a/libs/trimesh2d/.gitattributes
+++ b/libs/trimesh2d/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+upstream/** linguist-vendored

--- a/libs/trimesh2d/.github/FUNDING.yml
+++ b/libs/trimesh2d/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: slimsag

--- a/libs/trimesh2d/.github/pull_request_template.md
+++ b/libs/trimesh2d/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Please send your change to [the main repository](https://github.com/hexops/mach/tree/main/libs/trimesh2d) instead, sorry for the trouble!
+
+This helps us avoid some complex merge conflicts we run into when changes are made to both repositories and history needs to be reconciled. Keeping PRs in just that repository enables us to use `git subtree` to trivially keep the two repositories in sync.
+
+Once your PR is merged over there, it'll automatically sync to this repository.

--- a/libs/trimesh2d/.github/workflows/ci.yml
+++ b/libs/trimesh2d/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  x86_64-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Zig
+        run: |
+          sudo apt install xz-utils
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-linux-x86_64-0.10.0-dev.3952+9e070b653.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+      - name: x86_64-linux -> aarch64-macos
+        run: zig build test -Dtarget=aarch64-macos.12-none
+      - name: test
+        run: |
+          zig build test
+  x86_64-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Git
+        run: choco install git
+      - name: Setup Zig
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri "https://ziglang.org/builds/zig-windows-x86_64-0.10.0-dev.3952+9e070b653.zip" -OutFile "C:\zig.zip"
+          cd C:\
+          7z x zig.zip
+          Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.10.0-dev.3952+9e070b653\"
+      - name: test
+        run: zig build test
+  x86_64-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Zig
+        run: |
+          brew install xz
+          sudo sh -c 'wget -c https://ziglang.org/builds/zig-macos-x86_64-0.10.0-dev.3952+9e070b653.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+      - name: test
+        run: zig build test

--- a/libs/trimesh2d/.gitignore
+++ b/libs/trimesh2d/.gitignore
@@ -1,0 +1,18 @@
+# This file is for zig-specific build artifacts.
+# If you have OS-specific or editor-specific files to ignore,
+# such as *.swp or .DS_Store, put those in your global
+# ~/.gitignore and put this in your ~/.gitconfig:
+#
+# [core]
+#     excludesfile = ~/.gitignore
+#
+# Cheers!
+# -andrewrk
+
+zig-cache/
+zig-out/
+/release/
+/debug/
+/build/
+/build-*/
+/docgen_tmp/

--- a/libs/trimesh2d/LICENSE
+++ b/libs/trimesh2d/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2021, Hexops Contributors (given via the Git commit history).
+
+All documentation, image, sound, font, and 2D/3D model files are CC-BY-4.0 licensed unless
+otherwise noted. You may get a copy of this license at https://creativecommons.org/licenses/by/4.0
+
+Files in a directory with a separate LICENSE file may contain files under different license terms,
+described within that LICENSE file.
+
+All other files are licensed under the Apache License, Version 2.0 (see LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0)
+or the MIT license (see LICENSE-MIT or http://opensource.org/licenses/MIT), at your option.
+
+All files in the project without exclusions may not be copied, modified, or distributed except
+according to the terms above.

--- a/libs/trimesh2d/LICENSE-APACHE
+++ b/libs/trimesh2d/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/libs/trimesh2d/LICENSE-MIT
+++ b/libs/trimesh2d/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2021 Hexops Contributors (given via the Git commit history).
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/libs/trimesh2d/README.md
+++ b/libs/trimesh2d/README.md
@@ -1,0 +1,68 @@
+# mach/trimesh2d - simple polygon triangulation in linear time
+
+Converts 'simple' polygons (i.e. no holes) into triangle meshes in linear time using a modern earcut algorithm that works in linear time and has proven correctness.
+
+This is a Zig implementation of the paper:
+
+> "_[Deterministic Linear Time Constrained Triangulation using Simplified Earcut](https://arxiv.org/abs/2009.04294)_" - Marco Livesu, Gianmarco Cherchi, Riccardo Scateni, Marco Attene, 2020.
+> IEEE Transactions on Visualization and Computer Graphics, 2021. [arXiv:2009.04294](https://arxiv.org/abs/2009.04294)
+
+(This repository is a separate copy of the same library in the [main Mach repository](https://github.com/hexops/mach), and is automatically kept in sync, so that anyone can use this library in their own project if they like!)
+
+## Getting started
+
+### Adding dependency
+
+In a `libs` subdirectory of the root of your project:
+
+```sh
+git clone https://github.com/hexops/mach-trimesh2d
+```
+
+Then in your `build.zig` add:
+
+```zig
+...
+const trimesh2d = @import("libs/mach-trimesh2d/build.zig");
+
+pub fn build(b: *Builder) void {
+    ...
+    exe.addPackage(trimesh2d.pkg);
+}
+```
+
+### Usage
+
+```zig
+const trimesh2d = @import("trimesh2d");
+
+pub fn main() {
+    const allocator = std.heap.page_allocator;
+
+    var polygon = std.ArrayListUnmanaged(f32){};
+    // append your polygon vertices:
+    // try polygon.append(1.0);
+
+    var out_triangles = std.ArrayListUnmanaged(u32){};
+    var processor = trimesh2d.Processor(f32){};
+    defer processor.deinit(allocator);
+
+    // Process a polygon.
+    try processor.process(allocator, polygon, &out_triangles);
+
+    // out_triangles has indices into polygon.items of our triangle vertices.
+    // If desired, call .reset() and call .process() again! Internal buffers will be reused.
+}
+```
+
+## Join the community
+
+Join the Mach community [on Discord](https://discord.gg/XNG3NZgCqp) or [Matrix](https://matrix.to/#/#hexops:matrix.org) to discuss this project, ask questions, get help, etc.
+
+## Issues
+
+Issues are tracked in the [main Mach repository](https://github.com/hexops/mach/issues?q=is%3Aissue+is%3Aopen+label%3Atrimesh2d).
+
+## Contributing
+
+Contributions are very welcome. Pull requests must be sent to [the main repository](https://github.com/hexops/mach/tree/main/trimesh2d) to avoid some complex merge conflicts we'd get by accepting contributions in both repositories. Once the changes are merged there, they'll get sync'd to this repository automatically.

--- a/libs/trimesh2d/README.md
+++ b/libs/trimesh2d/README.md
@@ -1,11 +1,13 @@
-# mach/trimesh2d - simple polygon triangulation in linear time
+# mach/trimesh2d - simple polygon triangulation
 
-Converts 'simple' polygons (i.e. no holes) into triangle meshes in linear time using a modern earcut algorithm that works in linear time and has proven correctness.
+Triangulates 'simple' polygons (i.e. no holes) into triangle meshes.
 
-This is a Zig implementation of the paper:
+This uses inspiration/ideas from the paper:
 
 > "_[Deterministic Linear Time Constrained Triangulation using Simplified Earcut](https://arxiv.org/abs/2009.04294)_" - Marco Livesu, Gianmarco Cherchi, Riccardo Scateni, Marco Attene, 2020.
 > IEEE Transactions on Visualization and Computer Graphics, 2021. [arXiv:2009.04294](https://arxiv.org/abs/2009.04294)
+
+Notably, this paper does not consider lateral ears ("we never consider lateral ears in our triangulation algorithm"); and so we found many polygons that failed to triangulate with it due to extremas. To correct this, we adjusted the algorithm to clip ears with the smallest produced triangle area first.
 
 (This repository is a separate copy of the same library in the [main Mach repository](https://github.com/hexops/mach), and is automatically kept in sync, so that anyone can use this library in their own project if they like!)
 

--- a/libs/trimesh2d/README.md
+++ b/libs/trimesh2d/README.md
@@ -41,7 +41,7 @@ pub fn main() {
 
     var polygon = std.ArrayListUnmanaged(f32){};
     // append your polygon vertices:
-    // try polygon.append(1.0);
+    // try polygon.append(allocator, 1.0);
 
     var out_triangles = std.ArrayListUnmanaged(u32){};
     var processor = trimesh2d.Processor(f32){};

--- a/libs/trimesh2d/build.zig
+++ b/libs/trimesh2d/build.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) void {
+    const mode = b.standardReleaseOptions();
+    const lib = b.addStaticLibrary("trimesh2d", "src/main.zig");
+    lib.setBuildMode(mode);
+    lib.install();
+
+    var main_tests = b.addTest("src/main.zig");
+    main_tests.setBuildMode(mode);
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&main_tests.step);
+
+    _ = pkg;
+}
+
+pub const pkg = std.build.Pkg{
+    .name = "trimesh2d",
+    .source = .{ .path = thisDir() ++ "/src/main.zig" },
+};
+
+fn thisDir() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
+}

--- a/libs/trimesh2d/src/main.zig
+++ b/libs/trimesh2d/src/main.zig
@@ -4,6 +4,8 @@ const std = @import("std");
 /// (call reset between process calls.) The type T denotes e.g. f16, f32, or f64 vertices.
 pub fn Processor(comptime T: type) type {
     return struct {
+        const Vec2 = @Vector(2, T);
+
         // Doubly linked list for fast polygon inspection
         prev: std.ArrayListUnmanaged(u32) = .{},
         next: std.ArrayListUnmanaged(u32) = .{},
@@ -16,14 +18,14 @@ pub fn Processor(comptime T: type) type {
 
         /// Resets the processor, clearing the internal buffers and preparing it for processing a
         /// new polygon.
-        pub fn reset(self: *Processor) void {
+        pub fn reset(self: *@This()) void {
             self.prev.clearRetainingCapacity();
             self.next.clearRetainingCapacity();
             self.ears.clearRetainingCapacity();
             self.is_ear.clearRetainingCapacity();
         }
 
-        pub fn deinit(self: *Processor, allocator: std.mem.Allocator) void {
+        pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
             self.prev.deinit(allocator);
             self.next.deinit(allocator);
             self.ears.deinit(allocator);
@@ -32,96 +34,118 @@ pub fn Processor(comptime T: type) type {
 
         /// Processes a simple polygon (no holes) into triangles in linear time, writing the
         /// triangles to out_triangles (indices into polygon vertices list.)
+        ///
+        /// The polygons must be sorted in counter-clockwise order.
         pub fn process(
-            self: *Processor,
+            self: *@This(),
             allocator: std.mem.Allocator,
-            polygon: std.ArrayListUnmanaged(T),
+            // TODO(trimesh2d): make this a slice?
+            polygon: std.ArrayListUnmanaged(Vec2),
             out_triangles: *std.ArrayListUnmanaged(u32),
         ) error{OutOfMemory}!void {
-            if (polygon.len < 3) {
+            if (polygon.items.len < 3) {
                 return;
             }
 
             // Ensure our doubly linked list and ears list are large enough.
-            const size = polygon.len;
-            try self.prev.ensureTotalCapacity(allocator, size);
-            try self.next.ensureTotalCapacity(allocator, size);
+            const size = polygon.items.len;
+            try self.prev.resize(allocator, size);
+            try self.next.resize(allocator, size);
             try self.ears.ensureTotalCapacity(allocator, size);
             try self.is_ear.resize(allocator, size);
+            for (self.is_ear.items) |*v| v.* = false;
 
             // Fill prev list with prior-index values, e.g.:
             // [4, 0, 1, 2, 3]
-            for (self.prev.items) |_, i| self.prev.items[i] = if (i == 0) size - 1 else i - 1;
+            for (self.prev.items) |_, i| self.prev.items[i] = @intCast(u32, if (i == 0) size - 1 else i - 1);
 
             // Fill next list with next-index values, e.g.:
             // [1, 2, 3, 4, 0]
-            for (self.prev.items) |_, i| self.prev.items[i] = if (i == self.prev.items.len - 1) size - 1 else i + 1;
+            for (self.next.items) |_, i| self.next.items[i] = @intCast(u32, if (i == size - 1) 0 else i + 1);
 
             // Detect all safe ears in O(n).
             // This amounts to finding all convex vertices but the endpoints of the constrained edge
             var curr: u32 = 1;
-            while (cur < size - 1) : (curr += 1) {
-                // NOTE: the polygon may contain dangling edges, so !arrayListElementsEqual(prev, next)
-                // avoids need to even do the more expensive ear test for them below.
-                if (!arrayListElementsEqual(prev, next) and orient2d(
-                    // TODO(trimesh2d): all this code would be simpler if we had a poly index helper
-                    // which returned a @Vector2(2, T)
-                    @Vector(2, T){ poly[self.prev.items[curr]], poly[self.prev.items[curr] + 1] },
-                    @Vector(2, T){ poly[curr], poly[curr + 1] },
-                    @Vector(2, T){ poly[self.next.items[curr]], poly[self.next.items[curr] + 1] },
-                )) {
-                    try self.ears.append(curr);
+            while (curr < size - 1) : (curr += 1) {
+                // NOTE: the polygon may contain dangling edges
+                if (orient2d(
+                    polygon.items[self.prev.items[curr]],
+                    polygon.items[curr],
+                    polygon.items[self.next.items[curr]],
+                ) > 0) {
+                    try self.ears.append(allocator, curr);
                     self.is_ear.items[curr] = true;
                 }
             }
 
             // Progressively delete all ears, updating the data structure
-            const length = size;
-            while (true) {
-                const curr = self.ears.pop();
+            while (self.ears.items.len > 0) {
+                curr = self.ears.pop();
 
                 // make new tri
-                try out_triangles.append(self.prev.items[curr]);
-                try out_triangles.append(curr);
-                try out_triangles.append(self.next.items[curr]);
+                try out_triangles.append(allocator, self.prev.items[curr]);
+                try out_triangles.append(allocator, curr);
+                try out_triangles.append(allocator, self.next.items[curr]);
 
                 // exclude curr from the polygon, connecting prev and next
                 self.next.items[self.prev.items[curr]] = self.next.items[curr];
                 self.prev.items[self.next.items[curr]] = self.prev.items[curr];
 
-                length -= 1;
-                if (length < 3) return; // last triangle
-
                 // check if prev and next have become new ears
                 if (!self.is_ear.items[self.prev.items[curr]] and self.prev.items[curr] != 0) {
                     if (self.prev.items[self.prev.items[curr]] != self.next.items[curr] and orient2d(
-                        @Vector(2, T){ poly[self.prev.items[self.prev.items[curr]]], poly[(self.prev.items[self.prev.items[curr]]) + 1] },
-                        @Vector(2, T){ poly[self.prev.items[curr]], poly[self.prev.items[curr] + 1] },
-                        @Vector(2, T){ poly[self.next.items[curr]], poly[self.next.items[curr] + 1] },
+                        polygon.items[self.prev.items[self.prev.items[curr]]],
+                        polygon.items[self.prev.items[curr]],
+                        polygon.items[self.next.items[curr]],
                     ) > 0) {
-                        try self.ears.append(self.prev.items[curr]);
+                        try self.ears.append(allocator, self.prev.items[curr]);
                         self.is_ear.items[self.prev.items[curr]] = true;
                     }
                 }
                 if (!self.is_ear.items[self.next.items[curr]] and self.next.items[curr] < size - 1) {
                     if (self.next.items[self.next.items[curr]] != self.prev.items[curr] and orient2d(
-                        @Vector(2, T){ poly[self.prev.items[curr]], poly[(self.prev.items[curr]) + 1] },
-                        @Vector(2, T){ poly[self.next.items[curr]], poly[self.next.items[curr] + 1] },
-                        @Vector(2, T){ poly[self.next.items[self.next.items[curr]]], poly[self.next.items[self.next.items[curr]] + 1] },
+                        polygon.items[self.prev.items[curr]],
+                        polygon.items[self.next.items[curr]],
+                        polygon.items[self.next.items[self.next.items[curr]]],
                     ) > 0) {
-                        try self.ears.append(self.next.items[curr]);
+                        try self.ears.append(allocator, self.next.items[curr]);
                         self.is_ear.items[self.next.items[curr]] = true;
                     }
                 }
             }
         }
 
+        pub fn sort(allocator: std.mem.Allocator, polygon: std.ArrayListUnmanaged(Vec2)) !std.ArrayListUnmanaged(Vec2) {
+            var max_dist: f32 = 0;
+            var extrema_start: usize = undefined;
+            var extrema_end: usize = undefined;
+            var i: usize = 0;
+            while (i < polygon.items.len) : (i += 1) {
+                var next_index = (i + 1) % polygon.items.len;
+                var p0 = polygon.items[i];
+                var p1 = polygon.items[next_index];
+                var dist = std.math.hypot(T, p1[0] - p0[0], p1[1] - p0[1]);
+                if (dist > max_dist) {
+                    max_dist = dist;
+                    extrema_start = i;
+                    extrema_end = next_index;
+                }
+            }
+
+            var sorted = std.ArrayListUnmanaged(Vec2){};
+            i = extrema_end;
+            while (i < polygon.items.len) : (i += 1) try sorted.append(allocator, polygon.items[i]);
+            i = 0;
+            while (i <= extrema_start) : (i += 1) try sorted.append(allocator, polygon.items[i]);
+            return sorted;
+        }
+
         /// Inexact geometric predicate.
         /// Basically Shewchuk's orient2dfast()
         fn orient2d(
-            pa: @Vector(2, T),
-            pb: @Vector(2, T),
-            pc: @Vector(2, T),
+            pa: Vec2,
+            pb: Vec2,
+            pc: Vec2,
         ) T {
             const acx = pa[0] - pc[0];
             const bcx = pb[0] - pc[0];
@@ -129,18 +153,38 @@ pub fn Processor(comptime T: type) type {
             const bcy = pb[1] - pc[1];
             return acx * bcy - acy * bcx;
         }
-
-        fn arrayListElementsEqual(
-            a: std.ArrayListUnmanaged(u32),
-            b: std.ArrayListUnmanaged(u32),
-        ) bool {
-            if (a.len != b.len) return false;
-            for (a.items) |aa, i| {
-                if (b.items[i] != aa) return false;
-            }
-            return true;
-        }
     };
+}
+
+test "simple" {
+    const allocator = std.testing.allocator;
+    const Vec2 = @Vector(2, f32);
+
+    var polygon = std.ArrayListUnmanaged(Vec2){};
+    defer polygon.deinit(allocator);
+    // CCW
+    try polygon.append(allocator, Vec2{ 0.0, 0.0 }); // bottom-left
+    try polygon.append(allocator, Vec2{ 1.0, 0.0 }); // bottom-right
+    try polygon.append(allocator, Vec2{ 1.0, 1.0 }); // top-right
+    try polygon.append(allocator, Vec2{ 0.0, 1.0 }); // top-left
+
+    var out_triangles = std.ArrayListUnmanaged(u32){};
+    defer out_triangles.deinit(allocator);
+    var processor = Processor(f32){};
+    defer processor.deinit(allocator);
+
+    // Process a polygon.
+    try processor.process(allocator, polygon, &out_triangles);
+
+    // out_triangles has indices into polygon.items of our triangle vertices.
+    // If desired, call .reset() and call .process() again! Internal buffers will be reused.
+    try std.testing.expectEqual(@as(usize, 6), out_triangles.items.len);
+    try std.testing.expectEqual(@as(u32, 1), out_triangles.items[0]); // bottom-right
+    try std.testing.expectEqual(@as(u32, 2), out_triangles.items[1]); // top-right
+    try std.testing.expectEqual(@as(u32, 3), out_triangles.items[2]); // top-left
+    try std.testing.expectEqual(@as(u32, 0), out_triangles.items[3]); // bottom-left
+    try std.testing.expectEqual(@as(u32, 1), out_triangles.items[4]); // bottom-right
+    try std.testing.expectEqual(@as(u32, 3), out_triangles.items[5]); // top-left
 }
 
 test {

--- a/libs/trimesh2d/src/main.zig
+++ b/libs/trimesh2d/src/main.zig
@@ -1,0 +1,148 @@
+const std = @import("std");
+
+/// Returns a trimesh2d processor, which can reuse its internal buffers to process multiple polygons
+/// (call reset between process calls.) The type T denotes e.g. f16, f32, or f64 vertices.
+pub fn Processor(comptime T: type) type {
+    return struct {
+        // Doubly linked list for fast polygon inspection
+        prev: std.ArrayListUnmanaged(u32) = .{},
+        next: std.ArrayListUnmanaged(u32) = .{},
+
+        // A list of the ears to be cut
+        ears: std.ArrayListUnmanaged(u32) = .{},
+
+        // Keeps track of ears (corners that were not ears at the beginning may become so later on.)
+        is_ear: std.ArrayListUnmanaged(bool) = .{},
+
+        /// Resets the processor, clearing the internal buffers and preparing it for processing a
+        /// new polygon.
+        pub fn reset(self: *Processor) void {
+            self.prev.clearRetainingCapacity();
+            self.next.clearRetainingCapacity();
+            self.ears.clearRetainingCapacity();
+            self.is_ear.clearRetainingCapacity();
+        }
+
+        pub fn deinit(self: *Processor, allocator: std.mem.Allocator) void {
+            self.prev.deinit(allocator);
+            self.next.deinit(allocator);
+            self.ears.deinit(allocator);
+            self.is_ear.deinit(allocator);
+        }
+
+        /// Processes a simple polygon (no holes) into triangles in linear time, writing the
+        /// triangles to out_triangles (indices into polygon vertices list.)
+        pub fn process(
+            self: *Processor,
+            allocator: std.mem.Allocator,
+            polygon: std.ArrayListUnmanaged(T),
+            out_triangles: *std.ArrayListUnmanaged(u32),
+        ) error{OutOfMemory}!void {
+            if (polygon.len < 3) {
+                return;
+            }
+
+            // Ensure our doubly linked list and ears list are large enough.
+            const size = polygon.len;
+            try self.prev.ensureTotalCapacity(allocator, size);
+            try self.next.ensureTotalCapacity(allocator, size);
+            try self.ears.ensureTotalCapacity(allocator, size);
+            try self.is_ear.resize(allocator, size);
+
+            // Fill prev list with prior-index values, e.g.:
+            // [4, 0, 1, 2, 3]
+            for (self.prev.items) |_, i| self.prev.items[i] = if (i == 0) size - 1 else i - 1;
+
+            // Fill next list with next-index values, e.g.:
+            // [1, 2, 3, 4, 0]
+            for (self.prev.items) |_, i| self.prev.items[i] = if (i == self.prev.items.len - 1) size - 1 else i + 1;
+
+            // Detect all safe ears in O(n).
+            // This amounts to finding all convex vertices but the endpoints of the constrained edge
+            var curr: u32 = 1;
+            while (cur < size - 1) : (curr += 1) {
+                // NOTE: the polygon may contain dangling edges, so !arrayListElementsEqual(prev, next)
+                // avoids need to even do the more expensive ear test for them below.
+                if (!arrayListElementsEqual(prev, next) and orient2d(
+                    // TODO(trimesh2d): all this code would be simpler if we had a poly index helper
+                    // which returned a @Vector2(2, T)
+                    @Vector(2, T){ poly[self.prev.items[curr]], poly[self.prev.items[curr] + 1] },
+                    @Vector(2, T){ poly[curr], poly[curr + 1] },
+                    @Vector(2, T){ poly[self.next.items[curr]], poly[self.next.items[curr] + 1] },
+                )) {
+                    try self.ears.append(curr);
+                    self.is_ear.items[curr] = true;
+                }
+            }
+
+            // Progressively delete all ears, updating the data structure
+            const length = size;
+            while (true) {
+                const curr = self.ears.pop();
+
+                // make new tri
+                try out_triangles.append(self.prev.items[curr]);
+                try out_triangles.append(curr);
+                try out_triangles.append(self.next.items[curr]);
+
+                // exclude curr from the polygon, connecting prev and next
+                self.next.items[self.prev.items[curr]] = self.next.items[curr];
+                self.prev.items[self.next.items[curr]] = self.prev.items[curr];
+
+                length -= 1;
+                if (length < 3) return; // last triangle
+
+                // check if prev and next have become new ears
+                if (!self.is_ear.items[self.prev.items[curr]] and self.prev.items[curr] != 0) {
+                    if (self.prev.items[self.prev.items[curr]] != self.next.items[curr] and orient2d(
+                        @Vector(2, T){ poly[self.prev.items[self.prev.items[curr]]], poly[(self.prev.items[self.prev.items[curr]]) + 1] },
+                        @Vector(2, T){ poly[self.prev.items[curr]], poly[self.prev.items[curr] + 1] },
+                        @Vector(2, T){ poly[self.next.items[curr]], poly[self.next.items[curr] + 1] },
+                    ) > 0) {
+                        try self.ears.append(self.prev.items[curr]);
+                        self.is_ear.items[self.prev.items[curr]] = true;
+                    }
+                }
+                if (!self.is_ear.items[self.next.items[curr]] and self.next.items[curr] < size - 1) {
+                    if (self.next.items[self.next.items[curr]] != self.prev.items[curr] and orient2d(
+                        @Vector(2, T){ poly[self.prev.items[curr]], poly[(self.prev.items[curr]) + 1] },
+                        @Vector(2, T){ poly[self.next.items[curr]], poly[self.next.items[curr] + 1] },
+                        @Vector(2, T){ poly[self.next.items[self.next.items[curr]]], poly[self.next.items[self.next.items[curr]] + 1] },
+                    ) > 0) {
+                        try self.ears.append(self.next.items[curr]);
+                        self.is_ear.items[self.next.items[curr]] = true;
+                    }
+                }
+            }
+        }
+
+        /// Inexact geometric predicate.
+        /// Basically Shewchuk's orient2dfast()
+        fn orient2d(
+            pa: @Vector(2, T),
+            pb: @Vector(2, T),
+            pc: @Vector(2, T),
+        ) T {
+            const acx = pa[0] - pc[0];
+            const bcx = pb[0] - pc[0];
+            const acy = pa[1] - pc[1];
+            const bcy = pb[1] - pc[1];
+            return acx * bcy - acy * bcx;
+        }
+
+        fn arrayListElementsEqual(
+            a: std.ArrayListUnmanaged(u32),
+            b: std.ArrayListUnmanaged(u32),
+        ) bool {
+            if (a.len != b.len) return false;
+            for (a.items) |aa, i| {
+                if (b.items[i] != aa) return false;
+            }
+            return true;
+        }
+    };
+}
+
+test {
+    std.testing.refAllDeclsRecursive(@This());
+}


### PR DESCRIPTION
This adds a tesselator used for text rendering in my SYCL 2022 talk ("gkurve: simpler vector graphics")

I think this is not the right long-term polygon tesselator to have, but it'll do for now.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.