### PR TITLE
WIP: multi-window handling on native

### DIFF
--- a/src/Core.zig
+++ b/src/Core.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const builtin = @import("builtin");
-const glfw = @import("glfw");
 const gpu = @import("gpu");
 const platform = @import("platform.zig");
 const structs = @import("structs.zig");
 const enums = @import("enums.zig");
+const Window = @import("Window.zig");
 const Timer = @import("Timer.zig");
 
 const Core = @This();
@@ -23,8 +23,11 @@ delta_time: f32 = 0,
 delta_time_ns: u64 = 0,
 timer: Timer,
 
+instance: *gpu.Instance,
+adapter: *gpu.Adapter,
 device: *gpu.Device,
 backend_type: gpu.BackendType,
+
 swap_chain: ?*gpu.SwapChain,
 swap_chain_format: gpu.Texture.Format,
 
@@ -52,6 +55,11 @@ pub fn setOptions(core: *Core, options: structs.Options) !void {
 // Signals mach to stop the update loop.
 pub fn close(core: *Core) void {
     core.internal.close();
+}
+
+pub fn initWindow(core: *Core, window: *Window) !void {
+    window.options = structs.WindowOptions{};
+    window.internal = try core.internal.initWindow(window);
 }
 
 // Sets seconds to wait for an event with timeout before calling update()

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -1,0 +1,43 @@
+const gpu = @import("gpu");
+const platform = @import("platform.zig");
+const structs = @import("structs.zig");
+
+const Window = @This();
+
+options: structs.WindowOptions,
+
+swap_chain: ?*gpu.SwapChain,
+swap_chain_format: gpu.Texture.Format,
+
+surface: ?*gpu.Surface,
+current_desc: gpu.SwapChain.Descriptor,
+target_desc: gpu.SwapChain.Descriptor,
+
+internal: platform.BackingWindowType,
+
+/// Set runtime options for the window, like title, window size etc.
+///
+/// See mach.WindowOptions for details
+pub fn setOptions(window: *Window, options: structs.WindowOptions) !void {
+    try window.internal.setOptions(options);
+    window.options = options;
+}
+
+// Signals mach to close the window.
+pub fn close(window: *Window) void {
+    window.internal.close();
+}
+
+// Returns the framebuffer size, in subpixel units.
+//
+// e.g. returns 1280x960 on macOS for a window that is 640x480
+pub fn getFramebufferSize(window: *Window) structs.Size {
+    return window.internal.getFramebufferSize();
+}
+
+// Returns the window size, in pixel units.
+//
+// e.g. returns 1280x960 on macOS for a window that is 640x480
+pub fn getSize(window: *Window) structs.Size {
+    return window.internal.getSize();
+}

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -6,6 +6,7 @@ else
     Interface(@import("platform/native.zig"));
 
 pub const Type = Platform.Platform;
+pub const BackingWindowType = Platform.BackingWindow; // TODO: window interface check, platform support
 pub const BackingTimerType = Platform.BackingTimer;
 
 /// Verifies that a Platform implementation exposes the expected function declarations.

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -36,11 +36,11 @@ pub const Options = struct {
     /// Fullscreen window.
     fullscreen: bool = false,
 
-    /// Headless mode.
-    headless: bool = false,
-
     /// Monitor synchronization modes.
     vsync: enums.VSyncMode = .double,
+
+    /// Headless mode.
+    headless: bool = false,
 
     /// GPU features required by the application.
     required_features: ?[]gpu.FeatureName = null,
@@ -51,8 +51,35 @@ pub const Options = struct {
     /// Whether the application has a preference for low power or high performance GPU.
     power_preference: gpu.PowerPreference = .undef,
 
-    /// If set, optimize for regular applications rather than games. e.g. disable Linux gamemode / process priority, prefer low-power GPU (if preference is .undef), etc.
+    /// If set, optimize for regular applications rather than games. e.g. disable Linux gamemode /
+    /// process priority, prefer low-power GPU (if preference is .undef), etc.
     is_app: bool = false,
+};
+
+/// Per-window options that can be configured at run time.
+pub const WindowOptions = struct {
+    /// The title of the window.
+    title: [*:0]const u8 = "Mach core",
+
+    /// The width of the window.
+    width: u32 = 640,
+
+    /// The height of the window.
+    height: u32 = 480,
+
+    /// The minimum allowed size for the window. On Linux, if we don't set a minimum size,
+    /// you can squish the window to 0 width and height with strange effects, so it's better to leave
+    /// a minimum size to avoid that. This doesn't prevent you from minimizing the window.
+    size_min: SizeOptional = .{ .width = 350, .height = 350 },
+
+    /// The maximum allowed size for the window.
+    size_max: SizeOptional = .{ .width = null, .height = null },
+
+    /// Fullscreen window.
+    fullscreen: bool = false,
+
+    /// Monitor synchronization modes.
+    vsync: enums.VSyncMode = .double,
 };
 
 pub const Event = union(enum) {


### PR DESCRIPTION
#532

some fields have been reorganized, as Window, BackingWindow, and WindowOptions share the window-specific interfaces of Core, Platform, and Options. maybe that should be split out on its own.

it might make sense to fully refactor window-specific interfaces out, but i couldn't figure out a nice way to organize it. that may become necessary depending on how Events convey which window an event is for to the user. that's also why i'm not sure about who should be allocating the Window.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.