### PR TITLE
mach: 0 size swapchain noop fix

### DIFF
--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -626,7 +626,7 @@ pub fn coreUpdate(core: *Core, resize: ?CoreResizeCallback) !void {
     core.target_desc.width = framebuffer_size.width;
     core.target_desc.height = framebuffer_size.height;
 
-    if (core.swap_chain == null or !std.meta.eql(core.current_desc, core.target_desc)) {
+    if ((core.swap_chain == null or !std.meta.eql(core.current_desc, core.target_desc)) and !(core.target_desc.width == 0 or core.target_desc.height == 0)) {
         core.swap_chain = core.device.createSwapChain(core.surface, &core.target_desc);
 
         if (@hasDecl(App, "resize")) {


### PR DESCRIPTION
Noops swapchain creation for when the target_desc has a width or height of 0. Cases that hit this are when a user minimizes a window or resizes the window to only render the toolbar.

Helps https://github.com/hexops/mach/issues/528

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.