### PR TITLE
freetype/harfbuzz: correct Position struct layout

### DIFF
--- a/libs/freetype/src/harfbuzz/buffer.zig
+++ b/libs/freetype/src/harfbuzz/buffer.zig
@@ -40,6 +40,7 @@ pub const Position = extern struct {
     y_advance: i32,
     x_offset: i32,
     y_offset: i32,
+    _padding: u32, // private
 };
 
 pub const GlyphFlags = packed struct {


### PR DESCRIPTION
There's an undocumented private field in this struct which wasn't replicated, meaning getGlyphPositions was returning garbage data.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.