### PR TITLE
freetype: don't expose harfbuzz directly from freetype pkg

### DIFF
--- a/libs/freetype/src/main.zig
+++ b/libs/freetype/src/main.zig
@@ -7,7 +7,6 @@ pub usingnamespace @import("stroke.zig");
 pub usingnamespace @import("types.zig");
 pub usingnamespace @import("computations.zig");
 pub usingnamespace @import("error.zig");
-pub const harfbuzz = @import("harfbuzz/main.zig");
 pub const c = @import("c.zig");
 
 const std = @import("std");


### PR DESCRIPTION
This declaration itself was nonsensical, as the file being imported was from the harfbuzz package (instead users should import the harfbuzz package directly). But as well as being nonsensical, this line was occasionally triggering a stage2 bug which we haven't quite tracked down yet which seems to be something to do with conflicting modules importing a file. This issue meant that projects with a specific dependency pattern on freetype and harfbuzz would sometimes randomly get a nonsensical compilation error. This change works around that issue for mach-freetype.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.