### PR TITLE
glfw: fix compilation with latest zig master

### DIFF
--- a/libs/glfw/system_sdk.zig
+++ b/libs/glfw/system_sdk.zig
@@ -210,7 +210,7 @@ fn determineSdkRoot(allocator: std.mem.Allocator, org: []const u8, name: []const
     ensureGit(allocator);
 
     // If the SDK exists, return it. Otherwise, clone it.
-    if (std.fs.openDirAbsolute(sdk_root_dir, .{})) {
+    if (std.fs.openDirAbsolute(sdk_root_dir, .{})) |_| {
         const current_revision = try getCurrentGitRevision(allocator, sdk_root_dir);
         if (!std.mem.eql(u8, current_revision, revision)) {
             // Update the SDK to the target revision. This may be either forward or backwards in


### PR DESCRIPTION
Breaking zig change for some error handling.

See https://github.com/Vexu/zig/commit/0b1dd845d9ac15ade5748dcb6ffa6b868fdfe0c0



- [ x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.