### PR TITLE
glfw: fix native import

### DIFF
--- a/libs/glfw/.gitignore
+++ b/libs/glfw/.gitignore
@@ -16,4 +16,3 @@ zig-out/
 /build/
 /build-*/
 /docgen_tmp/
-src/c_native.zig

--- a/libs/glfw/src/native.zig
+++ b/libs/glfw/src/native.zig
@@ -40,7 +40,7 @@ pub const BackendOptions = struct {
 /// The chosen backends must match those the library was compiled for. Failure to do so
 /// will cause a link-time error.
 pub fn Native(comptime options: BackendOptions) type {
-    const native = @import("c_native.zig").import(options);
+    const native = @import("cimport/c_normal_native.zig").import(options);
 
     return struct {
         /// Returns the adapter device name of the specified monitor.

--- a/libs/glfw/src/native.zig
+++ b/libs/glfw/src/native.zig
@@ -40,7 +40,20 @@ pub const BackendOptions = struct {
 /// The chosen backends must match those the library was compiled for. Failure to do so
 /// will cause a link-time error.
 pub fn Native(comptime options: BackendOptions) type {
-    const native = @import("cimport/c_normal_native.zig").import(options);
+    const native = @cImport({
+        @cDefine("GLFW_INCLUDE_VULKAN", "1");
+        @cInclude("GLFW/glfw3.h");
+        if (options.win32) @cDefine("GLFW_EXPOSE_NATIVE_WIN32", "1");
+        if (options.wgl) @cDefine("GLFW_EXPOSE_NATIVE_WGL", "1");
+        if (options.cocoa) @cDefine("GLFW_EXPOSE_NATIVE_COCOA", "1");
+        if (options.nsgl) @cDefine("GLFW_EXPOSE_NATIVE_NGSL", "1");
+        if (options.x11) @cDefine("GLFW_EXPOSE_NATIVE_X11", "1");
+        if (options.glx) @cDefine("GLFW_EXPOSE_NATIVE_GLX", "1");
+        if (options.wayland) @cDefine("GLFW_EXPOSE_NATIVE_WAYLAND", "1");
+        if (options.egl) @cDefine("GLFW_EXPOSE_NATIVE_EGL", "1");
+        if (options.osmesa) @cDefine("GLFW_EXPOSE_NATIVE_OSMESA", "1");
+        @cInclude("GLFW/glfw3native.h");
+    });
 
     return struct {
         /// Returns the adapter device name of the specified monitor.


### PR DESCRIPTION
Should close #582 (unless there is something wrong on darwin)

Commits e7e179f6 72ddde25 removed a cImport workaround in glfw, but it looks like it removal of the generation of `libs/glfw/src/c_native.zig` wasn't taken into account (likely because this file is in the `.gitignore`). I seem to be able to fix this by importing `cimport/c_normal_native.zig` instead of `c_native.zig` in `src/native.zig` but, I have no idea if this is meant to work for darwin or not, but hopefully CI will say it does (this change should fix CI failing  the glfw-test)

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.