### PR TITLE
mach: add option to set the monitor index on fullscreen

### DIFF
--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -319,7 +319,11 @@ pub const Platform = struct {
         if (options.fullscreen) {
             platform.last_position = try platform.window.getPos();
 
-            const monitor = glfw.Monitor.getPrimary().?;
+            const monitorList = try glfw.Monitor.getAll(platform.allocator);
+            defer platform.allocator.free(monitorList);
+
+            const monitor = monitorList[options.monitor];
+    
             const video_mode = try monitor.getVideoMode();
             try platform.window.setMonitor(monitor, 0, 0, video_mode.getWidth(), video_mode.getHeight(), null);
         } else {

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -316,8 +316,10 @@ pub const Platform = struct {
             .double => .fifo,
             .triple => .mailbox,
         };
+
+        platform.last_position = try platform.window.getPos();
+
         if (options.fullscreen) {
-            platform.last_position = try platform.window.getPos();
 
             const monitorList = try glfw.Monitor.getAll(platform.allocator);
             defer platform.allocator.free(monitorList);

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -320,13 +320,17 @@ pub const Platform = struct {
         platform.last_position = try platform.window.getPos();
 
         if (options.fullscreen) {
+            var monitor: ?glfw.Monitor = null;
 
-            const monitorList = try glfw.Monitor.getAll(platform.allocator);
-            defer platform.allocator.free(monitorList);
+            if (options.monitor) |monitorIndex| {
+                const monitorList = try glfw.Monitor.getAll(platform.allocator);
+                defer platform.allocator.free(monitorList);
+                monitor = monitorList[monitorIndex];
+            } else {
+                monitor = glfw.Monitor.getPrimary();
+            }
 
-            const monitor = monitorList[options.monitor];
-    
-            const video_mode = try monitor.getVideoMode();
+            const video_mode = try monitor.?.getVideoMode();
             try platform.window.setMonitor(monitor, 0, 0, video_mode.getWidth(), video_mode.getHeight(), null);
         } else {
             const position = platform.last_position;

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -36,8 +36,8 @@ pub const Options = struct {
     /// Fullscreen window.
     fullscreen: bool = false,
 
-    // Fullscreen monitor index
-    monitor: u32 = 0,
+    /// Fullscreen monitor index
+    monitor: ?u32 = null,
 
     /// Headless mode.
     headless: bool = false,

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -36,6 +36,9 @@ pub const Options = struct {
     /// Fullscreen window.
     fullscreen: bool = false,
 
+    // Fullscreen monitor index
+    monitor: u32 = 0,
+
     /// Headless mode.
     headless: bool = false,
 


### PR DESCRIPTION
For multiple monitors (at least on native), it would be nice to be able to select the monitor for fullscreen mode.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.