### PR TITLE
{mach,model3d}: link model3d as static lib instead of adding C files to build step

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -169,6 +169,7 @@ pub const App = struct {
     res_dirs: ?[]const []const u8,
     watch_paths: ?[]const []const u8,
     use_freetype: ?[]const u8 = null,
+    use_model3d: bool = false,
 
     pub const InitError = error{OutOfMemory} || std.zig.system.NativeTargetInfo.DetectError;
     pub const LinkError = glfw.LinkError;
@@ -199,6 +200,7 @@ pub const App = struct {
             /// If set, freetype will be linked and can be imported using this name.
             // TODO(build-system): name is currently not used / always "freetype"
             use_freetype: ?[]const u8 = null,
+            use_model3d: bool = false,
         },
     ) InitError!App {
         const target = (try std.zig.system.NativeTargetInfo.detect(options.target)).target;
@@ -254,6 +256,7 @@ pub const App = struct {
             .res_dirs = options.res_dirs,
             .watch_paths = options.watch_paths,
             .use_freetype = options.use_freetype,
+            .use_model3d = options.use_model3d,
         };
     }
 
@@ -266,6 +269,9 @@ pub const App = struct {
         }
         sysaudio.link(app.b, app.step, options.sysaudio_options);
         if (app.use_freetype) |_| freetype.link(app.b, app.step, options.freetype_options);
+        if (app.use_model3d) {
+            model3d.link(app.b, app.step);
+        }
     }
 
     pub fn install(app: *const App) void {

--- a/libs/model3d/build.zig
+++ b/libs/model3d/build.zig
@@ -16,15 +16,17 @@ pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.C
     const main_tests = b.addTestExe("model3d-tests", "src/main.zig");
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
-    link(main_tests);
+    link(b, main_tests);
     main_tests.install();
     return main_tests.run();
 }
 
-pub fn link(step: *std.build.LibExeObjStep) void {
-    step.addCSourceFile(sdkPath("/src/c/m3d.c"), &.{});
-    step.addIncludePath(sdkPath("/src/c"));
-    step.linkLibC();
+pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep) void {
+    const lib = b.addStaticLibrarySource("model3d", null);
+    lib.addCSourceFile(sdkPath("/src/c/m3d.c"), &.{ "-std=c89", "-DM3D_ASCII" });
+    lib.linkLibC();
+    step.addIncludePath(sdkPath("/src/c/"));
+    step.linkLibrary(lib);
 }
 
 fn sdkPath(comptime suffix: []const u8) []const u8 {


### PR DESCRIPTION
This allows the library to link with projects that are using different c compiler options (E.g compiling C++ or using a different c standard)

Also adds .use_model3d option to mach build system. If set to true, model3d will be linked in statically to target project.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.