### PR TITLE
model3d: set cross-target when compiling statically

### DIFF
--- a/libs/model3d/build.zig
+++ b/libs/model3d/build.zig
@@ -16,13 +16,14 @@ pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.C
     const main_tests = b.addTestExe("model3d-tests", "src/main.zig");
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
-    link(b, main_tests);
+    link(b, main_tests, target);
     main_tests.install();
     return main_tests.run();
 }
 
-pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep) void {
+pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep, target: std.zig.CrossTarget) void {
     const lib = b.addStaticLibrarySource("model3d", null);
+    lib.setTarget(target);
     lib.addCSourceFile(sdkPath("/src/c/m3d.c"), &.{ "-std=c89", "-DM3D_ASCII" });
     lib.linkLibC();
     step.addIncludePath(sdkPath("/src/c/"));


### PR DESCRIPTION
This is required for building with a non-native target, otherwise library is build for the native platform and attempts to link fail

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.