### PR TITLE
sysaudio: add ability to provide system_sdk options

### DIFF
--- a/libs/sysaudio/sdk.zig
+++ b/libs/sysaudio/sdk.zig
@@ -17,6 +17,9 @@ pub fn Sdk(comptime deps: anytype) type {
 
         pub const Options = struct {
             install_libs: bool = false,
+
+            /// System SDK options.
+            system_sdk: deps.system_sdk.Options = .{},
         };
 
         pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
@@ -44,7 +47,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 const soundio_lib = buildSoundIo(b, step.build_mode, step.target, options);
                 step.linkLibrary(soundio_lib);
                 step.addIncludePath(soundio_path);
-                deps.system_sdk.include(b, step, .{});
+                deps.system_sdk.include(b, step, options.system_sdk);
             }
         }
 
@@ -72,7 +75,7 @@ pub fn Sdk(comptime deps: anytype) type {
             lib.linkLibC();
             lib.addIncludePath(soundio_path);
             lib.addCSourceFiles(soundio_sources, &.{});
-            deps.system_sdk.include(b, lib, .{});
+            deps.system_sdk.include(b, lib, options.system_sdk);
 
             const target_info = (std.zig.system.NativeTargetInfo.detect(target) catch unreachable).target;
             if (target_info.isDarwin()) {


### PR DESCRIPTION
Do not really know if it's ok or not, but for now, it is the only way to build Mach under macOS 13 without preparing actual SDK (which is a hard task for me). With this change, one can pass overridden `sdk_list` to glfw and sysaudio libs.
Btw on my laptop it is enough to copy `Sdk` from 12th version and just change semver to 13 to successfully compile Mach.
Can be used as a temporary workaround for https://github.com/hexops/mach/issues/610

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.