### PR TITLE
freetype: add option to build using separate zlib

### DIFF
--- a/libs/freetype/README.md
+++ b/libs/freetype/README.md
@@ -30,6 +30,9 @@ pub fn build(b: *Builder) void {
     ...
     exe.addPackage(freetype.pkg);
     freetype.link(b, exe, .{});
+
+    // use this option if you are including zlib separately
+    //freetype.link(b, exe, .{ .freetype = .{ .use_system_zlib = true } });
 }
 ```
 

--- a/libs/freetype/build.zig
+++ b/libs/freetype/build.zig
@@ -30,6 +30,7 @@ pub const FreetypeOptions = struct {
     config_path: ?[]const u8 = null,
     install_libs: bool = false,
     brotli: bool = false,
+    use_system_zlib: bool = false,
 };
 
 pub const HarfbuzzOptions = struct {
@@ -131,6 +132,9 @@ pub fn buildFreetype(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossT
 
     const lib = b.addStaticLibrary("freetype", null);
     lib.defineCMacro("FT2_BUILD_LIBRARY", "1");
+    if (options.use_system_zlib) {
+        lib.defineCMacro("FT_CONFIG_OPTION_SYSTEM_ZLIB", "1");
+    }
     lib.setBuildMode(mode);
     lib.setTarget(target);
     lib.linkLibC();


### PR DESCRIPTION
I ran into this when trying to use both mach-freetype and zig-libcurl (https://github.com/mattnite/zig-libcurl).  First I got undefined symbols like:

```
ld.lld: error: undefined symbol: inflate
>>> referenced by content_encoding.c:196 (libs/zig-libcurl/curl/lib/content_encoding.c:196)
>>>               /home/dvanderson/gui/zig-cache/o/e7a848841ad0f6ef64dd93429b6b18b5/content_encoding.o:(inflate_stream) in archive /home/dvanderson/gui/zig-cache/o/95294db893708419c83e8414f31f1147/libcurl.a
```
So I added zig-zlib (https://github.com/mattnite/zig-zlib).  Then I got duplicate symbols like:
```
ld.lld: error: duplicate symbol: inflateResetKeep
>>> defined at inflate.c:123 (libs/mach/libs/freetype/upstream/freetype/src/gzip/inflate.c:123)
>>>            /home/dvanderson/gui/zig-cache/o/6a165bd051f981ac91cbb4f2624cd006/ftgzip.o:(inflateResetKeep) in archive /home/dvanderson/gui/zig-cache/o/1805910d2fe891e313ab5e3835f3c7d4/libfreetype.a
>>> defined at inflate.c:121 (libs/zig-zlib/zlib/inflate.c:121)
>>>            /home/dvanderson/gui/zig-cache/o/9b6e8398cc498c39e731f1280b430117/inflate.o:(.text+0x0) in archive /home/dvanderson/gui/zig-cache/o/342308fbe7d19c8c086056be2b44f141/libz.a
```
My best guess so far is that freetype normally builds its own copy of zlib in a way that doesn't expose everything?  But enough to conflict with a separate zlib?

This exposes the option FT_CONFIG_OPTION_SYSTEM_ZLIB already present in freetype.  I think this makes sense but let me know if I'm going about this the wrong way.

Thanks!

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.