### PR TITLE
ecs: fix segfault in Entities.deinit()

### DIFF
--- a/libs/ecs/src/entities.zig
+++ b/libs/ecs/src/entities.zig
@@ -470,7 +470,7 @@ pub fn Entities(comptime all_components: anytype) type {
                 .len = 0,
                 .capacity = 0,
                 .columns = columns,
-                .block = undefined,
+                .block = &[_]u8{},
                 .hash = void_archetype_hash,
             });
 
@@ -587,7 +587,7 @@ pub fn Entities(comptime all_components: anytype) type {
                     .len = 0,
                     .capacity = 0,
                     .columns = columns,
-                    .block = undefined,
+                    .block = &[_]u8{},
                     .hash = undefined,
                 };
 
@@ -715,7 +715,7 @@ pub fn Entities(comptime all_components: anytype) type {
                     .len = 0,
                     .capacity = 0,
                     .columns = columns,
-                    .block = undefined,
+                    .block = &[_]u8{},
                     .hash = undefined,
                 };
 
@@ -866,4 +866,12 @@ test "example" {
     //-------------------------------------------------------------------------
     // Remove an entity whenever you wish. Just be sure not to try and use it later!
     try world.remove(player1);
+}
+
+test "empty_world" {
+    const allocator = testing.allocator;
+    //-------------------------------------------------------------------------
+    var world = try Entities(.{}).init(allocator);
+    // Create a world.
+    defer world.deinit();
 }


### PR DESCRIPTION
fixed segfault when calling deinit on empty world by setting a default value to archetype blocks, rather than them being undefined

fixes #627 

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.