### PR TITLE
use try to handle build.Pkg oom errors

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -220,7 +220,7 @@ pub const App = struct {
         const app_pkg = Pkg{
             .name = "app",
             .source = .{ .path = options.src },
-            .dependencies = deps.toOwnedSlice(),
+            .dependencies = try deps.toOwnedSlice(),
         };
 
         const step = blk: {

--- a/build.zig
+++ b/build.zig
@@ -220,7 +220,8 @@ pub const App = struct {
         const app_pkg = Pkg{
             .name = "app",
             .source = .{ .path = options.src },
-            .dependencies = try deps.toOwnedSlice(),
+            // .dependencies = try deps.toOwnedSlice(),
+            .dependencies = try arrayListToOwnedSlice(&deps),
         };
 
         const step = blk: {
@@ -359,4 +360,10 @@ fn sdkPath(comptime suffix: []const u8) []const u8 {
         const root_dir = std.fs.path.dirname(@src().file) orelse ".";
         break :blk root_dir ++ suffix;
     };
+}
+
+// compat function for 0.10.0
+// TODO: remove on zig 0.11.0 release
+inline fn arrayListToOwnedSlice(list: anytype) !@TypeOf(list.*).Slice {
+    return list.*.toOwnedSlice();
 }


### PR DESCRIPTION
Using newer versions of zig (tested with `0.11.0-dev.664+c49e4d534`)  `ArrayList.toOwnedSlice` returns an error union:

```zig
fn toOwnedSlice(self: *Self) Allocator.Error!Slice
```

which causes a build error on the dependencies ArrayList, which needs to be handled. It would break compatibilty with 0.10.0 though.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.