### PR TITLE
freetype: incorrect font path in embedFile

### DIFF
--- a/libs/freetype/src/main.zig
+++ b/libs/freetype/src/main.zig
@@ -34,7 +34,7 @@ test {
 }
 
 const firasans_font_path = sdkPath("/../upstream/assets/FiraSans-Regular.ttf");
-const firasans_font_data = @embedFile(sdkPath("/../upstream/assets/FiraSans-Regular.ttf"));
+const firasans_font_data = @embedFile("../upstream/assets/FiraSans-Regular.ttf");
 
 test "create face from file" {
     const lib = try ft.Library.init();


### PR DESCRIPTION
Fixes the following error when running the freetype tests.

`libs/freetype/src/main.zig:37:46: error: unable to open 'libs/freetype/src/../upstream/assets/FiraSans-Regular.ttf': FileNotFound`

Not entirely sure what is going on here. I would have expected the path to be `'src/../upstream/assets/FiraSans-Regular.ttf'` based on the sdkPath function but either way I don't think the sdkPath wrapper is needed here.

This works for running all the mach tests, and only the freetype tests from mach/libs/freetype

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.