### PR TITLE
{mach,gpu}: more undef/nul -> undefined/null renames

### DIFF
--- a/libs/gpu/README.md
+++ b/libs/gpu/README.md
@@ -215,8 +215,6 @@ The rules for translating `webgpu.h` are as follows:
   * As a result, a `null`able `Buffer` is represented simply as `?*Buffer`, and any function that would normally take `WGPUBuffer` now takes `*Buffer` as a parameter.
 * `WGPUBufferBindingType` -> `gpu.Buffer.BindingType` (purely because it's prefix matches an opaque pointer type, it thus goes into the `Buffer` opaque type.)
 * Reserved Zig keywords are translated as follows:
-  * `undefined` -> `undef`
-  * `null` -> `nul`
   * `error` -> `err`
   * `type` -> `typ`
   * `opaque` -> `opaq`

--- a/src/platform/util.zig
+++ b/src/platform/util.zig
@@ -26,7 +26,7 @@ pub fn detectBackendType(allocator: std.mem.Allocator) !gpu.BackendType {
     const MACH_GPU_BACKEND = try getEnvVarOwned(allocator, "MACH_GPU_BACKEND");
     if (MACH_GPU_BACKEND) |backend| {
         defer allocator.free(backend);
-        if (std.ascii.eqlIgnoreCase(backend, "null")) return .nul;
+        if (std.ascii.eqlIgnoreCase(backend, "null")) return .null;
         if (std.ascii.eqlIgnoreCase(backend, "d3d11")) return .d3d11;
         if (std.ascii.eqlIgnoreCase(backend, "d3d12")) return .d3d12;
         if (std.ascii.eqlIgnoreCase(backend, "metal")) return .metal;


### PR DESCRIPTION
Sorry, it was not caught by tests, only by `mach-examples`

Signed-off-by: Eric Joldasov <bratishkaerik@getgoogleoff.me>
- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.