### PR TITLE
WIP: glfw: Calling pollEvents can reach unreachable code.

### DIFF
--- a/libs/glfw/src/main.zig
+++ b/libs/glfw/src/main.zig
@@ -372,12 +372,13 @@ pub fn platformSupported(platform: PlatformType) bool {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: events, glfw.waitEvents, glfw.waitEventsTimeout
-pub inline fn pollEvents() error{PlatformError}!void {
+pub inline fn pollEvents() error{PlatformError,InvalidValue}!void {
     internal_debug.assertInitialized();
     c.glfwPollEvents();
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.PlatformError => |e| e,
+        Error.InvalidValue => |e| e,
         else => unreachable,
     };
 }


### PR DESCRIPTION
Calling pollEvents on windows will cause Error.InvalidValue when scancode 256 is hit on keyboard, which is the volume up key. It would reach unreachable code.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.