### PR TITLE
mach: remove compiler error for missing field in app (upstream issue fixed)

### DIFF
--- a/src/platform/common.zig
+++ b/src/platform/common.zig
@@ -6,17 +6,8 @@ pub fn checkApplication(comptime app_pkg: type) void {
     }
     const App = app_pkg.App;
 
-    // If App has no fields, it gets interpretted as '*const App' when it should be '*App'
-    // This gives a more useful compiler error.
-    switch (@typeInfo(App)) {
-        .Struct => |app| {
-            if (app.fields.len == 0) {
-                @compileError("App must contain fields. Example: '_unused: i32,'");
-            }
-        },
-        else => {
-            @compileError("App must be a struct type. Found:" ++ @typeName(App));
-        },
+    if (@typeInfo(App) != .Struct) {
+        @compileError("App must be a struct type. Found:" ++ @typeName(App));
     }
 
     if (@hasDecl(App, "init")) {

--- a/src/platform/libmach.zig
+++ b/src/platform/libmach.zig
@@ -7,9 +7,6 @@ const native = @import("native.zig");
 
 pub const App = @This();
 
-// TODO(self-hosted): https://github.com/ziglang/zig/issues/12275
-_unused: i32,
-
 pub const GPUInterface = gpu.dawn.Interface;
 
 const _ = gpu.Export(GPUInterface);


### PR DESCRIPTION
Workaround originally added in #548. Fortunately, the upstream issue has since been resolved. I removed the check
enforcing more than zero fields in `App`, but kept the check ensuring that `App` is a struct.

Upstream issue here: https://github.com/ziglang/zig/issues/12275
 
- [ x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.