### PR TITLE
glfw: accept null cursor in Window.setCursor

### DIFF
--- a/libs/glfw/src/Window.zig
+++ b/libs/glfw/src/Window.zig
@@ -2059,9 +2059,9 @@ pub inline fn setCursorPos(self: Window, xpos: f64, ypos: f64) error{PlatformErr
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: cursor_object
-pub inline fn setCursor(self: Window, cursor: Cursor) error{PlatformError}!void {
+pub inline fn setCursor(self: Window, cursor: ?Cursor) error{PlatformError}!void {
     internal_debug.assertInitialized();
-    c.glfwSetCursor(self.handle, cursor.ptr);
+    c.glfwSetCursor(self.handle, if (cursor) |cs| cs.ptr else null);
     getError() catch |err| return switch (err) {
         Error.NotInitialized => unreachable,
         Error.PlatformError => |e| e,

--- a/libs/glfw/src/Window.zig
+++ b/libs/glfw/src/Window.zig
@@ -699,8 +699,7 @@ pub const SizeOptional = struct {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: window_sizelimits, glfw.Window.setAspectRatio
-// TODO(self-hosted): make inline fn again, once https://github.com/ziglang/zig/issues/13164 is fixed.
-pub fn setSizeLimits(self: Window, min: SizeOptional, max: SizeOptional) error{PlatformError}!void {
+pub inline fn setSizeLimits(self: Window, min: SizeOptional, max: SizeOptional) error{PlatformError}!void {
     internal_debug.assertInitialized();
 
     if (min.width != null and max.width != null) {

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -320,6 +320,10 @@ pub const Platform = struct {
 
         platform.last_position = try platform.window.getPos();
 
+        if (options.borderless_window) {
+            try glfw.Window.setAttrib(platform.window, .decorated, false);
+        }
+
         if (options.fullscreen) {
             var monitor: ?glfw.Monitor = null;
 

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -299,6 +299,7 @@ pub const Platform = struct {
                 const pf = (window.getUserPointer(UserPtr) orelse unreachable).platform;
                 pf.last_framebuffer_size.width = width;
                 pf.last_framebuffer_size.height = height;
+                render(pf.core) catch {};
             }
         }.callback;
         platform.window.setFramebufferSizeCallback(framebuffer_size_callback);
@@ -592,15 +593,19 @@ pub fn main() !void {
     defer app.deinit(core);
 
     while (!core.internal.window.shouldClose()) {
-        // On Darwin targets, Dawn requires an NSAutoreleasePool per frame to release
-        // some resources. See Dawn's CHelloWorld example.
-        const pool = try util.AutoReleasePool.init();
-        defer util.AutoReleasePool.release(pool);
-
-        try coreUpdate(core, null);
-
-        try app.update(core);
+        try render(core);
     }
+}
+
+fn render(core: *Core) !void {
+    // On Darwin targets, Dawn requires an NSAutoreleasePool per frame to release
+    // some resources. See Dawn's CHelloWorld example.
+    const pool = try util.AutoReleasePool.init();
+    defer util.AutoReleasePool.release(pool);
+
+    try coreUpdate(core, null);
+
+    try app.update(core);
 }
 
 pub fn coreInit(allocator: std.mem.Allocator) !*Core {

--- a/src/structs.zig
+++ b/src/structs.zig
@@ -42,6 +42,9 @@ pub const Options = struct {
     /// Headless mode.
     headless: bool = false,
 
+    /// Borderless window
+    borderless_window: bool = false,
+
     /// Monitor synchronization modes.
     vsync: enums.VSyncMode = .double,
 


### PR DESCRIPTION
Fixes #620 and Fixes #581 and Fixes #527 and Helps #534

looks like transparent windows aren't supported by dawn. it's also a hint that must be set before window creation

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.