### PR TITLE
all: build: fix sdkPath for relative @src.file / fix autocompletion with ZLS / IDEs

### DIFF
--- a/dev/template/README.md
+++ b/dev/template/README.md
@@ -20,7 +20,7 @@ const foobar = @import("libs/mach-foobar/build.zig");
 
 pub fn build(b: *Builder) void {
     ...
-    exe.addPackage(foobar.pkg);
+    exe.addPackage(foobar.pkg(b));
     foobar.link(b, exe, .{});
 }
 ```

--- a/libs/earcut/README.md
+++ b/libs/earcut/README.md
@@ -32,7 +32,7 @@ const earcut = @import("libs/mach-earcut/build.zig");
 
 pub fn build(b: *Builder) void {
     ...
-    exe.addPackage(earcut.pkg);
+    exe.addPackage(earcut.pkg(b));
 }
 ```
 

--- a/libs/earcut/build.zig
+++ b/libs/earcut/build.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
+const Builder = std.build.Builder;
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
     const lib = b.addStaticLibrary("earcut", "src/main.zig");
     lib.setBuildMode(mode);
@@ -12,14 +13,67 @@ pub fn build(b: *std.build.Builder) void {
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.step);
 
-    _ = pkg;
+    _ = pkg(b);
 }
 
-pub const pkg = std.build.Pkg{
-    .name = "earcut",
-    .source = .{ .path = thisDir() ++ "/src/main.zig" },
-};
+var cached_pkg: ?std.build.Pkg = null;
 
-fn thisDir() []const u8 {
-    return std.fs.path.dirname(@src().file) orelse ".";
+pub fn pkg(b: *Builder) std.build.Pkg {
+    if (cached_pkg == null) {
+        cached_pkg = .{
+            .name = "earcut",
+            .source = .{ .path = sdkPath(b, "/src/main.zig") },
+            .dependencies = &.{},
+        };
+    }
+
+    return cached_pkg.?;
+}
+
+const unresolved_dir = (struct {
+    inline fn unresolvedDir() []const u8 {
+        return comptime std.fs.path.dirname(@src().file) orelse ".";
+    }
+}).unresolvedDir();
+
+fn thisDir(allocator: std.mem.Allocator) []const u8 {
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir;
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
+    }
+
+    return cached_dir.*.?;
+}
+
+inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
+    return sdkPathAllocator(b.allocator, suffix);
+}
+
+inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
+}
+
+fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+    if (suffix[0] != '/') @compileError("suffix must be an absolute path");
+
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir ++ @as([]const u8, &suffix);
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
+    }
+
+    return cached_dir.*.?;
 }

--- a/libs/ecs/build.zig
+++ b/libs/ecs/build.zig
@@ -1,30 +1,79 @@
 const std = @import("std");
+const Builder = std.build.Builder;
 
-pub const pkg = std.build.Pkg{
-    .name = "ecs",
-    .source = .{ .path = sdkPath("/src/main.zig") },
-    .dependencies = &[_]std.build.Pkg{},
-};
+var cached_pkg: ?std.build.Pkg = null;
 
-pub fn build(b: *std.build.Builder) void {
+pub fn pkg(b: *Builder) std.build.Pkg {
+    if (cached_pkg == null) {
+        cached_pkg = .{
+            .name = "ecs",
+            .source = .{ .path = sdkPath(b, "/src/main.zig") },
+            .dependencies = &.{},
+        };
+    }
+
+    return cached_pkg.?;
+}
+
+pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&testStep(b, mode, target).step);
 }
 
-pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
-    const main_tests = b.addTestExe("ecs-tests", sdkPath("/src/main.zig"));
+pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+    const main_tests = b.addTestExe("ecs-tests", sdkPath(b, "/src/main.zig"));
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
     main_tests.install();
     return main_tests.run();
 }
 
-fn sdkPath(comptime suffix: []const u8) []const u8 {
+const unresolved_dir = (struct {
+    inline fn unresolvedDir() []const u8 {
+        return comptime std.fs.path.dirname(@src().file) orelse ".";
+    }
+}).unresolvedDir();
+
+fn thisDir(allocator: std.mem.Allocator) []const u8 {
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir;
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
+    }
+
+    return cached_dir.*.?;
+}
+
+inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
+    return sdkPathAllocator(b.allocator, suffix);
+}
+
+inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
+}
+
+fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-    return comptime blk: {
-        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-        break :blk root_dir ++ suffix;
-    };
+
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir ++ @as([]const u8, &suffix);
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
+    }
+
+    return cached_dir.*.?;
 }

--- a/libs/freetype/README.md
+++ b/libs/freetype/README.md
@@ -28,7 +28,7 @@ const freetype = @import("libs/mach-freetype/build.zig");
 
 pub fn build(b: *Builder) void {
     ...
-    exe.addPackage(freetype.pkg);
+    exe.addPackage(freetype.pkg(b));
     freetype.link(b, exe, .{});
 
     // use this option if you are including zlib separately
@@ -46,7 +46,7 @@ freetype.link(b, exe, .{ .harfbuzz = .{} });
 You can also optionally build brotli compression (for WOFF2 font support):
 
 ```zig
-    exe.addPackage(freetype.pkg);
+    exe.addPackage(freetype.pkg(b));
     freetype.link(b, exe, .{ .freetype = .{ .brotli = true } });
 ```
 

--- a/libs/gamemode/build.zig
+++ b/libs/gamemode/build.zig
@@ -1,18 +1,70 @@
 const std = @import("std");
+const Builder = std.build.Builder;
 
-pub const pkg = std.build.Pkg{
-    .name = "gamemode",
-    .source = .{ .path = sdkPath("/gamemode.zig") },
-};
+pub fn build(_: *Builder) void {}
 
-pub fn link(step: *std.build.LibExeObjStep) void {
-    step.addIncludePath(sdkPath("/upstream/include"));
+var cached_pkg: ?std.build.Pkg = null;
+
+pub fn pkg(b: *Builder) std.build.Pkg {
+    if (cached_pkg == null) {
+        cached_pkg = .{
+            .name = "gamemode",
+            .source = .{ .path = sdkPath(b, "/src/main.zig") },
+            .dependencies = &.{},
+        };
+    }
+
+    return cached_pkg.?;
 }
 
-fn sdkPath(comptime suffix: []const u8) []const u8 {
+pub fn link(step: *std.build.LibExeObjStep) void {
+    step.addIncludePath(sdkPath(step.builder, "/upstream/include"));
+}
+
+const unresolved_dir = (struct {
+    inline fn unresolvedDir() []const u8 {
+        return comptime std.fs.path.dirname(@src().file) orelse ".";
+    }
+}).unresolvedDir();
+
+fn thisDir(allocator: std.mem.Allocator) []const u8 {
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir;
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
+    }
+
+    return cached_dir.*.?;
+}
+
+inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
+    return sdkPathAllocator(b.allocator, suffix);
+}
+
+inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
+}
+
+fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-    return comptime blk: {
-        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-        break :blk root_dir ++ suffix;
-    };
+
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir ++ @as([]const u8, &suffix);
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
+    }
+
+    return cached_dir.*.?;
 }

--- a/libs/glfw/README.md
+++ b/libs/glfw/README.md
@@ -59,7 +59,7 @@ const glfw = @import("libs/mach-glfw/build.zig");
 
 pub fn build(b: *Builder) !void {
     ...
-    exe.addPackage(glfw.pkg);
+    exe.addPackage(glfw.pkg(b));
     try glfw.link(b, exe, .{});
 }
 ```

--- a/libs/gpu/sdk.zig
+++ b/libs/gpu/sdk.zig
@@ -1,9 +1,10 @@
 const std = @import("std");
+const Builder = std.build.Builder;
 
 pub fn Sdk(comptime deps: anytype) type {
     return struct {
-        pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, options: Options) !*std.build.RunStep {
-            const main_tests = b.addTestExe("gpu-tests", sdkPath("/src/main.zig"));
+        pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, options: Options) !*std.build.RunStep {
+            const main_tests = b.addTestExe("gpu-tests", sdkPath(b, "/src/main.zig"));
             main_tests.setBuildMode(mode);
             main_tests.setTarget(target);
             try link(b, main_tests, options);
@@ -16,27 +17,58 @@ pub fn Sdk(comptime deps: anytype) type {
             gpu_dawn_options: deps.gpu_dawn.Options = .{},
         };
 
-        pub const pkg = std.build.Pkg{
-            .name = "gpu",
-            .source = .{ .path = sdkPath("/src/main.zig") },
-            .dependencies = &.{deps.glfw.pkg},
-        };
+        var cached_pkg: ?std.build.Pkg = null;
+
+        pub fn pkg(b: *Builder) std.build.Pkg {
+            if (cached_pkg == null) {
+                const dependencies = b.allocator.create([1]std.build.Pkg) catch unreachable;
+                dependencies.* = .{
+                    deps.glfw.pkg(b),
+                };
+
+                cached_pkg = .{
+                    .name = "gpu",
+                    .source = .{ .path = sdkPath(b, "/src/main.zig") },
+                    .dependencies = dependencies,
+                };
+            }
+
+            return cached_pkg.?;
+        }
 
         pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep, options: Options) !void {
             if (step.target.toTarget().cpu.arch != .wasm32) {
                 try deps.glfw.link(b, step, options.glfw_options);
                 try deps.gpu_dawn.link(b, step, options.gpu_dawn_options);
-                step.addCSourceFile(sdkPath("/src/mach_dawn.cpp"), &.{"-std=c++17"});
-                step.addIncludePath(sdkPath("/src"));
+                step.addCSourceFile(sdkPath(b, "/src/mach_dawn.cpp"), &.{"-std=c++17"});
+                step.addIncludePath(sdkPath(b, "/src"));
             }
         }
 
-        fn sdkPath(comptime suffix: []const u8) []const u8 {
+        var this_dir: ?[]const u8 = null;
+
+        fn thisDir(allocator: std.mem.Allocator) []const u8 {
+            if (this_dir == null) {
+                const unresolved_dir = comptime std.fs.path.dirname(@src().file) orelse ".";
+
+                if (comptime unresolved_dir[0] == '/') {
+                    this_dir = unresolved_dir;
+                } else {
+                    this_dir = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
+                }
+            }
+
+            return this_dir.?;
+        }
+
+        fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
+            return sdkPathAllocator(b.allocator, suffix);
+        }
+
+        fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
             if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-            return comptime blk: {
-                const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-                break :blk root_dir ++ suffix;
-            };
+
+            return std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
         }
     };
 }

--- a/libs/model3d/build.zig
+++ b/libs/model3d/build.zig
@@ -1,18 +1,28 @@
 const std = @import("std");
+const Builder = std.build.Builder;
 
-pub const pkg = std.build.Pkg{
-    .name = "model3d",
-    .source = .{ .path = sdkPath("/src/main.zig") },
-};
+var cached_pkg: ?std.build.Pkg = null;
 
-pub fn build(b: *std.build.Builder) void {
+pub fn pkg(b: *Builder) std.build.Pkg {
+    if (cached_pkg == null) {
+        cached_pkg = .{
+            .name = "model3d",
+            .source = .{ .path = sdkPath(b, "/src/main.zig") },
+            .dependencies = &.{},
+        };
+    }
+
+    return cached_pkg.?;
+}
+
+pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&testStep(b, mode, target).step);
 }
 
-pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
     const main_tests = b.addTestExe("model3d-tests", "src/main.zig");
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
@@ -21,21 +31,61 @@ pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.C
     return main_tests.run();
 }
 
-pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep, target: std.zig.CrossTarget) void {
+pub fn link(b: *Builder, step: *std.build.LibExeObjStep, target: std.zig.CrossTarget) void {
     const lib = b.addStaticLibrarySource("model3d", null);
     lib.setTarget(target);
     // Note: model3d needs unaligned accesses, which are safe on all modern architectures.
     // See https://gitlab.com/bztsrc/model3d/-/issues/19
-    lib.addCSourceFile(sdkPath("/src/c/m3d.c"), &.{ "-std=c89", "-fno-sanitize=alignment" });
+    lib.addCSourceFile(sdkPath(b, "/src/c/m3d.c"), &.{ "-std=c89", "-fno-sanitize=alignment" });
     lib.linkLibC();
-    step.addIncludePath(sdkPath("/src/c/"));
+    step.addIncludePath(sdkPath(b, "/src/c/"));
     step.linkLibrary(lib);
 }
 
-fn sdkPath(comptime suffix: []const u8) []const u8 {
+const unresolved_dir = (struct {
+    inline fn unresolvedDir() []const u8 {
+        return comptime std.fs.path.dirname(@src().file) orelse ".";
+    }
+}).unresolvedDir();
+
+fn thisDir(allocator: std.mem.Allocator) []const u8 {
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir;
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
+    }
+
+    return cached_dir.*.?;
+}
+
+inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
+    return sdkPathAllocator(b.allocator, suffix);
+}
+
+inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
+}
+
+fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-    return comptime blk: {
-        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-        break :blk root_dir ++ suffix;
-    };
+
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir ++ @as([]const u8, &suffix);
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
+    }
+
+    return cached_dir.*.?;
 }

--- a/libs/sysaudio/sdk.zig
+++ b/libs/sysaudio/sdk.zig
@@ -1,12 +1,26 @@
 const std = @import("std");
+const Builder = std.build.Builder;
 
 pub fn Sdk(comptime deps: anytype) type {
     return struct {
-        pub const pkg = std.build.Pkg{
-            .name = "sysaudio",
-            .source = .{ .path = sdkPath("/src/main.zig") },
-            .dependencies = &.{deps.sysjs.pkg},
-        };
+        var cached_pkg: ?std.build.Pkg = null;
+
+        pub fn pkg(b: *Builder) std.build.Pkg {
+            if (cached_pkg == null) {
+                const dependencies = b.allocator.create([1]std.build.Pkg) catch unreachable;
+                dependencies.* = .{
+                    deps.sysjs.pkg(b),
+                };
+
+                cached_pkg = .{
+                    .name = "sysaudio",
+                    .source = .{ .path = sdkPath(b, "/src/main.zig") },
+                    .dependencies = dependencies,
+                };
+            }
+
+            return cached_pkg.?;
+        }
 
         pub const Options = struct {
             install_libs: bool = false,
@@ -15,8 +29,8 @@ pub fn Sdk(comptime deps: anytype) type {
             system_sdk: deps.system_sdk.Options = .{},
         };
 
-        pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
-            const main_tests = b.addTestExe("sysaudio-tests", sdkPath("/src/main.zig"));
+        pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+            const main_tests = b.addTestExe("sysaudio-tests", sdkPath(b, "/src/main.zig"));
             main_tests.setBuildMode(mode);
             main_tests.setTarget(target);
             link(b, main_tests, .{});
@@ -24,7 +38,7 @@ pub fn Sdk(comptime deps: anytype) type {
             return main_tests.run();
         }
 
-        pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep, options: Options) void {
+        pub fn link(b: *Builder, step: *std.build.LibExeObjStep, options: Options) void {
             if (step.target.toTarget().cpu.arch != .wasm32) {
                 // TODO(build-system): pass system SDK options through
                 deps.system_sdk.include(b, step, .{});
@@ -50,19 +64,37 @@ pub fn Sdk(comptime deps: anytype) type {
                 if (std.mem.eql(u8, no_ensure_submodules, "true")) return;
             } else |_| {}
             var child = std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", path }, allocator);
-            child.cwd = sdkPath("/");
+            child.cwd = sdkPathAllocator(allocator, "/");
             child.stderr = std.io.getStdErr();
             child.stdout = std.io.getStdOut();
 
             _ = try child.spawnAndWait();
         }
 
-        fn sdkPath(comptime suffix: []const u8) []const u8 {
+        var this_dir: ?[]const u8 = null;
+
+        fn thisDir(allocator: std.mem.Allocator) []const u8 {
+            if (this_dir == null) {
+                const unresolved_dir = comptime std.fs.path.dirname(@src().file) orelse ".";
+
+                if (comptime unresolved_dir[0] == '/') {
+                    this_dir = unresolved_dir;
+                } else {
+                    this_dir = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
+                }
+            }
+
+            return this_dir.?;
+        }
+
+        fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
+            return sdkPathAllocator(b.allocator, suffix);
+        }
+
+        fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
             if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-            return comptime blk: {
-                const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-                break :blk root_dir ++ suffix;
-            };
+
+            return std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
         }
     };
 }

--- a/libs/sysjs/build.zig
+++ b/libs/sysjs/build.zig
@@ -1,29 +1,78 @@
 const std = @import("std");
+const Builder = std.build.Builder;
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *Builder) void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&testStep(b, mode, target).step);
 }
 
-pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
-    const main_tests = b.addTestExe("sysjs-tests", sdkPath("/src/main.zig"));
+pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+    const main_tests = b.addTestExe("sysjs-tests", sdkPath(b, "/src/main.zig"));
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
     return main_tests.run();
 }
 
-pub const pkg = std.build.Pkg{
-    .name = "sysjs",
-    .source = .{ .path = sdkPath("/src/main.zig") },
-    .dependencies = &[_]std.build.Pkg{},
-};
+var cached_pkg: ?std.build.Pkg = null;
 
-fn sdkPath(comptime suffix: []const u8) []const u8 {
+pub fn pkg(b: *Builder) std.build.Pkg {
+    if (cached_pkg == null) {
+        cached_pkg = .{
+            .name = "sysjs",
+            .source = .{ .path = sdkPath(b, "/src/main.zig") },
+            .dependencies = &.{},
+        };
+    }
+
+    return cached_pkg.?;
+}
+
+const unresolved_dir = (struct {
+    inline fn unresolvedDir() []const u8 {
+        return comptime std.fs.path.dirname(@src().file) orelse ".";
+    }
+}).unresolvedDir();
+
+fn thisDir(allocator: std.mem.Allocator) []const u8 {
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir;
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
+    }
+
+    return cached_dir.*.?;
+}
+
+inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
+    return sdkPathAllocator(b.allocator, suffix);
+}
+
+inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
+}
+
+fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-    return comptime blk: {
-        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-        break :blk root_dir ++ suffix;
-    };
+
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir ++ @as([]const u8, &suffix);
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
+    }
+
+    return cached_dir.*.?;
 }

--- a/tools/wasmserve/wasmserve.zig
+++ b/tools/wasmserve/wasmserve.zig
@@ -6,7 +6,7 @@ const mem = std.mem;
 const fs = std.fs;
 const build = std.build;
 
-const www_dir_path = sdkPath("/www");
+const www_dir_path = "/www";
 const buffer_size = 2048;
 const esc = struct {
     pub const reset = "\x1b[0m";
@@ -75,11 +75,13 @@ const Wasmserve = struct {
         self.compile();
         std.debug.assert(mem.eql(u8, fs.path.extension(self.exe_step.out_filename), ".wasm"));
 
-        var www_dir = try fs.cwd().openIterableDir(www_dir_path, .{});
+        const resolved_www_dir_path = sdkPathAllocator(step.dependencies.allocator, www_dir_path);
+
+        var www_dir = try fs.cwd().openIterableDir(resolved_www_dir_path, .{});
         defer www_dir.close();
         var www_dir_iter = www_dir.iterate();
         while (try www_dir_iter.next()) |file| {
-            const path = try fs.path.join(self.b.allocator, &.{ www_dir_path, file.name });
+            const path = try fs.path.join(self.b.allocator, &.{ resolved_www_dir_path, file.name });
             defer self.b.allocator.free(path);
             const install_www = self.b.addInstallFileWithDir(
                 .{ .path = path },
@@ -326,12 +328,52 @@ fn logErr(err: anyerror, src: std.builtin.SourceLocation) void {
     }
 }
 
-fn sdkPath(comptime suffix: []const u8) []const u8 {
+const unresolved_dir = (struct {
+    inline fn unresolvedDir() []const u8 {
+        return comptime std.fs.path.dirname(@src().file) orelse ".";
+    }
+}).unresolvedDir();
+
+fn thisDir(allocator: std.mem.Allocator) []const u8 {
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir;
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
+    }
+
+    return cached_dir.*.?;
+}
+
+inline fn sdkPath(b: *build.Builder, comptime suffix: []const u8) []const u8 {
+    return sdkPathAllocator(b.allocator, suffix);
+}
+
+inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
+}
+
+fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-    return comptime blk: {
-        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-        break :blk root_dir ++ suffix;
-    };
+
+    if (comptime unresolved_dir[0] == '/') {
+        return unresolved_dir ++ @as([]const u8, &suffix);
+    }
+
+    const cached_dir = &(struct {
+        var cached_dir: ?[]const u8 = null;
+    }).cached_dir;
+
+    if (cached_dir.* == null) {
+        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
+    }
+
+    return cached_dir.*.?;
 }
 
 // copied from LibExeObjStep.make()


### PR DESCRIPTION
Prior to this commit, the build system heavily assumed that the result of `@src.file` would always be absolute, but this is no longer guaranteed, likely due to there being no such thing as an "absolute path" in WASI.

It appears that for normal invocations of `zig build`, it is safe to assume that `@src.file` is absolute. However, when ZLS uses a custom `build_runner.zig` to collect build configuration, `@src.file` is actually relative to the current working directory, at least on my system. For a while, this led to ZLS completions breaking entirely, but presently it actually causes ZLS to crash!

The solution is not as simple as using relative `sdkPath` results as-is, because the build system may attempt to resolve these paths relative to build root, when the paths are actually relative to the current working directory.

This leads to a sticky situation: the current working directory is a runtime concept, but `@src.file` is resolved at compile time. However, it appears that the build runner does not change current working directory in between compilation and execution, so it is probably safe to calculate `sdkPath` using runtime current working directory.

Still, this requires major changes with how `sdkPath` works, since runtime computation and allocations are required. So pretty much anything that relied on `sdkPath` being comptime-known has been refactored in this commit.

The most severe result of this is that, for example, `gpu.pkg` can no longer be a comptime-known constant: it has to be a runtime function that takes a `*Builder` and returns a `Pkg`.

This commit deals with usages of `*.pkg` and `sdkPath` within Mach itself, but projects that depend on Mach such as `mach-examples` will almost certainly require changes as well.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.