### PR TITLE
glfw: complete overhaul of error handling (remove Zig errors)

### DIFF
--- a/libs/glfw/README.md
+++ b/libs/glfw/README.md
@@ -102,17 +102,29 @@ Now in your code you may import and use GLFW:
 ```zig
 const glfw = @import("glfw");
 
+/// Default GLFW error handling callback
+fn errorCallback(error_code: glfw.Error, description: [:0]const u8) void {
+    std.log.err("glfw: {}: {s}\n", .{ error_code, description });
+}
+
 pub fn main() !void {
-    try glfw.init(.{});
+    glfw.setErrorCallback(errorCallback);
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     // Create our window
-    const window = try glfw.Window.create(640, 480, "Hello, mach-glfw!", null, null, .{});
+    const window = glfw.Window.create(640, 480, "Hello, mach-glfw!", null, null, .{}) orelse {
+        std.log.err("failed to create GLFW window: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    };
     defer window.destroy();
 
     // Wait for the user to close the window.
     while (!window.shouldClose()) {
-        try glfw.pollEvents();
+        glfw.pollEvents();
     }
 }
 ```

--- a/libs/glfw/src/Joystick.zig
+++ b/libs/glfw/src/Joystick.zig
@@ -80,20 +80,14 @@ const GamepadState = extern struct {
 ///
 /// @return `true` if the joystick is present, or `false` otherwise.
 ///
-/// Possible errors include glfw.Error.NotInitialized, glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: joystick
-pub inline fn present(self: Joystick) error{PlatformError}!bool {
+pub inline fn present(self: Joystick) bool {
     internal_debug.assertInitialized();
     const is_present = c.glfwJoystickPresent(@enumToInt(self.jid));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidEnum => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     return is_present == c.GLFW_TRUE;
 }
 
@@ -107,7 +101,8 @@ pub inline fn present(self: Joystick) error{PlatformError}!bool {
 ///
 /// @return An array of axis values, or null if the joystick is not present.
 ///
-/// Possible errors include glfw.Error.NotInitialized, glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned array is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the specified joystick is disconnected or the library is
@@ -117,16 +112,10 @@ pub inline fn present(self: Joystick) error{PlatformError}!bool {
 ///
 /// see also: joystick_axis
 /// Replaces `glfwGetJoystickPos`.
-pub inline fn getAxes(self: Joystick) error{PlatformError}!?[]const f32 {
+pub inline fn getAxes(self: Joystick) ?[]const f32 {
     internal_debug.assertInitialized();
     var count: c_int = undefined;
     const axes = c.glfwGetJoystickAxes(@enumToInt(self.jid), &count);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidEnum => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     if (axes == null) return null;
     return axes[0..@intCast(u32, count)];
 }
@@ -147,7 +136,8 @@ pub inline fn getAxes(self: Joystick) error{PlatformError}!?[]const f32 {
 ///
 /// @return An array of button states, or null if the joystick is not present.
 ///
-/// Possible errors include glfw.Error.NotInitialized, glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned array is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the specified joystick is disconnected or the library is terminated.
@@ -155,16 +145,10 @@ pub inline fn getAxes(self: Joystick) error{PlatformError}!?[]const f32 {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: joystick_button
-pub inline fn getButtons(self: Joystick) error{PlatformError}!?[]const u8 {
+pub inline fn getButtons(self: Joystick) ?[]const u8 {
     internal_debug.assertInitialized();
     var count: c_int = undefined;
     const buttons = c.glfwGetJoystickButtons(@enumToInt(self.jid), &count);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidEnum => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     if (buttons == null) return null;
     return buttons[0..@intCast(u32, count)];
 }
@@ -200,7 +184,8 @@ pub inline fn getButtons(self: Joystick) error{PlatformError}!?[]const u8 {
 ///
 /// @return An array of hat states, or null if the joystick is not present.
 ///
-/// Possible errors include glfw.Error.NotInitialized, glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned array is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the specified joystick is disconnected, this function is called
@@ -209,16 +194,10 @@ pub inline fn getButtons(self: Joystick) error{PlatformError}!?[]const u8 {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: joystick_hat
-pub inline fn getHats(self: Joystick) error{PlatformError}!?[]const Hat {
+pub inline fn getHats(self: Joystick) ?[]const Hat {
     internal_debug.assertInitialized();
     var count: c_int = undefined;
     const hats = c.glfwGetJoystickHats(@enumToInt(self.jid), &count);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidEnum => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     if (hats == null) return null;
     const slice = hats[0..@intCast(u32, count)];
     return @ptrCast(*const []const Hat, &slice).*;
@@ -235,7 +214,8 @@ pub inline fn getHats(self: Joystick) error{PlatformError}!?[]const Hat {
 /// @return The UTF-8 encoded name of the joystick, or null if the joystick is not present or an
 /// error occurred.
 ///
-/// Possible errors include glfw.Error.NotInitialized, glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the specified joystick is disconnected or the library is terminated.
@@ -243,15 +223,9 @@ pub inline fn getHats(self: Joystick) error{PlatformError}!?[]const Hat {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: joystick_name
-pub inline fn getName(self: Joystick) error{PlatformError}!?[:0]const u8 {
+pub inline fn getName(self: Joystick) ?[:0]const u8 {
     internal_debug.assertInitialized();
     const name_opt = c.glfwGetJoystickName(@enumToInt(self.jid));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidEnum => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     return if (name_opt) |name|
         std.mem.span(@ptrCast([*:0]const u8, name))
     else
@@ -277,7 +251,8 @@ pub inline fn getName(self: Joystick) error{PlatformError}!?[:0]const u8 {
 ///
 /// @return The UTF-8 encoded GUID of the joystick, or null if the joystick is not present.
 ///
-/// Possible errors include glfw.Error.NotInitialized, glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the specified joystick is disconnected or the library is terminated.
@@ -285,15 +260,9 @@ pub inline fn getName(self: Joystick) error{PlatformError}!?[:0]const u8 {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: gamepad
-pub inline fn getGUID(self: Joystick) error{PlatformError}!?[:0]const u8 {
+pub inline fn getGUID(self: Joystick) ?[:0]const u8 {
     internal_debug.assertInitialized();
     const guid_opt = c.glfwGetJoystickGUID(@enumToInt(self.jid));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidEnum => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     return if (guid_opt) |guid|
         std.mem.span(@ptrCast([*:0]const u8, guid))
     else
@@ -313,10 +282,6 @@ pub inline fn getGUID(self: Joystick) error{PlatformError}!?[:0]const u8 {
 pub inline fn setUserPointer(self: Joystick, comptime T: type, pointer: *T) void {
     internal_debug.assertInitialized();
     c.glfwSetJoystickUserPointer(@enumToInt(self.jid), @ptrCast(*anyopaque, pointer));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
 }
 
 /// Returns the user pointer of the specified joystick.
@@ -333,10 +298,6 @@ pub inline fn setUserPointer(self: Joystick, comptime T: type, pointer: *T) void
 pub inline fn getUserPointer(self: Joystick, comptime PointerType: type) ?PointerType {
     internal_debug.assertInitialized();
     const ptr = c.glfwGetJoystickUserPointer(@enumToInt(self.jid));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
     if (ptr) |p| return @ptrCast(PointerType, @alignCast(@alignOf(std.meta.Child(PointerType)), p));
     return null;
 }
@@ -366,8 +327,6 @@ pub const Event = enum(c_int) {
 /// @callback_param `event` One of `.connected` or `.disconnected`. Future releases may add
 /// more events.
 ///
-/// Possible errors include glfw.Error.NotInitialized.
-///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: joystick_event
@@ -388,11 +347,6 @@ pub inline fn setCallback(comptime callback: ?fn (joystick: Joystick, event: Eve
     } else {
         if (c.glfwSetJoystickCallback(null) != null) return;
     }
-
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
 }
 
 /// Adds the specified SDL_GameControllerDB gamepad mappings.
@@ -410,7 +364,8 @@ pub inline fn setCallback(comptime callback: ?fn (joystick: Joystick, event: Eve
 ///
 /// @param[in] string The string containing the gamepad mappings.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.InvalidValue.
+/// Possible errors include glfw.Error.InvalidValue.
+/// Returns a boolean indicating success.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -418,18 +373,9 @@ pub inline fn setCallback(comptime callback: ?fn (joystick: Joystick, event: Eve
 ///
 ///
 /// @ingroup input
-pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) error{InvalidValue}!void {
+pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) bool {
     internal_debug.assertInitialized();
-    if (c.glfwUpdateGamepadMappings(gamepad_mappings) == c.GLFW_TRUE) return;
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        // TODO: Maybe return as 'ParseError' here?
-        // TODO: Look into upstream proposal for GLFW to publicize
-        // their Gamepad mappings parsing functions/interface
-        // for a better error message in debug.
-        Error.InvalidValue => |e| e,
-        else => unreachable,
-    };
+    return c.glfwUpdateGamepadMappings(gamepad_mappings) == c.GLFW_TRUE;
 }
 
 /// Returns whether the specified joystick has a gamepad mapping.
@@ -442,7 +388,8 @@ pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) error{Inval
 ///
 /// @return `true` if a joystick is both present and has a gamepad mapping, or `false` otherwise.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.InvalidEnum.
+/// Possible errors include glfw.Error.InvalidEnum.
+/// Additionally returns false in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -450,11 +397,6 @@ pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) error{Inval
 pub inline fn isGamepad(self: Joystick) bool {
     internal_debug.assertInitialized();
     const is_gamepad = c.glfwJoystickIsGamepad(@enumToInt(self.jid));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidEnum => unreachable,
-        else => unreachable,
-    };
     return is_gamepad == c.GLFW_TRUE;
 }
 
@@ -470,7 +412,8 @@ pub inline fn isGamepad(self: Joystick) bool {
 /// @return The UTF-8 encoded name of the gamepad, or null if the joystick is not present or does
 /// not have a mapping.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.InvalidEnum.
+/// Possible errors include glfw.Error.InvalidEnum.
+/// Additionally returns null in the event of an error.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the specified joystick is disconnected, the gamepad mappings are
@@ -482,11 +425,6 @@ pub inline fn isGamepad(self: Joystick) bool {
 pub inline fn getGamepadName(self: Joystick) ?[:0]const u8 {
     internal_debug.assertInitialized();
     const name_opt = c.glfwGetGamepadName(@enumToInt(self.jid));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidValue => unreachable,
-        else => unreachable,
-    };
     return if (name_opt) |name|
         std.mem.span(@ptrCast([*:0]const u8, name))
     else
@@ -512,7 +450,8 @@ pub inline fn getGamepadName(self: Joystick) ?[:0]const u8 {
 /// @return the gamepad input state if successful, or null if no joystick is connected or it has no
 /// gamepad mapping.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.InvalidEnum.
+/// Possible errors include glfw.Error.InvalidEnum.
+/// Returns null in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -521,81 +460,101 @@ pub inline fn getGamepadState(self: Joystick) ?GamepadState {
     internal_debug.assertInitialized();
     var state: GamepadState = undefined;
     const success = c.glfwGetGamepadState(@enumToInt(self.jid), @ptrCast(*c.GLFWgamepadstate, &state));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidEnum => unreachable,
-        else => unreachable,
-    };
     return if (success == c.GLFW_TRUE) state else null;
 }
 
 test "present" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
-
-    _ = joystick.present() catch |err| std.debug.print("failed to detect joystick, joysticks not supported? error={}\n", .{err});
+    _ = joystick.present();
 }
 
 test "getAxes" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
-
-    _ = joystick.getAxes() catch |err| std.debug.print("failed to get joystick axes, joysticks not supported? error={}\n", .{err});
+    _ = joystick.getAxes();
 }
 
 test "getButtons" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
-
-    _ = joystick.getButtons() catch |err| std.debug.print("failed to get joystick buttons, joysticks not supported? error={}\n", .{err});
+    _ = joystick.getButtons();
 }
 
 test "getHats" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
 
-    _ = joystick.getHats() catch |err| std.debug.print("failed to get joystick hats, joysticks not supported? error={}\n", .{err});
-    const hats = std.mem.zeroes(Hat);
-    if (hats.down and hats.up) {
-        // down-up!
+    if (joystick.getHats()) |hats| {
+        for (hats) |hat| {
+            if (hat.down and hat.up) {
+                // down-up!
+            }
+        }
     }
 }
 
 test "getName" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
-
-    _ = joystick.getName() catch |err| std.debug.print("failed to get joystick name, joysticks not supported? error={}\n", .{err});
+    _ = joystick.getName();
 }
 
 test "getGUID" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
-
-    _ = joystick.getGUID() catch |err| std.debug.print("failed to get joystick GUID, joysticks not supported? error={}\n", .{err});
+    _ = joystick.getGUID();
 }
 
 test "setUserPointer_syntax" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
@@ -607,7 +566,11 @@ test "setUserPointer_syntax" {
 
 test "getUserPointer_syntax" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
@@ -619,7 +582,11 @@ test "getUserPointer_syntax" {
 
 test "setCallback" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     glfw.Joystick.setCallback((struct {
@@ -637,7 +604,11 @@ test "updateGamepadMappings_syntax" {
 
 test "isGamepad" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
@@ -646,7 +617,11 @@ test "isGamepad" {
 
 test "getGamepadName" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };
@@ -655,7 +630,11 @@ test "getGamepadName" {
 
 test "getGamepadState" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const joystick = glfw.Joystick{ .jid = .one };

--- a/libs/glfw/src/Monitor.zig
+++ b/libs/glfw/src/Monitor.zig
@@ -27,21 +27,16 @@ const Pos = struct {
 
 /// Returns the position of the monitor's viewport on the virtual screen.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_properties
-pub inline fn getPos(self: Monitor) error{PlatformError}!Pos {
+pub inline fn getPos(self: Monitor) Pos {
     internal_debug.assertInitialized();
     var xpos: c_int = 0;
     var ypos: c_int = 0;
     c.glfwGetMonitorPos(self.handle, &xpos, &ypos);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     return Pos{ .x = @intCast(u32, xpos), .y = @intCast(u32, ypos) };
 }
 
@@ -60,23 +55,19 @@ const Workarea = struct {
 
 /// Retrieves the work area of the monitor.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.PlatformError.
+/// A zero value is returned in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_workarea
-pub inline fn getWorkarea(self: Monitor) error{PlatformError}!Workarea {
+pub inline fn getWorkarea(self: Monitor) Workarea {
     internal_debug.assertInitialized();
     var xpos: c_int = 0;
     var ypos: c_int = 0;
     var width: c_int = 0;
     var height: c_int = 0;
     c.glfwGetMonitorWorkarea(self.handle, &xpos, &ypos, &width, &height);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     return Workarea{ .x = @intCast(u32, xpos), .y = @intCast(u32, ypos), .width = @intCast(u32, width), .height = @intCast(u32, height) };
 }
 
@@ -92,9 +83,6 @@ const PhysicalSize = struct {
 /// [EDID](https://en.wikipedia.org/wiki/Extended_display_identification_data)
 /// data is incorrect or because the driver does not report it accurately.
 ///
-/// Possible errors include glfw.Error.NotInitialized.
-///
-///
 /// win32: On Windows 8 and earlier the physical size is calculated from
 /// the current resolution and system DPI instead of querying the monitor EDID data
 /// @thread_safety This function must only be called from the main thread.
@@ -105,10 +93,6 @@ pub inline fn getPhysicalSize(self: Monitor) PhysicalSize {
     var width_mm: c_int = 0;
     var height_mm: c_int = 0;
     c.glfwGetMonitorPhysicalSize(self.handle, &width_mm, &height_mm);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
     return PhysicalSize{ .width_mm = @intCast(u32, width_mm), .height_mm = @intCast(u32, height_mm) };
 }
 
@@ -130,21 +114,17 @@ const ContentScale = struct {
 
 /// Returns the content scale for the monitor.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.PlatformError.
+/// A zero value is returned in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_scale, glfw.Window.getContentScale
-pub inline fn getContentScale(self: Monitor) error{PlatformError}!ContentScale {
+pub inline fn getContentScale(self: Monitor) ContentScale {
     internal_debug.assertInitialized();
     var x_scale: f32 = 0;
     var y_scale: f32 = 0;
     c.glfwGetMonitorContentScale(self.handle, &x_scale, &y_scale);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
     return ContentScale{ .x_scale = @floatCast(f32, x_scale), .y_scale = @floatCast(f32, y_scale) };
 }
 
@@ -153,8 +133,6 @@ pub inline fn getContentScale(self: Monitor) error{PlatformError}!ContentScale {
 /// This function returns a human-readable name, encoded as UTF-8, of the specified monitor. The
 /// name typically reflects the make and model of the monitor and is not guaranteed to be unique
 /// among the connected monitors.
-///
-/// Possible errors include glfw.Error.NotInitialized.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the specified monitor is disconnected or the library is terminated.
@@ -165,11 +143,8 @@ pub inline fn getContentScale(self: Monitor) error{PlatformError}!ContentScale {
 pub inline fn getName(self: Monitor) [*:0]const u8 {
     internal_debug.assertInitialized();
     if (c.glfwGetMonitorName(self.handle)) |name| return @ptrCast([*:0]const u8, name);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
-    // `glfwGetMonitorName` returns `null` only for errors
+    // `glfwGetMonitorName` returns `null` only for errors, but the only error is unreachable
+    // (NotInitialized)
     unreachable;
 }
 
@@ -181,18 +156,12 @@ pub inline fn getName(self: Monitor) [*:0]const u8 {
 /// This function may be called from the monitor callback, even for a monitor that is being
 /// disconnected.
 ///
-/// Possible errors include glfw.Error.NotInitialized.
-///
 /// @thread_safety This function may be called from any thread. Access is not synchronized.
 ///
 /// see also: monitor_userptr, glfw.Monitor.getUserPointer
 pub inline fn setUserPointer(self: Monitor, comptime T: type, ptr: *T) void {
     internal_debug.assertInitialized();
     c.glfwSetMonitorUserPointer(self.handle, ptr);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
 }
 
 /// Returns the user pointer of the specified monitor.
@@ -202,18 +171,12 @@ pub inline fn setUserPointer(self: Monitor, comptime T: type, ptr: *T) void {
 /// This function may be called from the monitor callback, even for a monitor that is being
 /// disconnected.
 ///
-/// Possible errors include glfw.Error.NotInitialized.
-///
 /// @thread_safety This function may be called from any thread. Access is not synchronized.
 ///
 /// see also: monitor_userptr, glfw.Monitor.setUserPointer
 pub inline fn getUserPointer(self: Monitor, comptime T: type) ?*T {
     internal_debug.assertInitialized();
     const ptr = c.glfwGetMonitorUserPointer(self.handle);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
     if (ptr == null) return null;
     return @ptrCast(*T, @alignCast(@alignOf(T), ptr.?));
 }
@@ -225,14 +188,17 @@ pub inline fn getUserPointer(self: Monitor, comptime T: type) ?*T {
 /// then by resolution area (the product of width and height), then resolution width and finally
 /// by refresh rate.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.PlatformError.
+/// Returns null in the event of an error.
 ///
 /// The returned slice memory is owned by the caller.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_modes, glfw.Monitor.getVideoMode
-pub inline fn getVideoModes(self: Monitor, allocator: mem.Allocator) (mem.Allocator.Error || error{PlatformError})![]VideoMode {
+//
+/// TODO(glfw): rewrite this to not require any allocation.
+pub inline fn getVideoModes(self: Monitor, allocator: mem.Allocator) mem.Allocator.Error!?[]VideoMode {
     internal_debug.assertInitialized();
     var count: c_int = 0;
     if (c.glfwGetVideoModes(self.handle, &count)) |modes| {
@@ -243,13 +209,7 @@ pub inline fn getVideoModes(self: Monitor, allocator: mem.Allocator) (mem.Alloca
         }
         return slice;
     }
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
-    // `glfwGetVideoModes` returns `null` only for errors
-    unreachable;
+    return null;
 }
 
 /// Returns the current mode of the specified monitor.
@@ -258,21 +218,16 @@ pub inline fn getVideoModes(self: Monitor, allocator: mem.Allocator) (mem.Alloca
 /// full screen window for that monitor, the return value will depend on whether that window is
 /// iconified.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.PlatformError.
+/// Additionally returns null in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_modes, glfw.Monitor.getVideoModes
-pub inline fn getVideoMode(self: Monitor) error{PlatformError}!VideoMode {
+pub inline fn getVideoMode(self: Monitor) ?VideoMode {
     internal_debug.assertInitialized();
     if (c.glfwGetVideoMode(self.handle)) |mode| return VideoMode{ .handle = mode.* };
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
-    // `glfwGetVideoMode` returns `null` only for errors
-    unreachable;
+    return null;
 }
 
 /// Generates a gamma ramp and sets it for the specified monitor.
@@ -286,7 +241,7 @@ pub inline fn getVideoMode(self: Monitor) error{PlatformError}!VideoMode {
 ///
 /// For gamma correct rendering with OpenGL or OpenGL ES, see the glfw.srgb_capable hint.
 ///
-/// Possible errors include glfw.Error.NotInitialized, glfw.Error.InvalidValue and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.InvalidValue and glfw.Error.PlatformError.
 ///
 /// wayland: Gamma handling is a privileged protocol, this function will thus never be implemented
 /// and emits glfw.Error.PlatformError.
@@ -294,7 +249,7 @@ pub inline fn getVideoMode(self: Monitor) error{PlatformError}!VideoMode {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_gamma
-pub inline fn setGamma(self: Monitor, gamma: f32) error{PlatformError}!void {
+pub inline fn setGamma(self: Monitor, gamma: f32) void {
     internal_debug.assertInitialized();
 
     std.debug.assert(!std.math.isNan(gamma));
@@ -302,19 +257,14 @@ pub inline fn setGamma(self: Monitor, gamma: f32) error{PlatformError}!void {
     std.debug.assert(gamma <= std.math.f32_max);
 
     c.glfwSetGamma(self.handle, gamma);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidValue => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
 }
 
 /// Returns the current gamma ramp for the specified monitor.
 ///
 /// This function returns the current gamma ramp of the specified monitor.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.PlatformError.
+/// Additionally returns null in the event of an error.
 ///
 /// wayland: Gamma handling is a privileged protocol, this function will thus never be implemented
 /// and returns glfw.Error.PlatformError.
@@ -326,16 +276,10 @@ pub inline fn setGamma(self: Monitor, gamma: f32) error{PlatformError}!void {
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_gamma
-pub inline fn getGammaRamp(self: Monitor) error{ PlatformError, FeatureUnavailable }!GammaRamp {
+pub inline fn getGammaRamp(self: Monitor) ?GammaRamp {
     internal_debug.assertInitialized();
     if (c.glfwGetGammaRamp(self.handle)) |ramp| return GammaRamp.fromC(ramp.*);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.PlatformError, Error.FeatureUnavailable => |e| e,
-        else => unreachable,
-    };
-    // `glfwGetGammaRamp` returns `null` only for errors
-    unreachable;
+    return null;
 }
 
 /// Sets the current gamma ramp for the specified monitor.
@@ -350,7 +294,7 @@ pub inline fn getGammaRamp(self: Monitor) error{ PlatformError, FeatureUnavailab
 ///
 /// For gamma correct rendering with OpenGL or OpenGL ES, see the glfw.srgb_capable hint.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.PlatformError.
 ///
 /// The size of the specified gamma ramp should match the size of the current ramp for that
 /// monitor. On win32, the gamma ramp size must be 256.
@@ -363,14 +307,9 @@ pub inline fn getGammaRamp(self: Monitor) error{ PlatformError, FeatureUnavailab
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_gamma
-pub inline fn setGammaRamp(self: Monitor, ramp: GammaRamp) error{PlatformError}!void {
+pub inline fn setGammaRamp(self: Monitor, ramp: GammaRamp) void {
     internal_debug.assertInitialized();
     c.glfwSetGammaRamp(self.handle, &ramp.toC());
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
 }
 
 /// Returns the currently connected monitors.
@@ -395,11 +334,8 @@ pub inline fn getAll(allocator: mem.Allocator) mem.Allocator.Error![]Monitor {
         }
         return slice;
     }
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
-    // `glfwGetMonitors` returning null can be either an error or no monitors
+    // `glfwGetMonitors` returning null can be either an error or no monitors, but the only error is
+    // unreachable (NotInitialized)
     return &[_]Monitor{};
 }
 
@@ -408,18 +344,12 @@ pub inline fn getAll(allocator: mem.Allocator) mem.Allocator.Error![]Monitor {
 /// This function returns the primary monitor. This is usually the monitor where elements like
 /// the task bar or global menu bar are located.
 ///
-/// Possible errors include glfw.Error.NotInitialized.
-///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_monitors, glfw.monitors.getAll
 pub inline fn getPrimary() ?Monitor {
     internal_debug.assertInitialized();
     if (c.glfwGetPrimaryMonitor()) |handle| return Monitor{ .handle = handle };
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
     return null;
 }
 
@@ -448,8 +378,6 @@ pub const Event = enum(c_int) {
 ///
 /// `event` may be one of .connected or .disconnected. More events may be added in the future.
 ///
-/// Possible errors include glfw.Error.NotInitialized.
-///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: monitor_event
@@ -470,16 +398,15 @@ pub inline fn setCallback(comptime callback: ?fn (monitor: Monitor, event: Event
     } else {
         if (c.glfwSetMonitorCallback(null) != null) return;
     }
-
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
 }
 
 test "getAll" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const allocator = testing.allocator;
@@ -489,7 +416,11 @@ test "getAll" {
 
 test "getPrimary" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     _ = getPrimary();
@@ -497,29 +428,41 @@ test "getPrimary" {
 
 test "getPos" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
     if (monitor) |m| {
-        _ = try m.getPos();
+        _ = m.getPos();
     }
 }
 
 test "getWorkarea" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
     if (monitor) |m| {
-        _ = try m.getWorkarea();
+        _ = m.getWorkarea();
     }
 }
 
 test "getPhysicalSize" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
@@ -530,18 +473,26 @@ test "getPhysicalSize" {
 
 test "getContentScale" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
     if (monitor) |m| {
-        _ = try m.getContentScale();
+        _ = m.getContentScale();
     }
 }
 
 test "getName" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
@@ -552,7 +503,11 @@ test "getName" {
 
 test "userPointer" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
@@ -568,7 +523,11 @@ test "userPointer" {
 
 test "setCallback" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     setCallback(struct {
@@ -581,46 +540,57 @@ test "setCallback" {
 
 test "getVideoModes" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
     if (monitor) |m| {
         const allocator = testing.allocator;
-        const modes = try m.getVideoModes(allocator);
-        defer allocator.free(modes);
+        const modes_maybe = try m.getVideoModes(allocator);
+        if (modes_maybe) |modes| {
+            defer allocator.free(modes);
+        }
     }
 }
 
 test "getVideoMode" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
     if (monitor) |m| {
-        _ = try m.getVideoMode();
+        _ = m.getVideoMode();
     }
 }
 
 test "set_getGammaRamp" {
     const allocator = testing.allocator;
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     const monitor = getPrimary();
     if (monitor) |m| {
-        const ramp = m.getGammaRamp() catch |err| {
-            std.debug.print("can't get window position, wayland maybe? error={}\n", .{err});
-            return;
-        };
+        if (m.getGammaRamp()) |ramp| {
+            // Set it to the exact same value; if we do otherwise an our tests fail it wouldn't call
+            // terminate and our made-up gamma ramp would get stuck.
+            m.setGammaRamp(ramp);
 
-        // Set it to the exact same value; if we do otherwise an our tests fail it wouldn't call
-        // terminate and our made-up gamma ramp would get stuck.
-        try m.setGammaRamp(ramp);
-
-        // technically not needed here / noop because GLFW owns this gamma ramp.
-        defer ramp.deinit(allocator);
+            // technically not needed here / noop because GLFW owns this gamma ramp.
+            defer ramp.deinit(allocator);
+        }
     }
 }

--- a/libs/glfw/src/clipboard.zig
+++ b/libs/glfw/src/clipboard.zig
@@ -12,21 +12,16 @@ const internal_debug = @import("internal_debug.zig");
 ///
 /// @param[in] string A UTF-8 encoded string.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.PlatformError.
 ///
 /// @pointer_lifetime The specified string is copied before this function returns.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: clipboard, glfwGetClipboardString
-pub inline fn setClipboardString(value: [*:0]const u8) error{PlatformError}!void {
+pub inline fn setClipboardString(value: [*:0]const u8) void {
     internal_debug.assertInitialized();
     c.glfwSetClipboardString(null, value);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.PlatformError => |e| e,
-        else => unreachable,
-    };
 }
 
 /// Returns the contents of the clipboard as a string.
@@ -37,7 +32,8 @@ pub inline fn setClipboardString(value: [*:0]const u8) error{PlatformError}!void
 ///
 /// @return The contents of the clipboard as a UTF-8 encoded string.
 ///
-/// Possible errors include glfw.Error.NotInitialized, glfw.Error.FormatUnavailable and glfw.Error.PlatformError.
+/// Possible errors include glfw.Error.FormatUnavailable and glfw.Error.PlatformError.
+/// null is returned in the event of an error.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
 /// yourself. It is valid until the next call to glfw.getClipboardString or glfw.setClipboardString
@@ -46,30 +42,32 @@ pub inline fn setClipboardString(value: [*:0]const u8) error{PlatformError}!void
 /// @thread_safety This function must only be called from the main thread.
 ///
 /// see also: clipboard, glfwSetClipboardString
-pub inline fn getClipboardString() error{ FormatUnavailable, PlatformError }![:0]const u8 {
+pub inline fn getClipboardString() ?[:0]const u8 {
     internal_debug.assertInitialized();
     if (c.glfwGetClipboardString(null)) |c_str| return std.mem.span(@ptrCast([*:0]const u8, c_str));
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.FormatUnavailable, Error.PlatformError => |e| e,
-        else => unreachable,
-    };
-    // `glfwGetClipboardString` returns `null` only for errors
-    unreachable;
+    return null;
 }
 
 test "setClipboardString" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
-    try glfw.setClipboardString("hello mach");
+    glfw.setClipboardString("hello mach");
 }
 
 test "getClipboardString" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
-    _ = glfw.getClipboardString() catch |err| std.debug.print("can't get clipboard, not supported by OS? error={}\n", .{err});
+    _ = glfw.getClipboardString();
 }

--- a/libs/glfw/src/errors.zig
+++ b/libs/glfw/src/errors.zig
@@ -190,6 +190,13 @@ pub inline fn getError() Error!void {
     return convertError(c.glfwGetError(null));
 }
 
+/// Returns and clears the last error for the calling thread. If no error is present, this function
+/// panics.
+pub inline fn mustGetError() Error {
+    try getError();
+    @panic("glfw: mustGetError called but no error is present");
+}
+
 /// Returns and clears the last error description for the calling thread.
 ///
 /// This function returns a UTF-8 encoded human-readable description of the last error that occured

--- a/libs/glfw/src/native.zig
+++ b/libs/glfw/src/native.zig
@@ -61,17 +61,12 @@ pub fn Native(comptime options: BackendOptions) type {
         /// return: The UTF-8 encoded adapter device name (for example `\\.\DISPLAY1`) of the
         /// specified monitor.
         ///
-        /// Possible errors include glfw.Error.NotInitalized.
-        ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWin32Adapter(monitor: Monitor) [*:0]const u8 {
             internal_debug.assertInitialized();
             if (native.glfwGetWin32Adapter(@ptrCast(*native.GLFWmonitor, monitor.handle))) |adapter| return adapter;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetWin32Adapter` returns `null` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
@@ -80,17 +75,12 @@ pub fn Native(comptime options: BackendOptions) type {
         /// return: The UTF-8 encoded display device name (for example `\\.\DISPLAY1\Monitor0`)
         /// of the specified monitor.
         ///
-        /// Possible errors include glfw.Error.NotInitalized.
-        ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWin32Monitor(monitor: Monitor) [*:0]const u8 {
             internal_debug.assertInitialized();
             if (native.glfwGetWin32Monitor(@ptrCast(*native.GLFWmonitor, monitor.handle))) |mon| return mon;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetWin32Monitor` returns `null` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
@@ -104,18 +94,13 @@ pub fn Native(comptime options: BackendOptions) type {
         /// ```
         /// This DC is private and does not need to be released.
         ///
-        /// Possible errors include glfw.Error.NotInitalized.
-        ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWin32Window(window: Window) std.os.windows.HWND {
             internal_debug.assertInitialized();
             if (native.glfwGetWin32Window(@ptrCast(*native.GLFWwindow, window.handle))) |win|
                 return @ptrCast(std.os.windows.HWND, win);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetWin32Window` returns `null` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
@@ -129,260 +114,180 @@ pub fn Native(comptime options: BackendOptions) type {
         /// ```
         /// This DC is private and does not need to be released.
         ///
-        /// Possible errors include glfw.Error.NotInitalized.
+        /// Possible errors include glfw.Error.NoWindowContext
+        /// null is returned in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
-        pub fn getWGLContext(window: Window) error{NoWindowContext}!std.os.windows.HGLRC {
+        pub fn getWGLContext(window: Window) ?std.os.windows.HGLRC {
             internal_debug.assertInitialized();
             if (native.glfwGetWGLContext(@ptrCast(*native.GLFWwindow, window.handle))) |context| return context;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetWGLContext` returns `null` only for errors
-            unreachable;
+            return null;
         }
 
         /// Returns the `CGDirectDisplayID` of the specified monitor.
-        ///
-        /// Possible errors include glfw.Error.NotInitalized.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getCocoaMonitor(monitor: Monitor) u32 {
             internal_debug.assertInitialized();
             const mon = native.glfwGetCocoaMonitor(@ptrCast(*native.GLFWmonitor, monitor.handle));
             if (mon != native.kCGNullDirectDisplay) return mon;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetCocoaMonitor` returns `kCGNullDirectDisplay` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Returns the `NSWindow` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NotInitalized.
-        ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getCocoaWindow(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
-            const win = native.glfwGetCocoaWindow(@ptrCast(*native.GLFWwindow, window.handle));
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
-            return win;
+            return native.glfwGetCocoaWindow(@ptrCast(*native.GLFWwindow, window.handle));
         }
 
         /// Returns the `NSWindow` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NotInitialized, glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.Error.NoWindowContext.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
-        pub fn getNSGLContext(window: Window) error{NoWindowContext}!u32 {
+        pub fn getNSGLContext(window: Window) u32 {
             internal_debug.assertInitialized();
-            const context = native.glfwGetNSGLContext(@ptrCast(*native.GLFWwindow, window.handle));
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            return context;
+            return native.glfwGetNSGLContext(@ptrCast(*native.GLFWwindow, window.handle));
         }
 
         /// Returns the `Display` used by GLFW.
-        ///
-        /// Possible errors include glfw.Error.NotInitalized.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getX11Display() *anyopaque {
             internal_debug.assertInitialized();
             if (native.glfwGetX11Display()) |display| return @ptrCast(*anyopaque, display);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetX11Display` returns `null` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Returns the `RRCrtc` of the specified monitor.
-        ///
-        /// Possible errors include glfw.Error.NotInitalized.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getX11Adapter(monitor: Monitor) u32 {
             internal_debug.assertInitialized();
             const adapter = native.glfwGetX11Adapter(@ptrCast(*native.GLFWMonitor, monitor.handle));
             if (adapter != 0) return adapter;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetX11Adapter` returns `0` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Returns the `RROutput` of the specified monitor.
-        ///
-        /// Possible errors include glfw.Error.NotInitalized.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getX11Monitor(monitor: Monitor) u32 {
             internal_debug.assertInitialized();
             const mon = native.glfwGetX11Monitor(@ptrCast(*native.GLFWmonitor, monitor.handle));
             if (mon != 0) return mon;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetX11Monitor` returns `0` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Returns the `Window` of the specified window.
-        ///
-        /// Possible errors include glfw.Error.NotInitalized.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getX11Window(window: Window) u32 {
             internal_debug.assertInitialized();
             const win = native.glfwGetX11Window(@ptrCast(*native.GLFWwindow, window.handle));
             if (win != 0) return @intCast(u32, win);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetX11Window` returns `0` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Sets the current primary selection to the specified string.
         ///
-        /// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+        /// Possible errors include glfw.Error.PlatformError.
         ///
         /// The specified string is copied before this function returns.
         ///
         /// thread_safety: This function must only be called from the main thread.
-        pub fn setX11SelectionString(string: [*:0]const u8) error{PlatformError}!void {
+        pub fn setX11SelectionString(string: [*:0]const u8) void {
             internal_debug.assertInitialized();
             native.glfwSetX11SelectionString(string);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.PlatformError => |e| e,
-                else => unreachable,
-            };
         }
 
         /// Returns the contents of the current primary selection as a string.
         ///
-        /// Possible errors include glfw.Error.NotInitialized and glfw.Error.PlatformError.
+        /// Possible errors include glfw.Error.PlatformError.
+        /// Returns null in the event of an error.
         ///
         /// The returned string is allocated and freed by GLFW. You should not free it
         /// yourself. It is valid until the next call to getX11SelectionString or
         /// setX11SelectionString, or until the library is terminated.
         ///
         /// thread_safety: This function must only be called from the main thread.
-        pub fn getX11SelectionString() error{FormatUnavailable}![*:0]const u8 {
+        pub fn getX11SelectionString() ?[*:0]const u8 {
             internal_debug.assertInitialized();
             if (native.glfwGetX11SelectionString()) |str| return str;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.FormatUnavailable => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetX11SelectionString` returns `null` only for errors
-            unreachable;
+            return null;
         }
 
         /// Returns the `GLXContext` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext and glfw.Error.NotInitialized.
+        /// Possible errors include glfw.Error.NoWindowContext.
+        /// Returns null in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
-        pub fn getGLXContext(window: Window) error{NoWindowContext}!*anyopaque {
+        pub fn getGLXContext(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
             if (native.glfwGetGLXContext(@ptrCast(*native.GLFWwindow, window.handle))) |context| return @ptrCast(*anyopaque, context);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetGLXContext` returns `null` only for errors
-            unreachable;
+            return null;
         }
 
         /// Returns the `GLXWindow` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext and glfw.Error.NotInitialized.
+        /// Possible errors include glfw.Error.NoWindowContext.
+        /// Returns null in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
-        pub fn getGLXWindow(window: Window) error{NoWindowContext}!*anyopaque {
+        pub fn getGLXWindow(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
             const win = native.glfwGetGLXWindow(@ptrCast(*native.GLFWwindow, window.handle));
             if (win != 0) return @ptrCast(*anyopaque, win);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetGLXWindow` returns `0` only for errors
-            unreachable;
+            return null;
         }
 
         /// Returns the `*wl_display` used by GLFW.
-        ///
-        /// Possible errors include glfw.Error.NotInitalized.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWaylandDisplay() *anyopaque {
             internal_debug.assertInitialized();
             if (native.glfwGetWaylandDisplay()) |display| return @ptrCast(*anyopaque, display);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetWaylandDisplay` returns `null` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Returns the `*wl_output` of the specified monitor.
         ///
-        /// Possible errors include glfw.Error.NotInitalized.
-        ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWaylandMonitor(monitor: Monitor) *anyopaque {
             internal_debug.assertInitialized();
             if (native.glfwGetWaylandMonitor(@ptrCast(*native.GLFWmonitor, monitor.handle))) |mon| return @ptrCast(*anyopaque, mon);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetWaylandMonitor` returns `null` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Returns the `*wl_surface` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NotInitalized.
-        ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWaylandWindow(window: Window) *anyopaque {
             internal_debug.assertInitialized();
             if (native.glfwGetWaylandWindow(@ptrCast(*native.GLFWwindow, window.handle))) |win| return @ptrCast(*anyopaque, win);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetWaylandWindow` returns `null` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Returns the `EGLDisplay` used by GLFW.
-        ///
-        /// Possible errors include glfw.Error.NotInitalized.
         ///
         /// remark: Because EGL is initialized on demand, this function will return `EGL_NO_DISPLAY`
         /// until the first context has been created via EGL.
@@ -392,30 +297,22 @@ pub fn Native(comptime options: BackendOptions) type {
             internal_debug.assertInitialized();
             const display = native.glfwGetEGLDisplay();
             if (display != native.EGL_NO_DISPLAY) return @ptrCast(*anyopaque, display);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                else => unreachable,
-            };
             // `glfwGetEGLDisplay` returns `EGL_NO_DISPLAY` only for errors
+            // but the only potential error is unreachable (NotInitialized)
             unreachable;
         }
 
         /// Returns the `EGLContext` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NotInitalized and glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.Error.NoWindowContext.
+        /// Returns null in the event of an error.
         ///
         /// thread_safety This function may be called from any thread. Access is not synchronized.
-        pub fn getEGLContext(window: Window) error{NoWindowContext}!*anyopaque {
+        pub fn getEGLContext(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
             const context = native.glfwGetEGLContext(@ptrCast(*native.GLFWwindow, window.handle));
             if (context != native.EGL_NO_CONTEXT) return @ptrCast(*anyopaque, context);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetEGLContext` returns `EGL_NO_CONTEXT` only for errors
-            unreachable;
+            return null;
         }
 
         /// Returns the `EGLSurface` of the specified window.
@@ -423,17 +320,11 @@ pub fn Native(comptime options: BackendOptions) type {
         /// Possible errors include glfw.Error.NotInitalized and glfw.Error.NoWindowContext.
         ///
         /// thread_safety This function may be called from any thread. Access is not synchronized.
-        pub fn getEGLSurface(window: Window) error{NoWindowContext}!*anyopaque {
+        pub fn getEGLSurface(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
             const surface = native.glfwGetEGLSurface(@ptrCast(*native.GLFWwindow, window.handle));
             if (surface != native.EGL_NO_SURFACE) return @ptrCast(*anyopaque, surface);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetEGLSurface` returns `EGL_NO_SURFACE` only for errors
-            unreachable;
+            return null;
         }
 
         pub const OSMesaColorBuffer = struct {
@@ -445,11 +336,11 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Retrieves the color buffer associated with the specified window.
         ///
-        /// Possible errors include glfw.Error.NotInitalized, glfw.Error.NoWindowContext
-        /// and glfw.Error.PlatformError.
+        /// Possible errors include glfw.Error.NoWindowContext and glfw.Error.PlatformError.
+        /// Returns null in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
-        pub fn getOSMesaColorBuffer(window: Window) error{ PlatformError, NoWindowContext }!OSMesaColorBuffer {
+        pub fn getOSMesaColorBuffer(window: Window) ?OSMesaColorBuffer {
             internal_debug.assertInitialized();
             var buf: OSMesaColorBuffer = undefined;
             if (native.glfwGetOSMesaColorBuffer(
@@ -459,13 +350,7 @@ pub fn Native(comptime options: BackendOptions) type {
                 &buf.format,
                 &buf.buffer,
             ) == native.GLFW_TRUE) return buf;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.PlatformError, Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetOSMesaColorBuffer` returns `GLFW_FALSE` only for errors
-            unreachable;
+            return null;
         }
 
         pub const OSMesaDepthBuffer = struct {
@@ -477,11 +362,11 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Retrieves the depth buffer associated with the specified window.
         ///
-        /// Possible errors include glfw.Error.NotInitalized, glfw.Error.NoWindowContext
-        /// and glfw.Error.PlatformError.
+        /// Possible errors include glfw.Error.NoWindowContext and glfw.Error.PlatformError.
+        /// Returns null in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
-        pub fn getOSMesaDepthBuffer(window: Window) error{ PlatformError, NoWindowContext }!OSMesaDepthBuffer {
+        pub fn getOSMesaDepthBuffer(window: Window) ?OSMesaDepthBuffer {
             internal_debug.assertInitialized();
             var buf: OSMesaDepthBuffer = undefined;
             if (native.glfwGetOSMesaDepthBuffer(
@@ -491,30 +376,18 @@ pub fn Native(comptime options: BackendOptions) type {
                 &buf.bytes_per_value,
                 &buf.buffer,
             ) == native.GLFW_TRUE) return buf;
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.PlatformError, Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetOSMesaDepthBuffer` returns `GLFW_FALSE` only for errors
-            unreachable;
+            return null;
         }
 
         /// Returns the 'OSMesaContext' of the specified window.
         ///
-        /// Possible errors include glfw.Error.NotInitalized and glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.Error.NoWindowContext.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
-        pub fn getOSMesaContext(window: Window) error{NoWindowContext}!*anyopaque {
+        pub fn getOSMesaContext(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
             if (native.glfwGetOSMesaContext(@ptrCast(*native.GLFWwindow, window.handle))) |context| return @ptrCast(*anyopaque, context);
-            getError() catch |err| return switch (err) {
-                Error.NotInitialized => unreachable,
-                Error.NoWindowContext => |e| e,
-                else => unreachable,
-            };
-            // `glfwGetOSMesaContext` returns `null` only for errors
-            unreachable;
+            return null;
         }
     };
 }

--- a/libs/glfw/src/time.zig
+++ b/libs/glfw/src/time.zig
@@ -31,11 +31,8 @@ pub inline fn getTime() f64 {
     internal_debug.assertInitialized();
     const time = c.glfwGetTime();
     if (time != 0) return time;
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
     // `glfwGetTime` returns `0` only for errors
+    // but the only potential error is unreachable (NotInitialized)
     unreachable;
 }
 
@@ -49,7 +46,7 @@ pub inline fn getTime() f64 {
 ///
 /// @param[in] time The new value, in seconds.
 ///
-/// Possible errors include glfw.Error.NotInitialized and glfw.Error.InvalidValue.
+/// Possible errors include glfw.Error.InvalidValue.
 ///
 /// The upper limit of GLFW time is calculated as `floor((2^64 - 1) / 10^9)` and is due to
 /// implementations storing nanoseconds in 64 bits. The limit may be increased in the future.
@@ -70,11 +67,6 @@ pub inline fn setTime(time: f64) void {
     });
 
     c.glfwSetTime(time);
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        Error.InvalidValue => unreachable,
-        else => unreachable,
-    };
 }
 
 /// Returns the current value of the raw timer.
@@ -91,11 +83,8 @@ pub inline fn getTimerValue() u64 {
     internal_debug.assertInitialized();
     const value = c.glfwGetTimerValue();
     if (value != 0) return value;
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
     // `glfwGetTimerValue` returns `0` only for errors
+    // but the only potential error is unreachable (NotInitialized)
     unreachable;
 }
 
@@ -112,17 +101,18 @@ pub inline fn getTimerFrequency() u64 {
     internal_debug.assertInitialized();
     const frequency = c.glfwGetTimerFrequency();
     if (frequency != 0) return frequency;
-    getError() catch |err| return switch (err) {
-        Error.NotInitialized => unreachable,
-        else => unreachable,
-    };
     // `glfwGetTimerFrequency` returns `0` only for errors
+    // but the only potential error is unreachable (NotInitialized)
     unreachable;
 }
 
 test "getTime" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     _ = getTime();
@@ -130,7 +120,11 @@ test "getTime" {
 
 test "setTime" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     _ = glfw.setTime(1234);
@@ -138,7 +132,11 @@ test "setTime" {
 
 test "getTimerValue" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     _ = glfw.getTimerValue();
@@ -146,7 +144,11 @@ test "getTimerValue" {
 
 test "getTimerFrequency" {
     const glfw = @import("main.zig");
-    try glfw.init(.{});
+    defer glfw.getError() catch {}; // clear any error we generate
+    if (!glfw.init(.{})) {
+        std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
+        std.process.exit(1);
+    }
     defer glfw.terminate();
 
     _ = glfw.getTimerFrequency();


### PR DESCRIPTION
## The problem

When I wrote mach-glfw (one of my earliest Zig projects, in fact) - the hope was that we could map GLFW errors to nice Zig errors. This is not a new approach to me, in fact years ago I was one of the original authors of the best GLFW bindings in Go where we used a similar approach, and encouraged GLFW to more clearly document errors it can return etc.

The problem is that GLFW still today is very much not designed/intended to be used in a way where errors are handled per-function-call. The general expectation is that you will check errors at important points, or via a callback. 

* GLFW documentation of what errors specific functions can generate is not always 100% correct, and often errors can be rather vague (e.g. `GLFW_PLATFORM_ERROR`)
* Even when a function is documented as possibly producing a specific type of error, it is not clear exactly how it should be handled. For example, `glfwSwapBuffers` _can_ generate a platform error but it is not exactly specified what one should do in that circumstance.
* Often times, exiting the application or terminating on error is _not_ the right call to make. For example, there are [many simple functions](https://github.com/hexops/mach-glfw/tree/a9e9ac095509fdf6e7002b4c49e2d8c736dcfe5c#a-warning-about-error-handling) not supported with Wayland, or even on specific X11 compositors, which will generate an error. In most of the usage scenarios with these APIs, it is best for the user if you merely log/print the error and move on continuing to attempt to run. **Your GLFW application will not support the long-tail of X11 compositors and Wayland Linux distributions otherwise.**

Additionally, since messages cannot be attached to errors in Zig (whether you like this or not) this is extremely important in GLFW error handling, as it often communicates a vague error code followed by a very specific error message. If your application is not printing the error message today, then your error handling is most likely _very bad for the user and effectively no better than your app crashing_.

All of these points combined add up to one thing: our GLFW bindings prior to this change make it easy to shoot yourself (and your users) in the foot by writing `try` in front of a GLFW function call - because we try to map GLFW errors to per-function Zig errors.

## The solution

All per-function error handling has been removed. Instead, you should now handle errors similarly to how one would in GLFW's C API.

## "I don't care, how do I update my code?"

If you really do not care about proper error handling and just want your code to compile again, you should simply remove `try` in front of most of your GLFW function calls. By doing this, your application will actually behave better for most of your users than having had `try` in front of function calls before.

## "How do I handle errors properly?"

After making a GLFW function call, you should check errors explicitly using one of:

* `glfw.getErrorString()` - returns an error message or `null` if none present
* `glfw.getError()` - returns a Zig error or void if none is present
* `glfw.mustGetError()` - returns a Zig error or panics if none is present
* `glfw.setErrorCallback` - if you just want to log your errors (I do NOT suggest terminating your application if this callback is invoked.)

Here are some specific examples:

### Initialization

Previously you had:

```zig
try glfw.init(.{});
```

Proper error handling now looks something like:

```zig
if (!glfw.init(.{})) {
    std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
    std.process.exit(1);
}
```

### Creating a window

`glfw.Window.create` returns `null` in the event of an error, you can handle this by presenting the `glfw.getErrorString()` value to the user.

### Other GLFW API calls

In general, you should be explicit about handling errors. Ask yourself: if this code fails, does my application _need_ to exit, or can I continue best-effort? If your application needs to exit because the API call was critical, then add an error check to present the problem:

```zig
glfw.foobar();
if (glfw.getErrorString()) |msg| {
    std.log.err("glfw.foobar: {s}", .{msg});
    std.process.exit(1);
}
```

Keep in mind that GLFW errors are stored per-thread. If you call a function and it produces an error and you do not retrieve it, then the next person who checks for an error will find it. This means that you may find it useful to be a good citizen by "clearing" any stored errors that you do not care about when finished calling GLFW functions, e.g. using defer:

```
defer getError() catch {}; // clear any errors we generated
```

## "I don't like this"

I don't either, but I have only two options:

1. I can sell you a `try` pipe dream in which GLFW errors can be treated the same as Zig errors, and your application will have poor error handling and your users (especially those using Linux) will suffer.
2. I can remove footguns and provide the best guidance possible to ensure you handle errors in a way that makes your application run on the widest array of systems without fault.

## "I still object!"

Realistically, this doesn't affect Mach itself. I am confident that I know how to avoid all these footguns in Mach when we make use of GLFW and expose an API where it doesn't affect Mach engine or Mach core users.

I am doing this purely for users of mach-glfw. If the users of mach-glfw don't like this change, I may not merge it - but I think it'd be a pretty glaring violation of the `zig zen`.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.