### PR TITLE
Revert "all: build: fix sdkPath for relative @src.file / fix autocompletion with ZLS / IDEs (#661)"

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,27 +27,11 @@ const CrossTarget = std.zig.CrossTarget;
 const Builder = std.build.Builder;
 const Pkg = std.build.Pkg;
 
-var cached_pkg: ?Pkg = null;
-
-pub fn pkg(b: *Builder) Pkg {
-    if (cached_pkg == null) {
-        const dependencies = b.allocator.create([4]Pkg) catch unreachable;
-        dependencies.* = .{
-            gpu.pkg(b),
-            ecs.pkg(b),
-            sysaudio.pkg(b),
-            earcut.pkg(b),
-        };
-
-        cached_pkg = .{
-            .name = "mach",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = dependencies,
-        };
-    }
-
-    return cached_pkg.?;
-}
+pub const pkg = Pkg{
+    .name = "mach",
+    .source = .{ .path = sdkPath("/src/main.zig") },
+    .dependencies = &.{ gpu.pkg, ecs.pkg, sysaudio.pkg, earcut.pkg },
+};
 
 pub const Options = struct {
     glfw_options: glfw.Options = .{},
@@ -140,12 +124,11 @@ fn testStep(b: *Builder, mode: std.builtin.Mode, target: CrossTarget) *std.build
     const main_tests = b.addTestExe("mach-tests", "src/main.zig");
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
-
-    for (pkg(b).dependencies.?) |dependency| {
+    for (pkg.dependencies.?) |dependency| {
         main_tests.addPackage(dependency);
     }
 
-    main_tests.addPackage(freetype.pkg(b));
+    main_tests.addPackage(freetype.pkg);
     freetype.link(b, main_tests, .{});
 
     main_tests.install();
@@ -163,11 +146,11 @@ fn buildSharedLib(b: *Builder, mode: std.builtin.Mode, target: CrossTarget, opti
         .source = .{ .path = "src/platform/libmach.zig" },
     };
     lib.addPackage(app_pkg);
-    lib.addPackage(glfw.pkg(b));
-    lib.addPackage(gpu.pkg(b));
-    lib.addPackage(sysaudio.pkg(b));
+    lib.addPackage(glfw.pkg);
+    lib.addPackage(gpu.pkg);
+    lib.addPackage(sysaudio.pkg);
     if (target.isLinux()) {
-        lib.addPackage(gamemode.pkg(b));
+        lib.addPackage(gamemode.pkg);
         gamemode.link(lib);
     }
     try glfw.link(b, lib, options.glfw_options);
@@ -225,14 +208,14 @@ pub const App = struct {
         const platform = Platform.fromTarget(target);
 
         var deps = std.ArrayList(Pkg).init(b.allocator);
-        try deps.append(pkg(b));
-        try deps.append(gpu.pkg(b));
-        try deps.append(sysaudio.pkg(b));
+        try deps.append(pkg);
+        try deps.append(gpu.pkg);
+        try deps.append(sysaudio.pkg);
         switch (platform) {
-            .native => try deps.append(glfw.pkg(b)),
-            .web => try deps.append(sysjs.pkg(b)),
+            .native => try deps.append(glfw.pkg),
+            .web => try deps.append(sysjs.pkg),
         }
-        if (options.use_freetype) |_| try deps.append(freetype.pkg(b));
+        if (options.use_freetype) |_| try deps.append(freetype.pkg);
         if (options.deps) |app_deps| try deps.appendSlice(app_deps);
 
         const app_pkg = Pkg{
@@ -243,26 +226,26 @@ pub const App = struct {
 
         const step = blk: {
             if (platform == .web) {
-                const lib = b.addSharedLibrary(options.name, sdkPath(b, "/src/platform/wasm.zig"), .unversioned);
-                lib.addPackage(gpu.pkg(b));
-                lib.addPackage(sysaudio.pkg(b));
-                lib.addPackage(sysjs.pkg(b));
+                const lib = b.addSharedLibrary(options.name, sdkPath("/src/platform/wasm.zig"), .unversioned);
+                lib.addPackage(gpu.pkg);
+                lib.addPackage(sysaudio.pkg);
+                lib.addPackage(sysjs.pkg);
 
                 break :blk lib;
             } else {
-                const exe = b.addExecutable(options.name, sdkPath(b, "/src/platform/native.zig"));
-                exe.addPackage(gpu.pkg(b));
-                exe.addPackage(sysaudio.pkg(b));
-                exe.addPackage(glfw.pkg(b));
+                const exe = b.addExecutable(options.name, sdkPath("/src/platform/native.zig"));
+                exe.addPackage(gpu.pkg);
+                exe.addPackage(sysaudio.pkg);
+                exe.addPackage(glfw.pkg);
 
                 if (target.os.tag == .linux)
-                    exe.addPackage(gamemode.pkg(b));
+                    exe.addPackage(gamemode.pkg);
 
                 break :blk exe;
             }
         };
 
-        step.main_pkg_path = sdkPath(b, "/src");
+        step.main_pkg_path = sdkPath("/src");
         step.addPackage(app_pkg);
         step.setTarget(options.target);
         step.setBuildMode(options.mode);
@@ -304,14 +287,14 @@ pub const App = struct {
 
             inline for (.{ "/src/platform/mach.js", "/libs/sysjs/src/mach-sysjs.js" }) |js| {
                 const install_js = app.b.addInstallFileWithDir(
-                    .{ .path = sdkPath(app.b, js) },
+                    .{ .path = sdkPath(js) },
                     web_install_dir,
                     std.fs.path.basename(js),
                 );
                 app.getInstallStep().?.step.dependOn(&install_js.step);
             }
 
-            const html_generator = app.b.addExecutable("html-generator", sdkPath(app.b, "/tools/html-generator/main.zig"));
+            const html_generator = app.b.addExecutable("html-generator", sdkPath("/tools/html-generator/main.zig"));
             const run_html_generator = html_generator.run();
             const html_file_name = std.mem.concat(
                 app.b.allocator,
@@ -363,50 +346,10 @@ pub const App = struct {
     }
 };
 
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }

--- a/dev/template/README.md
+++ b/dev/template/README.md
@@ -20,7 +20,7 @@ const foobar = @import("libs/mach-foobar/build.zig");
 
 pub fn build(b: *Builder) void {
     ...
-    exe.addPackage(foobar.pkg(b));
+    exe.addPackage(foobar.pkg);
     foobar.link(b, exe, .{});
 }
 ```

--- a/libs/basisu/build.zig
+++ b/libs/basisu/build.zig
@@ -1,21 +1,14 @@
 const std = @import("std");
 const Builder = std.build.Builder;
 
-const basisu_root = "/upstream/basisu";
+const basisu_root = sdkPath("/upstream/basisu");
 
-var cached_pkg: ?std.build.Pkg = null;
-
-pub fn pkg(b: *Builder) std.build.Pkg {
-    if (cached_pkg == null) {
-        cached_pkg = .{
-            .name = "basisu",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = &.{},
-        };
-    }
-
-    return cached_pkg.?;
-}
+pub const pkg = std.build.Pkg{
+    .name = "basisu",
+    .source = .{
+        .path = "src/main.zig",
+    },
+};
 
 pub const Options = struct {
     encoder: ?EncoderOptions,
@@ -39,10 +32,10 @@ pub fn build(b: *Builder) void {
 }
 
 pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
-    const main_tests = b.addTestExe("basisu-tests", sdkPath(b, "/src/main.zig"));
+    const main_tests = b.addTestExe("basisu-tests", sdkPath("/src/main.zig"));
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
-    main_tests.main_pkg_path = sdkPath(b, "/");
+    main_tests.main_pkg_path = sdkPath("/");
     link(b, main_tests, target, .{
         .encoder = .{},
         .transcoder = .{},
@@ -54,13 +47,13 @@ pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget
 pub fn link(b: *Builder, step: *std.build.LibExeObjStep, target: std.zig.CrossTarget, options: Options) void {
     if (options.encoder) |encoder_options| {
         step.linkLibrary(buildEncoder(b, target, encoder_options));
-        step.addCSourceFile(sdkPath(b, "/src/encoder/wrapper.cpp"), &.{});
-        step.addIncludePath(sdkPath(b, basisu_root ++ "/encoder"));
+        step.addCSourceFile(sdkPath("/src/encoder/wrapper.cpp"), &.{});
+        step.addIncludePath(basisu_root ++ "/encoder");
     }
     if (options.transcoder) |transcoder_options| {
         step.linkLibrary(buildTranscoder(b, target, transcoder_options));
-        step.addCSourceFile(sdkPath(b, "/src/transcoder/wrapper.cpp"), &.{});
-        step.addIncludePath(sdkPath(b, basisu_root ++ "/transcoder"));
+        step.addCSourceFile(sdkPath("/src/transcoder/wrapper.cpp"), &.{});
+        step.addIncludePath(basisu_root ++ "/transcoder");
     }
 }
 
@@ -71,11 +64,10 @@ pub fn buildEncoder(b: *Builder, target: std.zig.CrossTarget, options: EncoderOp
     const encoder = b.addStaticLibrary("basisu-encoder", null);
     encoder.setTarget(target);
     encoder.linkLibCpp();
-
-    inline for (encoder_sources) |encoder_source| {
-        encoder.addCSourceFile(sdkPath(b, encoder_source), &.{});
-    }
-
+    encoder.addCSourceFiles(
+        encoder_sources,
+        &.{},
+    );
     encoder.defineCMacro("BASISU_FORCE_DEVEL_MESSAGES", "0");
     encoder.defineCMacro("BASISD_SUPPORT_KTX2_ZSTD", "0");
 
@@ -91,11 +83,10 @@ pub fn buildTranscoder(b: *Builder, target: std.zig.CrossTarget, options: Transc
     const transcoder = b.addStaticLibrary("basisu-transcoder", null);
     transcoder.setTarget(target);
     transcoder.linkLibCpp();
-
-    inline for (transcoder_sources) |transcoder_source| {
-        transcoder.addCSourceFile(sdkPath(b, transcoder_source), &.{});
-    }
-
+    transcoder.addCSourceFiles(
+        transcoder_sources,
+        &.{},
+    );
     transcoder.defineCMacro("BASISU_FORCE_DEVEL_MESSAGES", "0");
     transcoder.defineCMacro("BASISD_SUPPORT_KTX2_ZSTD", "0");
 
@@ -110,59 +101,19 @@ fn ensureDependencySubmodule(allocator: std.mem.Allocator, path: []const u8) !vo
         if (std.mem.eql(u8, no_ensure_submodules, "true")) return;
     } else |_| {}
     var child = std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", path }, allocator);
-    child.cwd = sdkPathAllocator(allocator, "/");
+    child.cwd = sdkPath("/");
     child.stderr = std.io.getStdErr();
     child.stdout = std.io.getStdOut();
 
     _ = try child.spawnAndWait();
 }
 
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }
 
 const transcoder_sources = &[_][]const u8{

--- a/libs/earcut/README.md
+++ b/libs/earcut/README.md
@@ -32,7 +32,7 @@ const earcut = @import("libs/mach-earcut/build.zig");
 
 pub fn build(b: *Builder) void {
     ...
-    exe.addPackage(earcut.pkg(b));
+    exe.addPackage(earcut.pkg);
 }
 ```
 

--- a/libs/earcut/build.zig
+++ b/libs/earcut/build.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
+pub fn build(b: *std.build.Builder) void {
     const mode = b.standardReleaseOptions();
     const lib = b.addStaticLibrary("earcut", "src/main.zig");
     lib.setBuildMode(mode);
@@ -13,67 +12,14 @@ pub fn build(b: *Builder) void {
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&main_tests.step);
 
-    _ = pkg(b);
+    _ = pkg;
 }
 
-var cached_pkg: ?std.build.Pkg = null;
+pub const pkg = std.build.Pkg{
+    .name = "earcut",
+    .source = .{ .path = thisDir() ++ "/src/main.zig" },
+};
 
-pub fn pkg(b: *Builder) std.build.Pkg {
-    if (cached_pkg == null) {
-        cached_pkg = .{
-            .name = "earcut",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = &.{},
-        };
-    }
-
-    return cached_pkg.?;
-}
-
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
-    if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+fn thisDir() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
 }

--- a/libs/ecs/build.zig
+++ b/libs/ecs/build.zig
@@ -1,79 +1,30 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-var cached_pkg: ?std.build.Pkg = null;
+pub const pkg = std.build.Pkg{
+    .name = "ecs",
+    .source = .{ .path = sdkPath("/src/main.zig") },
+    .dependencies = &[_]std.build.Pkg{},
+};
 
-pub fn pkg(b: *Builder) std.build.Pkg {
-    if (cached_pkg == null) {
-        cached_pkg = .{
-            .name = "ecs",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = &.{},
-        };
-    }
-
-    return cached_pkg.?;
-}
-
-pub fn build(b: *Builder) void {
+pub fn build(b: *std.build.Builder) void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&testStep(b, mode, target).step);
 }
 
-pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
-    const main_tests = b.addTestExe("ecs-tests", sdkPath(b, "/src/main.zig"));
+pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+    const main_tests = b.addTestExe("ecs-tests", sdkPath("/src/main.zig"));
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
     main_tests.install();
     return main_tests.run();
 }
 
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }

--- a/libs/freetype/README.md
+++ b/libs/freetype/README.md
@@ -28,7 +28,7 @@ const freetype = @import("libs/mach-freetype/build.zig");
 
 pub fn build(b: *Builder) void {
     ...
-    exe.addPackage(freetype.pkg(b));
+    exe.addPackage(freetype.pkg);
     freetype.link(b, exe, .{});
 
     // use this option if you are including zlib separately
@@ -46,7 +46,7 @@ freetype.link(b, exe, .{ .harfbuzz = .{} });
 You can also optionally build brotli compression (for WOFF2 font support):
 
 ```zig
-    exe.addPackage(freetype.pkg(b));
+    exe.addPackage(freetype.pkg);
     freetype.link(b, exe, .{ .freetype = .{ .brotli = true } });
 ```
 

--- a/libs/freetype/build.zig
+++ b/libs/freetype/build.zig
@@ -1,43 +1,23 @@
 const std = @import("std");
 const Builder = std.build.Builder;
 
-const ft_root = "/upstream/freetype";
+const ft_root = sdkPath("/upstream/freetype");
 const ft_include_path = ft_root ++ "/include";
-const hb_root = "/upstream/harfbuzz";
+const hb_root = sdkPath("/upstream/harfbuzz");
 const hb_include_path = hb_root ++ "/src";
-const brotli_root = "/upstream/brotli";
+const brotli_root = sdkPath("/upstream/brotli");
 
-var cached_pkg: ?std.build.Pkg = null;
-var cached_harfbuzz_pkg: ?std.build.Pkg = null;
+pub const pkg = std.build.Pkg{
+    .name = "freetype",
+    .source = .{ .path = sdkPath("/src/main.zig") },
+    .dependencies = &.{},
+};
 
-pub fn pkg(b: *Builder) std.build.Pkg {
-    if (cached_pkg == null) {
-        cached_pkg = .{
-            .name = "freetype",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = &.{},
-        };
-    }
-
-    return cached_pkg.?;
-}
-
-pub fn harfbuzz_pkg(b: *Builder) std.build.Pkg {
-    if (cached_harfbuzz_pkg == null) {
-        const dependencies = b.allocator.create([1]std.build.Pkg) catch unreachable;
-        dependencies.* = .{
-            pkg(b),
-        };
-
-        cached_harfbuzz_pkg = .{
-            .name = "harfbuzz",
-            .source = .{ .path = sdkPath(b, "/src/harfbuzz/main.zig") },
-            .dependencies = dependencies,
-        };
-    }
-
-    return cached_harfbuzz_pkg.?;
-}
+pub const harfbuzz_pkg = std.build.Pkg{
+    .name = "harfbuzz",
+    .source = .{ .path = sdkPath("/src/harfbuzz/main.zig") },
+    .dependencies = &.{pkg},
+};
 
 pub const Options = struct {
     freetype: FreetypeOptions = .{},
@@ -71,7 +51,7 @@ pub fn build(b: *std.build.Builder) !void {
         const example_exe = b.addExecutable("example-" ++ example, "examples/" ++ example ++ ".zig");
         example_exe.setBuildMode(mode);
         example_exe.setTarget(target);
-        example_exe.addPackage(pkg(b));
+        example_exe.addPackage(pkg);
 
         link(b, example_exe, .{});
 
@@ -91,30 +71,30 @@ pub fn build(b: *std.build.Builder) !void {
 }
 
 pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
-    const main_tests = b.addTestExe("freetype-tests", sdkPath(b, "/src/main.zig"));
+    const main_tests = b.addTestExe("freetype-tests", sdkPath("/src/main.zig"));
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
-    main_tests.addPackage(pkg(b));
+    main_tests.addPackage(pkg);
     link(b, main_tests, .{
         .freetype = .{
             .brotli = true,
         },
         .harfbuzz = .{},
     });
-    main_tests.main_pkg_path = sdkPath(b, "/");
+    main_tests.main_pkg_path = sdkPath("/");
     main_tests.install();
 
-    const harfbuzz_tests = b.addTestExe("harfbuzz-tests", sdkPath(b, "/src/harfbuzz/main.zig"));
+    const harfbuzz_tests = b.addTestExe("harfbuzz-tests", sdkPath("/src/harfbuzz/main.zig"));
     harfbuzz_tests.setBuildMode(mode);
     harfbuzz_tests.setTarget(target);
-    harfbuzz_tests.addPackage(pkg(b));
+    harfbuzz_tests.addPackage(pkg);
     link(b, harfbuzz_tests, .{
         .freetype = .{
             .brotli = true,
         },
         .harfbuzz = .{},
     });
-    harfbuzz_tests.main_pkg_path = sdkPath(b, "/");
+    harfbuzz_tests.main_pkg_path = sdkPath("/");
     harfbuzz_tests.install();
 
     const main_tests_run = main_tests.run();
@@ -131,7 +111,7 @@ pub fn link(b: *Builder, step: *std.build.LibExeObjStep, options: Options) void 
 pub fn linkFreetype(b: *Builder, step: *std.build.LibExeObjStep, options: FreetypeOptions) void {
     const ft_lib = buildFreetype(b, step.build_mode, step.target, options);
     step.linkLibrary(ft_lib);
-    step.addIncludePath(sdkPath(b, ft_include_path));
+    step.addIncludePath(ft_include_path);
     if (options.brotli) {
         const brotli_lib = buildBrotli(b, step.build_mode, step.target);
         if (options.install_libs)
@@ -143,7 +123,7 @@ pub fn linkFreetype(b: *Builder, step: *std.build.LibExeObjStep, options: Freety
 pub fn linkHarfbuzz(b: *Builder, step: *std.build.LibExeObjStep, options: HarfbuzzOptions) void {
     const hb_lib = buildHarfbuzz(b, step.build_mode, step.target, options);
     step.linkLibrary(hb_lib);
-    step.addIncludePath(sdkPath(b, hb_include_path));
+    step.addIncludePath(hb_include_path);
 }
 
 pub fn buildFreetype(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, options: FreetypeOptions) *std.build.LibExeObjStep {
@@ -158,7 +138,7 @@ pub fn buildFreetype(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossT
     lib.setBuildMode(mode);
     lib.setTarget(target);
     lib.linkLibC();
-    lib.addIncludePath(sdkPath(b, ft_include_path));
+    lib.addIncludePath(ft_include_path);
 
     if (options.config_path) |path|
         lib.addIncludePath(path);
@@ -169,23 +149,20 @@ pub fn buildFreetype(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossT
     const target_info = (std.zig.system.NativeTargetInfo.detect(target) catch unreachable).target;
 
     if (target_info.os.tag == .windows) {
-        lib.addCSourceFile(sdkPath(b, ft_root ++ "/builds/windows/ftsystem.c"), &.{});
-        lib.addCSourceFile(sdkPath(b, ft_root ++ "/builds/windows/ftdebug.c"), &.{});
+        lib.addCSourceFile(ft_root ++ "/builds/windows/ftsystem.c", &.{});
+        lib.addCSourceFile(ft_root ++ "/builds/windows/ftdebug.c", &.{});
     } else {
-        lib.addCSourceFile(sdkPath(b, ft_root ++ "/src/base/ftsystem.c"), &.{});
-        lib.addCSourceFile(sdkPath(b, ft_root ++ "/src/base/ftdebug.c"), &.{});
+        lib.addCSourceFile(ft_root ++ "/src/base/ftsystem.c", &.{});
+        lib.addCSourceFile(ft_root ++ "/src/base/ftdebug.c", &.{});
     }
     if (target_info.os.tag.isBSD() or target_info.os.tag == .linux) {
         lib.defineCMacro("HAVE_UNISTD_H", "1");
         lib.defineCMacro("HAVE_FCNTL_H", "1");
-        lib.addCSourceFile(sdkPath(b, ft_root ++ "/builds/unix/ftsystem.c"), &.{});
+        lib.addCSourceFile(ft_root ++ "/builds/unix/ftsystem.c", &.{});
         if (target_info.os.tag == .macos)
-            lib.addCSourceFile(sdkPath(b, ft_root ++ "/src/base/ftmac.c"), &.{});
+            lib.addCSourceFile(ft_root ++ "/src/base/ftmac.c", &.{});
     }
-
-    inline for (freetype_base_sources) |ft_source| {
-        lib.addCSourceFile(sdkPath(b, ft_source), &.{});
-    }
+    lib.addCSourceFiles(freetype_base_sources, &.{});
 
     if (options.install_libs)
         lib.install();
@@ -193,13 +170,13 @@ pub fn buildFreetype(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossT
 }
 
 pub fn buildHarfbuzz(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, options: HarfbuzzOptions) *std.build.LibExeObjStep {
-    const main_abs = sdkPath(b, hb_root ++ "/src/harfbuzz.cc");
+    const main_abs = hb_root ++ "/src/harfbuzz.cc";
     const lib = b.addStaticLibrary("harfbuzz", main_abs);
     lib.setBuildMode(mode);
     lib.setTarget(target);
     lib.linkLibCpp();
-    lib.addIncludePath(sdkPath(b, hb_include_path));
-    lib.addIncludePath(sdkPath(b, ft_include_path));
+    lib.addIncludePath(hb_include_path);
+    lib.addIncludePath(ft_include_path);
     lib.defineCMacro("HAVE_FREETYPE", "1");
 
     if (options.install_libs)
@@ -212,12 +189,8 @@ fn buildBrotli(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget)
     lib.setBuildMode(mode);
     lib.setTarget(target);
     lib.linkLibC();
-    lib.addIncludePath(sdkPath(b, brotli_root ++ "/include"));
-
-    inline for (brotli_base_sources) |brotli_source| {
-        lib.addCSourceFile(sdkPath(b, brotli_source), &.{});
-    }
-
+    lib.addIncludePath(brotli_root ++ "/include");
+    lib.addCSourceFiles(brotli_base_sources, &.{});
     return lib;
 }
 
@@ -227,59 +200,19 @@ fn ensureDependencySubmodule(allocator: std.mem.Allocator, path: []const u8) !vo
         if (std.mem.eql(u8, no_ensure_submodules, "true")) return;
     } else |_| {}
     var child = std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", path }, allocator);
-    child.cwd = sdkPathAllocator(allocator, "/");
+    child.cwd = sdkPath("/");
     child.stderr = std.io.getStdErr();
     child.stdout = std.io.getStdOut();
 
     _ = try child.spawnAndWait();
 }
 
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }
 
 const freetype_base_sources = &[_][]const u8{

--- a/libs/gamemode/build.zig
+++ b/libs/gamemode/build.zig
@@ -1,70 +1,18 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-pub fn build(_: *Builder) void {}
-
-var cached_pkg: ?std.build.Pkg = null;
-
-pub fn pkg(b: *Builder) std.build.Pkg {
-    if (cached_pkg == null) {
-        cached_pkg = .{
-            .name = "gamemode",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = &.{},
-        };
-    }
-
-    return cached_pkg.?;
-}
+pub const pkg = std.build.Pkg{
+    .name = "gamemode",
+    .source = .{ .path = sdkPath("/gamemode.zig") },
+};
 
 pub fn link(step: *std.build.LibExeObjStep) void {
-    step.addIncludePath(sdkPath(step.builder, "/upstream/include"));
+    step.addIncludePath(sdkPath("/upstream/include"));
 }
 
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }

--- a/libs/glfw/README.md
+++ b/libs/glfw/README.md
@@ -59,7 +59,7 @@ const glfw = @import("libs/mach-glfw/build.zig");
 
 pub fn build(b: *Builder) !void {
     ...
-    exe.addPackage(glfw.pkg(b));
+    exe.addPackage(glfw.pkg);
     try glfw.link(b, exe, .{});
 }
 ```

--- a/libs/glfw/build.zig
+++ b/libs/glfw/build.zig
@@ -14,7 +14,7 @@ pub fn build(b: *Builder) !void {
 }
 
 pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) !*std.build.RunStep {
-    const main_tests = b.addTestExe("glfw-tests", sdkPath(b, "/src/main.zig"));
+    const main_tests = b.addTestExe("glfw-tests", sdkPath("/src/main.zig"));
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
     try link(b, main_tests, .{});
@@ -23,7 +23,7 @@ pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget
 }
 
 fn testStepShared(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) !*std.build.RunStep {
-    const main_tests = b.addTestExe("glfw-tests-shared", sdkPath(b, "/src/main.zig"));
+    const main_tests = b.addTestExe("glfw-tests-shared", sdkPath("/src/main.zig"));
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
     try link(b, main_tests, .{ .shared = true });
@@ -64,19 +64,10 @@ pub const Options = struct {
     install_libs: bool = false,
 };
 
-var cached_pkg: ?std.build.Pkg = null;
-
-pub fn pkg(b: *Builder) std.build.Pkg {
-    if (cached_pkg == null) {
-        cached_pkg = .{
-            .name = "glfw",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = &.{},
-        };
-    }
-
-    return cached_pkg.?;
-}
+pub const pkg = std.build.Pkg{
+    .name = "glfw",
+    .source = .{ .path = sdkPath("/src/main.zig") },
+};
 
 pub const LinkError = error{FailedToLinkGPU} || BuildError;
 pub fn link(b: *Builder, step: *std.build.LibExeObjStep, options: Options) LinkError!void {
@@ -117,21 +108,21 @@ fn buildLibrary(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget
 }
 
 fn addGLFWIncludes(step: *std.build.LibExeObjStep) void {
-    step.addIncludePath(sdkPath(step.builder, "/upstream/glfw/include"));
-    step.addIncludePath(sdkPath(step.builder, "/upstream/vulkan_headers/include"));
+    step.addIncludePath(sdkPath("/upstream/glfw/include"));
+    step.addIncludePath(sdkPath("/upstream/vulkan_headers/include"));
 }
 
 fn addGLFWSources(b: *Builder, lib: *std.build.LibExeObjStep, options: Options) std.mem.Allocator.Error!void {
-    const include_glfw_src = try std.mem.concat(b.allocator, u8, &.{ "-I", sdkPath(b, "/upstream/glfw/src") });
+    const include_glfw_src = comptime "-I" ++ sdkPath("/upstream/glfw/src");
     switch (lib.target_info.target.os.tag) {
         .windows => lib.addCSourceFiles(&.{
-            sdkPath(b, "/src/sources_all.c"),
-            sdkPath(b, "/src/sources_windows.c"),
+            sdkPath("/src/sources_all.c"),
+            sdkPath("/src/sources_windows.c"),
         }, &.{ "-D_GLFW_WIN32", include_glfw_src }),
         .macos => lib.addCSourceFiles(&.{
-            sdkPath(b, "/src/sources_all.c"),
-            sdkPath(b, "/src/sources_macos.m"),
-            sdkPath(b, "/src/sources_macos.c"),
+            sdkPath("/src/sources_all.c"),
+            sdkPath("/src/sources_macos.m"),
+            sdkPath("/src/sources_macos.c"),
         }, &.{ "-D_GLFW_COCOA", include_glfw_src }),
         else => {
             // TODO(future): for now, Linux can't be built with musl:
@@ -142,17 +133,17 @@ fn addGLFWSources(b: *Builder, lib: *std.build.LibExeObjStep, options: Options) 
             // ```
             var sources = std.ArrayList([]const u8).init(b.allocator);
             var flags = std.ArrayList([]const u8).init(b.allocator);
-            try sources.append(sdkPath(b, "/src/sources_all.c"));
-            try sources.append(sdkPath(b, "/src/sources_linux.c"));
+            try sources.append(sdkPath("/src/sources_all.c"));
+            try sources.append(sdkPath("/src/sources_linux.c"));
             if (options.x11) {
-                try sources.append(sdkPath(b, "/src/sources_linux_x11.c"));
+                try sources.append(sdkPath("/src/sources_linux_x11.c"));
                 try flags.append("-D_GLFW_X11");
             }
             if (options.wayland) {
-                try sources.append(sdkPath(b, "/src/sources_linux_wayland.c"));
+                try sources.append(sdkPath("/src/sources_linux_wayland.c"));
                 try flags.append("-D_GLFW_WAYLAND");
             }
-            try flags.append(include_glfw_src);
+            try flags.append(comptime "-I" ++ sdkPath("/upstream/glfw/src"));
             // TODO(upstream): glfw can't compile on clang15 without this flag
             try flags.append("-Wno-implicit-function-declaration");
 
@@ -206,57 +197,17 @@ fn ensureDependencySubmodule(allocator: std.mem.Allocator, path: []const u8) !vo
         if (std.mem.eql(u8, no_ensure_submodules, "true")) return;
     } else |_| {}
     var child = std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", path }, allocator);
-    child.cwd = sdkPathAllocator(allocator, "/");
+    child.cwd = sdkPath("/");
     child.stderr = std.io.getStdErr();
     child.stdout = std.io.getStdOut();
 
     _ = try child.spawnAndWait();
 }
 
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }

--- a/libs/gpu-dawn/sdk.zig
+++ b/libs/gpu-dawn/sdk.zig
@@ -90,14 +90,14 @@ pub fn Sdk(comptime deps: anytype) type {
 
         fn linkFromSource(b: *Builder, step: *std.build.LibExeObjStep, options: Options) !void {
             // branch: generated-2022-08-06
-            try ensureGitRepoCloned(b.allocator, "https://github.com/hexops/dawn", "0b704c4acae154ec8d4be7615d18a489f270f6c0", sdkPath(b, "/libs/dawn"));
+            try ensureGitRepoCloned(b.allocator, "https://github.com/hexops/dawn", "0b704c4acae154ec8d4be7615d18a489f270f6c0", sdkPath("/libs/dawn"));
 
             // branch: mach
-            try ensureGitRepoCloned(b.allocator, "https://github.com/hexops/DirectXShaderCompiler", "cff9a6f0b7f961748b822e1d313a7205dfdecf9d", sdkPath(b, "/libs/DirectXShaderCompiler"));
+            try ensureGitRepoCloned(b.allocator, "https://github.com/hexops/DirectXShaderCompiler", "cff9a6f0b7f961748b822e1d313a7205dfdecf9d", sdkPath("/libs/DirectXShaderCompiler"));
 
-            step.addIncludePath(sdkPath(b, "/libs/dawn/out/Debug/gen/include"));
-            step.addIncludePath(sdkPath(b, "/libs/dawn/include"));
-            step.addIncludePath(sdkPath(b, "/src/dawn"));
+            step.addIncludePath(sdkPath("/libs/dawn/out/Debug/gen/include"));
+            step.addIncludePath(sdkPath("/libs/dawn/include"));
+            step.addIncludePath(sdkPath("/src/dawn"));
 
             if (options.separate_libs) {
                 const lib_mach_dawn_native = try buildLibMachDawnNative(b, step, options);
@@ -176,7 +176,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 error.FileNotFound => {
                     std.log.info("cloning required dependency..\ngit clone {s} {s}..\n", .{ clone_url, dir });
 
-                    try exec(allocator, &[_][]const u8{ "git", "clone", "-c", "core.longpaths=true", clone_url, dir }, sdkPathAllocator(allocator, "/"));
+                    try exec(allocator, &[_][]const u8{ "git", "clone", "-c", "core.longpaths=true", clone_url, dir }, sdkPath("/"));
                     try exec(allocator, &[_][]const u8{ "git", "reset", "--quiet", "--hard", revision }, dir);
                     try exec(allocator, &[_][]const u8{ "git", "submodule", "update", "--init", "--recursive" }, dir);
                     return;
@@ -297,7 +297,7 @@ pub fn Sdk(comptime deps: anytype) type {
             step.linkLibCpp();
 
             step.addIncludePath(include_dir);
-            step.addIncludePath(sdkPath(b, "/src/dawn"));
+            step.addIncludePath(sdkPath("/src/dawn"));
 
             if (options.linux_window_manager != null and options.linux_window_manager.? == .X11) {
                 step.linkSystemLibraryName("X11");
@@ -494,7 +494,7 @@ pub fn Sdk(comptime deps: anytype) type {
             const result = try std.ChildProcess.exec(.{
                 .allocator = allocator,
                 .argv = &.{ "git", "branch", branch, "--contains", commit },
-                .cwd = sdkPathAllocator(allocator, "/"),
+                .cwd = sdkPath("/"),
             });
             defer {
                 allocator.free(result.stdout);
@@ -507,7 +507,7 @@ pub fn Sdk(comptime deps: anytype) type {
             const result = try std.ChildProcess.exec(.{
                 .allocator = allocator,
                 .argv = &.{ "git", "rev-parse", "HEAD" },
-                .cwd = sdkPathAllocator(allocator, "/"),
+                .cwd = sdkPath("/"),
             });
             defer allocator.free(result.stderr);
             if (result.stdout.len > 0) return result.stdout[0 .. result.stdout.len - 1]; // trim newline
@@ -518,7 +518,7 @@ pub fn Sdk(comptime deps: anytype) type {
             const result = try std.ChildProcess.exec(.{
                 .allocator = allocator,
                 .argv = &.{ "git", "clone", repository, dir },
-                .cwd = sdkPathAllocator(allocator, "/"),
+                .cwd = sdkPath("/"),
             });
             defer {
                 allocator.free(result.stdout);
@@ -536,7 +536,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 std.ChildProcess.init(&.{ "curl", "--insecure", "-L", "-o", target_file, url }, allocator)
             else
                 std.ChildProcess.init(&.{ "curl", "-L", "-o", target_file, url }, allocator);
-            child.cwd = sdkPathAllocator(allocator, "/");
+            child.cwd = sdkPath("/");
             child.stderr = std.io.getStdErr();
             child.stdout = std.io.getStdOut();
             _ = try child.spawnAndWait();
@@ -546,7 +546,7 @@ pub fn Sdk(comptime deps: anytype) type {
             const result = std.ChildProcess.exec(.{
                 .allocator = allocator,
                 .argv = &.{ "curl", "--version" },
-                .cwd = sdkPathAllocator(allocator, "/"),
+                .cwd = sdkPath("/"),
             }) catch { // e.g. FileNotFound
                 std.log.err("mach: error: 'curl --version' failed. Is curl not installed?", .{});
                 std.process.exit(1);
@@ -586,11 +586,11 @@ pub fn Sdk(comptime deps: anytype) type {
             try options.appendFlags(&cpp_flags, false, true);
             try appendDawnEnableBackendTypeFlags(&cpp_flags, options);
             try cpp_flags.appendSlice(&.{
-                include(b, deps.glfw_include_dir),
-                include(b, "libs/dawn/out/Debug/gen/include"),
-                include(b, "libs/dawn/out/Debug/gen/src"),
-                include(b, "libs/dawn/include"),
-                include(b, "libs/dawn/src"),
+                include(deps.glfw_include_dir),
+                include("libs/dawn/out/Debug/gen/include"),
+                include("libs/dawn/out/Debug/gen/src"),
+                include("libs/dawn/include"),
+                include("libs/dawn/src"),
             });
             if (step.target_info.target.os.tag == .windows) {
                 try cpp_flags.appendSlice(&.{
@@ -618,9 +618,9 @@ pub fn Sdk(comptime deps: anytype) type {
 
             var flags = std.ArrayList([]const u8).init(b.allocator);
             try flags.appendSlice(&.{
-                include(b, "libs/dawn/src"),
-                include(b, "libs/dawn/out/Debug/gen/include"),
-                include(b, "libs/dawn/out/Debug/gen/src"),
+                include("libs/dawn/src"),
+                include("libs/dawn/out/Debug/gen/include"),
+                include("libs/dawn/out/Debug/gen/src"),
             });
             try appendLangScannedSources(b, lib, options, .{
                 .rel_dirs = &.{
@@ -641,11 +641,11 @@ pub fn Sdk(comptime deps: anytype) type {
                 // TODO(build-system): pass system SDK options through
                 deps.system_sdk.include(b, lib, .{});
                 lib.linkFramework("Foundation");
-                const abs_path = sdkPath(b, "/libs/dawn/src/dawn/common/SystemUtils_mac.mm");
+                const abs_path = sdkPath("/libs/dawn/src/dawn/common/SystemUtils_mac.mm");
                 try cpp_sources.append(abs_path);
             }
             if (step.target_info.target.os.tag == .windows) {
-                const abs_path = sdkPath(b, "/libs/dawn/src/dawn/common/WindowsUtils.cpp");
+                const abs_path = sdkPath("/libs/dawn/src/dawn/common/WindowsUtils.cpp");
                 try cpp_sources.append(abs_path);
             }
 
@@ -673,10 +673,10 @@ pub fn Sdk(comptime deps: anytype) type {
             var cpp_flags = std.ArrayList([]const u8).init(b.allocator);
             try options.appendFlags(&cpp_flags, false, true);
             try cpp_flags.appendSlice(&.{
-                include(b, "libs/dawn/src"),
-                include(b, "libs/dawn/include"),
+                include("libs/dawn/src"),
+                include("libs/dawn/include"),
 
-                include(b, "libs/dawn/out/Debug/gen/include"),
+                include("libs/dawn/out/Debug/gen/include"),
             });
 
             var cpp_sources = std.ArrayList([]const u8).init(b.allocator);
@@ -685,7 +685,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 "src/dawn/platform/WorkerThread.cpp",
                 "src/dawn/platform/tracing/EventTracer.cpp",
             }) |path| {
-                const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                const abs_path = sdkPath("/libs/dawn/" ++ path);
                 try cpp_sources.append(abs_path);
             }
 
@@ -747,12 +747,12 @@ pub fn Sdk(comptime deps: anytype) type {
             var flags = std.ArrayList([]const u8).init(b.allocator);
             try appendDawnEnableBackendTypeFlags(&flags, options);
             try flags.appendSlice(&.{
-                include(b, "libs/dawn"),
-                include(b, "libs/dawn/src"),
-                include(b, "libs/dawn/include"),
-                include(b, "libs/dawn/third_party/vulkan-deps/spirv-tools/src/include"),
-                include(b, "libs/dawn/third_party/abseil-cpp"),
-                include(b, "libs/dawn/third_party/khronos"),
+                include("libs/dawn"),
+                include("libs/dawn/src"),
+                include("libs/dawn/include"),
+                include("libs/dawn/third_party/vulkan-deps/spirv-tools/src/include"),
+                include("libs/dawn/third_party/abseil-cpp"),
+                include("libs/dawn/third_party/khronos"),
 
                 // TODO(build-system): make these optional
                 "-DTINT_BUILD_SPV_READER=1",
@@ -763,12 +763,12 @@ pub fn Sdk(comptime deps: anytype) type {
                 "-DTINT_BUILD_HLSL_WRITER=1",
                 "-DTINT_BUILD_GLSL_WRITER=1",
 
-                include(b, "libs/dawn/"),
-                include(b, "libs/dawn/include/tint"),
-                include(b, "libs/dawn/third_party/vulkan-deps/vulkan-tools/src/"),
+                include("libs/dawn/"),
+                include("libs/dawn/include/tint"),
+                include("libs/dawn/third_party/vulkan-deps/vulkan-tools/src/"),
 
-                include(b, "libs/dawn/out/Debug/gen/include"),
-                include(b, "libs/dawn/out/Debug/gen/src"),
+                include("libs/dawn/out/Debug/gen/include"),
+                include("libs/dawn/out/Debug/gen/src"),
             });
             if (options.d3d12.?) try flags.appendSlice(dawn_d3d12_flags);
 
@@ -811,7 +811,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/mingw_helpers.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/" ++ path);
+                    const abs_path = sdkPath("/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
 
@@ -847,7 +847,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/native/XlibXcbFunctions.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
             }
@@ -855,7 +855,7 @@ pub fn Sdk(comptime deps: anytype) type {
             inline for ([_][]const u8{
                 "src/dawn/native/null/DeviceNull.cpp",
             }) |path| {
-                const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                const abs_path = sdkPath("/libs/dawn/" ++ path);
                 try cpp_sources.append(abs_path);
             }
 
@@ -863,7 +863,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/native/SpirvValidation.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
             }
@@ -893,7 +893,7 @@ pub fn Sdk(comptime deps: anytype) type {
                         "src/dawn/native/vulkan/external_memory/MemoryServiceOpaqueFD.cpp",
                         "src/dawn/native/vulkan/external_semaphore/SemaphoreServiceFD.cpp",
                     }) |path| {
-                        const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                        const abs_path = sdkPath("/libs/dawn/" ++ path);
                         try cpp_sources.append(abs_path);
                     }
                 } else if (step.target_info.target.os.tag == .fuchsia) {
@@ -901,7 +901,7 @@ pub fn Sdk(comptime deps: anytype) type {
                         "src/dawn/native/vulkan/external_memory/MemoryServiceZirconHandle.cpp",
                         "src/dawn/native/vulkan/external_semaphore/SemaphoreServiceZirconHandle.cpp",
                     }) |path| {
-                        const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                        const abs_path = sdkPath("/libs/dawn/" ++ path);
                         try cpp_sources.append(abs_path);
                     }
                 } else {
@@ -909,7 +909,7 @@ pub fn Sdk(comptime deps: anytype) type {
                         "src/dawn/native/vulkan/external_memory/MemoryServiceNull.cpp",
                         "src/dawn/native/vulkan/external_semaphore/SemaphoreServiceNull.cpp",
                     }) |path| {
-                        const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                        const abs_path = sdkPath("/libs/dawn/" ++ path);
                         try cpp_sources.append(abs_path);
                     }
                 }
@@ -957,7 +957,7 @@ pub fn Sdk(comptime deps: anytype) type {
             inline for ([_][]const u8{
                 "src/dawn/native/null/NullBackend.cpp",
             }) |path| {
-                const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                const abs_path = sdkPath("/libs/dawn/" ++ path);
                 try cpp_sources.append(abs_path);
             }
 
@@ -965,7 +965,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/native/d3d12/D3D12Backend.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
             }
@@ -973,7 +973,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/native/opengl/OpenGLBackend.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
             }
@@ -981,7 +981,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/native/vulkan/VulkanBackend.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
                 // TODO(build-system): vulkan
@@ -1027,17 +1027,17 @@ pub fn Sdk(comptime deps: anytype) type {
                 "-DTINT_BUILD_HLSL_WRITER=1",
                 "-DTINT_BUILD_GLSL_WRITER=1",
 
-                include(b, "libs/dawn/"),
-                include(b, "libs/dawn/include/tint"),
+                include("libs/dawn/"),
+                include("libs/dawn/include/tint"),
 
                 // Required for TINT_BUILD_SPV_READER=1 and TINT_BUILD_SPV_WRITER=1, if specified
-                include(b, "libs/dawn/third_party/vulkan-deps"),
-                include(b, "libs/dawn/third_party/vulkan-deps/spirv-tools/src"),
-                include(b, "libs/dawn/third_party/vulkan-deps/spirv-tools/src/include"),
-                include(b, "libs/dawn/third_party/vulkan-deps/spirv-headers/src/include"),
-                include(b, "libs/dawn/out/Debug/gen/third_party/vulkan-deps/spirv-tools/src"),
-                include(b, "libs/dawn/out/Debug/gen/third_party/vulkan-deps/spirv-tools/src/include"),
-                include(b, "libs/dawn/include"),
+                include("libs/dawn/third_party/vulkan-deps"),
+                include("libs/dawn/third_party/vulkan-deps/spirv-tools/src"),
+                include("libs/dawn/third_party/vulkan-deps/spirv-tools/src/include"),
+                include("libs/dawn/third_party/vulkan-deps/spirv-headers/src/include"),
+                include("libs/dawn/out/Debug/gen/third_party/vulkan-deps/spirv-tools/src"),
+                include("libs/dawn/out/Debug/gen/third_party/vulkan-deps/spirv-tools/src/include"),
+                include("libs/dawn/include"),
             });
 
             // libtint_core_all_src
@@ -1062,9 +1062,9 @@ pub fn Sdk(comptime deps: anytype) type {
 
             var cpp_sources = std.ArrayList([]const u8).init(b.allocator);
             switch (step.target_info.target.os.tag) {
-                .windows => try cpp_sources.append(sdkPath(b, "/libs/dawn/src/tint/diagnostic/printer_windows.cc")),
-                .linux => try cpp_sources.append(sdkPath(b, "/libs/dawn/src/tint/diagnostic/printer_linux.cc")),
-                else => try cpp_sources.append(sdkPath(b, "/libs/dawn/src/tint/diagnostic/printer_other.cc")),
+                .windows => try cpp_sources.append(sdkPath("/libs/dawn/src/tint/diagnostic/printer_windows.cc")),
+                .linux => try cpp_sources.append(sdkPath("/libs/dawn/src/tint/diagnostic/printer_linux.cc")),
+                else => try cpp_sources.append(sdkPath("/libs/dawn/src/tint/diagnostic/printer_other.cc")),
             }
 
             // libtint_sem_src
@@ -1167,13 +1167,13 @@ pub fn Sdk(comptime deps: anytype) type {
 
             var flags = std.ArrayList([]const u8).init(b.allocator);
             try flags.appendSlice(&.{
-                include(b, "libs/dawn"),
-                include(b, "libs/dawn/third_party/vulkan-deps/spirv-tools/src"),
-                include(b, "libs/dawn/third_party/vulkan-deps/spirv-tools/src/include"),
-                include(b, "libs/dawn/third_party/vulkan-deps/spirv-headers/src/include"),
-                include(b, "libs/dawn/out/Debug/gen/third_party/vulkan-deps/spirv-tools/src"),
-                include(b, "libs/dawn/out/Debug/gen/third_party/vulkan-deps/spirv-tools/src/include"),
-                include(b, "libs/dawn/third_party/vulkan-deps/spirv-headers/src/include/spirv/unified1"),
+                include("libs/dawn"),
+                include("libs/dawn/third_party/vulkan-deps/spirv-tools/src"),
+                include("libs/dawn/third_party/vulkan-deps/spirv-tools/src/include"),
+                include("libs/dawn/third_party/vulkan-deps/spirv-headers/src/include"),
+                include("libs/dawn/out/Debug/gen/third_party/vulkan-deps/spirv-tools/src"),
+                include("libs/dawn/out/Debug/gen/third_party/vulkan-deps/spirv-tools/src/include"),
+                include("libs/dawn/third_party/vulkan-deps/spirv-headers/src/include/spirv/unified1"),
             });
 
             // spvtools
@@ -1241,8 +1241,8 @@ pub fn Sdk(comptime deps: anytype) type {
 
             var flags = std.ArrayList([]const u8).init(b.allocator);
             try flags.appendSlice(&.{
-                include(b, "libs/dawn"),
-                include(b, "libs/dawn/third_party/abseil-cpp"),
+                include("libs/dawn"),
+                include("libs/dawn/third_party/abseil-cpp"),
             });
             if (target.os.tag == .windows) try flags.appendSlice(&.{
                 "-DABSL_FORCE_THREAD_IDENTITY_MODE=2",
@@ -1250,7 +1250,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 "-DD3D10_ARBITRARY_HEADER_ORDERING",
                 "-D_CRT_SECURE_NO_WARNINGS",
                 "-DNOMINMAX",
-                include(b, "src/dawn/zig_mingw_pthread"),
+                include("src/dawn/zig_mingw_pthread"),
             });
 
             // absl
@@ -1299,11 +1299,11 @@ pub fn Sdk(comptime deps: anytype) type {
 
             var flags = std.ArrayList([]const u8).init(b.allocator);
             try flags.appendSlice(&.{
-                include(b, "libs/dawn"),
-                include(b, "libs/dawn/src"),
-                include(b, "libs/dawn/include"),
-                include(b, "libs/dawn/out/Debug/gen/include"),
-                include(b, "libs/dawn/out/Debug/gen/src"),
+                include("libs/dawn"),
+                include("libs/dawn/src"),
+                include("libs/dawn/include"),
+                include("libs/dawn/out/Debug/gen/include"),
+                include("libs/dawn/out/Debug/gen/src"),
             });
 
             try appendLangScannedSources(b, lib, options, .{
@@ -1339,10 +1339,10 @@ pub fn Sdk(comptime deps: anytype) type {
             var flags = std.ArrayList([]const u8).init(b.allocator);
             try appendDawnEnableBackendTypeFlags(&flags, options);
             try flags.appendSlice(&.{
-                include(b, deps.glfw_include_dir),
-                include(b, "libs/dawn/src"),
-                include(b, "libs/dawn/include"),
-                include(b, "libs/dawn/out/Debug/gen/include"),
+                include(deps.glfw_include_dir),
+                include("libs/dawn/src"),
+                include("libs/dawn/include"),
+                include("libs/dawn/out/Debug/gen/include"),
             });
 
             var cpp_sources = std.ArrayList([]const u8).init(b.allocator);
@@ -1350,7 +1350,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 "src/dawn/utils/BackendBinding.cpp",
                 "src/dawn/utils/NullBinding.cpp",
             }) |path| {
-                const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                const abs_path = sdkPath("/libs/dawn/" ++ path);
                 try cpp_sources.append(abs_path);
             }
 
@@ -1358,7 +1358,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/utils/D3D12Binding.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
                 try flags.appendSlice(dawn_d3d12_flags);
@@ -1367,7 +1367,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/utils/MetalBinding.mm",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
             }
@@ -1376,7 +1376,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/utils/OpenGLBinding.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
             }
@@ -1385,7 +1385,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 inline for ([_][]const u8{
                     "src/dawn/utils/VulkanBinding.cpp",
                 }) |path| {
-                    const abs_path = sdkPath(b, "/libs/dawn/" ++ path);
+                    const abs_path = sdkPath("/libs/dawn/" ++ path);
                     try cpp_sources.append(abs_path);
                 }
             }
@@ -1420,13 +1420,13 @@ pub fn Sdk(comptime deps: anytype) type {
 
             var flags = std.ArrayList([]const u8).init(b.allocator);
             try flags.appendSlice(&.{
-                include(b, "libs/"),
-                include(b, "libs/DirectXShaderCompiler/include/llvm/llvm_assert"),
-                include(b, "libs/DirectXShaderCompiler/include"),
-                include(b, "libs/DirectXShaderCompiler/build/include"),
-                include(b, "libs/DirectXShaderCompiler/build/lib/HLSL"),
-                include(b, "libs/DirectXShaderCompiler/build/lib/DxilPIXPasses"),
-                include(b, "libs/DirectXShaderCompiler/build/include"),
+                include("libs/"),
+                include("libs/DirectXShaderCompiler/include/llvm/llvm_assert"),
+                include("libs/DirectXShaderCompiler/include"),
+                include("libs/DirectXShaderCompiler/build/include"),
+                include("libs/DirectXShaderCompiler/build/lib/HLSL"),
+                include("libs/DirectXShaderCompiler/build/lib/DxilPIXPasses"),
+                include("libs/DirectXShaderCompiler/build/include"),
                 "-DUNREFERENCED_PARAMETER(x)=",
                 "-Wno-inconsistent-missing-override",
                 "-Wno-missing-exception-spec",
@@ -1562,7 +1562,7 @@ pub fn Sdk(comptime deps: anytype) type {
             excluding: []const []const u8,
             excluding_contains: []const []const u8,
         ) !void {
-            const abs_dir = try std.fs.path.join(b.allocator, &.{ sdkPath(b, "/"), rel_dir });
+            const abs_dir = try std.fs.path.join(b.allocator, &.{ sdkPath("/"), rel_dir });
             defer b.allocator.free(abs_dir);
             var dir = try std.fs.openIterableDirAbsolute(abs_dir, .{});
             defer dir.close();
@@ -1601,34 +1601,16 @@ pub fn Sdk(comptime deps: anytype) type {
             }
         }
 
-        var this_dir: ?[]const u8 = null;
-
-        fn thisDir(allocator: std.mem.Allocator) []const u8 {
-            if (this_dir == null) {
-                const unresolved_dir = comptime std.fs.path.dirname(@src().file) orelse ".";
-
-                if (comptime unresolved_dir[0] == '/') {
-                    this_dir = unresolved_dir;
-                } else {
-                    this_dir = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-                }
-            }
-
-            return this_dir.?;
+        fn include(comptime rel: []const u8) []const u8 {
+            return comptime "-I" ++ sdkPath("/" ++ rel);
         }
 
-        fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-            return sdkPathAllocator(b.allocator, suffix);
-        }
-
-        fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+        fn sdkPath(comptime suffix: []const u8) []const u8 {
             if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-            return std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-        }
-
-        fn include(b: *Builder, comptime rel: []const u8) []const u8 {
-            return std.mem.concat(b.allocator, u8, &.{ "-I", sdkPath(b, "/" ++ rel) }) catch unreachable;
+            return comptime blk: {
+                const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+                break :blk root_dir ++ suffix;
+            };
         }
     };
 }

--- a/libs/gpu/sdk.zig
+++ b/libs/gpu/sdk.zig
@@ -1,10 +1,9 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
 pub fn Sdk(comptime deps: anytype) type {
     return struct {
-        pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, options: Options) !*std.build.RunStep {
-            const main_tests = b.addTestExe("gpu-tests", sdkPath(b, "/src/main.zig"));
+        pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget, options: Options) !*std.build.RunStep {
+            const main_tests = b.addTestExe("gpu-tests", sdkPath("/src/main.zig"));
             main_tests.setBuildMode(mode);
             main_tests.setTarget(target);
             try link(b, main_tests, options);
@@ -17,58 +16,27 @@ pub fn Sdk(comptime deps: anytype) type {
             gpu_dawn_options: deps.gpu_dawn.Options = .{},
         };
 
-        var cached_pkg: ?std.build.Pkg = null;
-
-        pub fn pkg(b: *Builder) std.build.Pkg {
-            if (cached_pkg == null) {
-                const dependencies = b.allocator.create([1]std.build.Pkg) catch unreachable;
-                dependencies.* = .{
-                    deps.glfw.pkg(b),
-                };
-
-                cached_pkg = .{
-                    .name = "gpu",
-                    .source = .{ .path = sdkPath(b, "/src/main.zig") },
-                    .dependencies = dependencies,
-                };
-            }
-
-            return cached_pkg.?;
-        }
+        pub const pkg = std.build.Pkg{
+            .name = "gpu",
+            .source = .{ .path = sdkPath("/src/main.zig") },
+            .dependencies = &.{deps.glfw.pkg},
+        };
 
         pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep, options: Options) !void {
             if (step.target.toTarget().cpu.arch != .wasm32) {
                 try deps.glfw.link(b, step, options.glfw_options);
                 try deps.gpu_dawn.link(b, step, options.gpu_dawn_options);
-                step.addCSourceFile(sdkPath(b, "/src/mach_dawn.cpp"), &.{"-std=c++17"});
-                step.addIncludePath(sdkPath(b, "/src"));
+                step.addCSourceFile(sdkPath("/src/mach_dawn.cpp"), &.{"-std=c++17"});
+                step.addIncludePath(sdkPath("/src"));
             }
         }
 
-        var this_dir: ?[]const u8 = null;
-
-        fn thisDir(allocator: std.mem.Allocator) []const u8 {
-            if (this_dir == null) {
-                const unresolved_dir = comptime std.fs.path.dirname(@src().file) orelse ".";
-
-                if (comptime unresolved_dir[0] == '/') {
-                    this_dir = unresolved_dir;
-                } else {
-                    this_dir = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-                }
-            }
-
-            return this_dir.?;
-        }
-
-        fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-            return sdkPathAllocator(b.allocator, suffix);
-        }
-
-        fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+        fn sdkPath(comptime suffix: []const u8) []const u8 {
             if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-            return std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
+            return comptime blk: {
+                const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+                break :blk root_dir ++ suffix;
+            };
         }
     };
 }

--- a/libs/model3d/build.zig
+++ b/libs/model3d/build.zig
@@ -1,28 +1,18 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-var cached_pkg: ?std.build.Pkg = null;
+pub const pkg = std.build.Pkg{
+    .name = "model3d",
+    .source = .{ .path = sdkPath("/src/main.zig") },
+};
 
-pub fn pkg(b: *Builder) std.build.Pkg {
-    if (cached_pkg == null) {
-        cached_pkg = .{
-            .name = "model3d",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = &.{},
-        };
-    }
-
-    return cached_pkg.?;
-}
-
-pub fn build(b: *Builder) void {
+pub fn build(b: *std.build.Builder) void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&testStep(b, mode, target).step);
 }
 
-pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
     const main_tests = b.addTestExe("model3d-tests", "src/main.zig");
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
@@ -31,61 +21,21 @@ pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget
     return main_tests.run();
 }
 
-pub fn link(b: *Builder, step: *std.build.LibExeObjStep, target: std.zig.CrossTarget) void {
+pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep, target: std.zig.CrossTarget) void {
     const lib = b.addStaticLibrarySource("model3d", null);
     lib.setTarget(target);
     // Note: model3d needs unaligned accesses, which are safe on all modern architectures.
     // See https://gitlab.com/bztsrc/model3d/-/issues/19
-    lib.addCSourceFile(sdkPath(b, "/src/c/m3d.c"), &.{ "-std=c89", "-fno-sanitize=alignment" });
+    lib.addCSourceFile(sdkPath("/src/c/m3d.c"), &.{ "-std=c89", "-fno-sanitize=alignment" });
     lib.linkLibC();
-    step.addIncludePath(sdkPath(b, "/src/c/"));
+    step.addIncludePath(sdkPath("/src/c/"));
     step.linkLibrary(lib);
 }
 
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }

--- a/libs/sysaudio/sdk.zig
+++ b/libs/sysaudio/sdk.zig
@@ -1,26 +1,12 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
 pub fn Sdk(comptime deps: anytype) type {
     return struct {
-        var cached_pkg: ?std.build.Pkg = null;
-
-        pub fn pkg(b: *Builder) std.build.Pkg {
-            if (cached_pkg == null) {
-                const dependencies = b.allocator.create([1]std.build.Pkg) catch unreachable;
-                dependencies.* = .{
-                    deps.sysjs.pkg(b),
-                };
-
-                cached_pkg = .{
-                    .name = "sysaudio",
-                    .source = .{ .path = sdkPath(b, "/src/main.zig") },
-                    .dependencies = dependencies,
-                };
-            }
-
-            return cached_pkg.?;
-        }
+        pub const pkg = std.build.Pkg{
+            .name = "sysaudio",
+            .source = .{ .path = sdkPath("/src/main.zig") },
+            .dependencies = &.{deps.sysjs.pkg},
+        };
 
         pub const Options = struct {
             install_libs: bool = false,
@@ -29,8 +15,8 @@ pub fn Sdk(comptime deps: anytype) type {
             system_sdk: deps.system_sdk.Options = .{},
         };
 
-        pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
-            const main_tests = b.addTestExe("sysaudio-tests", sdkPath(b, "/src/main.zig"));
+        pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+            const main_tests = b.addTestExe("sysaudio-tests", sdkPath("/src/main.zig"));
             main_tests.setBuildMode(mode);
             main_tests.setTarget(target);
             link(b, main_tests, .{});
@@ -38,7 +24,7 @@ pub fn Sdk(comptime deps: anytype) type {
             return main_tests.run();
         }
 
-        pub fn link(b: *Builder, step: *std.build.LibExeObjStep, options: Options) void {
+        pub fn link(b: *std.build.Builder, step: *std.build.LibExeObjStep, options: Options) void {
             if (step.target.toTarget().cpu.arch != .wasm32) {
                 // TODO(build-system): pass system SDK options through
                 deps.system_sdk.include(b, step, .{});
@@ -64,37 +50,19 @@ pub fn Sdk(comptime deps: anytype) type {
                 if (std.mem.eql(u8, no_ensure_submodules, "true")) return;
             } else |_| {}
             var child = std.ChildProcess.init(&.{ "git", "submodule", "update", "--init", path }, allocator);
-            child.cwd = sdkPathAllocator(allocator, "/");
+            child.cwd = sdkPath("/");
             child.stderr = std.io.getStdErr();
             child.stdout = std.io.getStdOut();
 
             _ = try child.spawnAndWait();
         }
 
-        var this_dir: ?[]const u8 = null;
-
-        fn thisDir(allocator: std.mem.Allocator) []const u8 {
-            if (this_dir == null) {
-                const unresolved_dir = comptime std.fs.path.dirname(@src().file) orelse ".";
-
-                if (comptime unresolved_dir[0] == '/') {
-                    this_dir = unresolved_dir;
-                } else {
-                    this_dir = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-                }
-            }
-
-            return this_dir.?;
-        }
-
-        fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-            return sdkPathAllocator(b.allocator, suffix);
-        }
-
-        fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
+        fn sdkPath(comptime suffix: []const u8) []const u8 {
             if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-            return std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
+            return comptime blk: {
+                const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+                break :blk root_dir ++ suffix;
+            };
         }
     };
 }

--- a/libs/sysjs/build.zig
+++ b/libs/sysjs/build.zig
@@ -1,78 +1,29 @@
 const std = @import("std");
-const Builder = std.build.Builder;
 
-pub fn build(b: *Builder) void {
+pub fn build(b: *std.build.Builder) void {
     const mode = b.standardReleaseOptions();
     const target = b.standardTargetOptions(.{});
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&testStep(b, mode, target).step);
 }
 
-pub fn testStep(b: *Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
-    const main_tests = b.addTestExe("sysjs-tests", sdkPath(b, "/src/main.zig"));
+pub fn testStep(b: *std.build.Builder, mode: std.builtin.Mode, target: std.zig.CrossTarget) *std.build.RunStep {
+    const main_tests = b.addTestExe("sysjs-tests", sdkPath("/src/main.zig"));
     main_tests.setBuildMode(mode);
     main_tests.setTarget(target);
     return main_tests.run();
 }
 
-var cached_pkg: ?std.build.Pkg = null;
+pub const pkg = std.build.Pkg{
+    .name = "sysjs",
+    .source = .{ .path = sdkPath("/src/main.zig") },
+    .dependencies = &[_]std.build.Pkg{},
+};
 
-pub fn pkg(b: *Builder) std.build.Pkg {
-    if (cached_pkg == null) {
-        cached_pkg = .{
-            .name = "sysjs",
-            .source = .{ .path = sdkPath(b, "/src/main.zig") },
-            .dependencies = &.{},
-        };
-    }
-
-    return cached_pkg.?;
-}
-
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }

--- a/tools/wasmserve/wasmserve.zig
+++ b/tools/wasmserve/wasmserve.zig
@@ -6,7 +6,7 @@ const mem = std.mem;
 const fs = std.fs;
 const build = std.build;
 
-const www_dir_path = "/www";
+const www_dir_path = sdkPath("/www");
 const buffer_size = 2048;
 const esc = struct {
     pub const reset = "\x1b[0m";
@@ -75,13 +75,11 @@ const Wasmserve = struct {
         self.compile();
         std.debug.assert(mem.eql(u8, fs.path.extension(self.exe_step.out_filename), ".wasm"));
 
-        const resolved_www_dir_path = sdkPathAllocator(step.dependencies.allocator, www_dir_path);
-
-        var www_dir = try fs.cwd().openIterableDir(resolved_www_dir_path, .{});
+        var www_dir = try fs.cwd().openIterableDir(www_dir_path, .{});
         defer www_dir.close();
         var www_dir_iter = www_dir.iterate();
         while (try www_dir_iter.next()) |file| {
-            const path = try fs.path.join(self.b.allocator, &.{ resolved_www_dir_path, file.name });
+            const path = try fs.path.join(self.b.allocator, &.{ www_dir_path, file.name });
             defer self.b.allocator.free(path);
             const install_www = self.b.addInstallFileWithDir(
                 .{ .path = path },
@@ -328,52 +326,12 @@ fn logErr(err: anyerror, src: std.builtin.SourceLocation) void {
     }
 }
 
-const unresolved_dir = (struct {
-    inline fn unresolvedDir() []const u8 {
-        return comptime std.fs.path.dirname(@src().file) orelse ".";
-    }
-}).unresolvedDir();
-
-fn thisDir(allocator: std.mem.Allocator) []const u8 {
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir;
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.cwd().realpathAlloc(allocator, unresolved_dir) catch unreachable;
-    }
-
-    return cached_dir.*.?;
-}
-
-inline fn sdkPath(b: *build.Builder, comptime suffix: []const u8) []const u8 {
-    return sdkPathAllocator(b.allocator, suffix);
-}
-
-inline fn sdkPathAllocator(allocator: std.mem.Allocator, comptime suffix: []const u8) []const u8 {
-    return sdkPathInternal(allocator, suffix.len, suffix[0..suffix.len].*);
-}
-
-fn sdkPathInternal(allocator: std.mem.Allocator, comptime len: usize, comptime suffix: [len]u8) []const u8 {
+fn sdkPath(comptime suffix: []const u8) []const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-
-    if (comptime unresolved_dir[0] == '/') {
-        return unresolved_dir ++ @as([]const u8, &suffix);
-    }
-
-    const cached_dir = &(struct {
-        var cached_dir: ?[]const u8 = null;
-    }).cached_dir;
-
-    if (cached_dir.* == null) {
-        cached_dir.* = std.fs.path.resolve(allocator, &.{ thisDir(allocator), suffix[1..] }) catch unreachable;
-    }
-
-    return cached_dir.*.?;
+    return comptime blk: {
+        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
+        break :blk root_dir ++ suffix;
+    };
 }
 
 // copied from LibExeObjStep.make()


### PR DESCRIPTION
This reverts commit a1fe671db8fcea21a99a98448acf3b3ceea31fe9.

Lue suggested reverting #661 because ZLS worked around the issue of @src being relative in that environment: https://github.com/zigtools/zls/pull/898

This is not a perfect solution (what zls did seems to be a workaround), but is good enough for us until Zig gets an official package manager.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
