### PR TITLE
glfw: refactor `getError` and related functions

### DIFF
--- a/libs/glfw/src/Cursor.zig
+++ b/libs/glfw/src/Cursor.zig
@@ -4,8 +4,6 @@ const std = @import("std");
 const testing = std.testing;
 
 const c = @import("c.zig").c;
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 const Image = @import("Image.zig");
 
 const internal_debug = @import("internal_debug.zig");
@@ -106,7 +104,7 @@ pub const Shape = enum(i32) {
 /// @param[in] yhot The desired y-coordinate, in pixels, of the cursor hotspot.
 /// @return The handle of the created cursor.
 ///
-/// Possible errors include glfw.Error.PlatformError and glfw.Error.InvalidValue
+/// Possible errors include glfw.ErrorCode.PlatformError and glfw.ErrorCode.InvalidValue
 /// null is returned in the event of an error.
 ///
 /// @pointer_lifetime The specified image data is copied before this function returns.
@@ -147,7 +145,7 @@ pub inline fn create(image: Image, xhot: i32, yhot: i32) ?Cursor {
 /// 2. This uses a newer standard that not all cursor themes support.
 ///
 /// If the requested shape is not available, this function emits a CursorUnavailable error
-/// Possible errors include glfw.Error.PlatformError and glfw.Error.CursorUnavailable.
+/// Possible errors include glfw.ErrorCode.PlatformError and glfw.ErrorCode.CursorUnavailable.
 /// null is returned in the event of an error.
 ///
 /// thread_safety: This function must only be called from the main thread.
@@ -167,7 +165,7 @@ pub inline fn createStandard(shape: Shape) ?Cursor {
 /// If the specified cursor is current for any window, that window will be reverted to the default
 /// cursor. This does not affect the cursor mode.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// @reentrancy This function must not be called from a callback.
 ///
@@ -183,7 +181,7 @@ test "create" {
     const allocator = testing.allocator;
 
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -199,7 +197,7 @@ test "create" {
 
 test "createStandard" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);

--- a/libs/glfw/src/Joystick.zig
+++ b/libs/glfw/src/Joystick.zig
@@ -7,8 +7,6 @@ const std = @import("std");
 
 const c = @import("c.zig").c;
 const Window = @import("Window.zig");
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 const Action = @import("action.zig").Action;
 const GamepadAxis = @import("gamepad_axis.zig").GamepadAxis;
 const GamepadButton = @import("gamepad_button.zig").GamepadButton;
@@ -80,7 +78,7 @@ const GamepadState = extern struct {
 ///
 /// @return `true` if the joystick is present, or `false` otherwise.
 ///
-/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum and glfw.ErrorCode.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -101,7 +99,7 @@ pub inline fn present(self: Joystick) bool {
 ///
 /// @return An array of axis values, or null if the joystick is not present.
 ///
-/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum and glfw.ErrorCode.PlatformError.
 /// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned array is allocated and freed by GLFW. You should not free it
@@ -136,7 +134,7 @@ pub inline fn getAxes(self: Joystick) ?[]const f32 {
 ///
 /// @return An array of button states, or null if the joystick is not present.
 ///
-/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum and glfw.ErrorCode.PlatformError.
 /// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned array is allocated and freed by GLFW. You should not free it
@@ -184,7 +182,7 @@ pub inline fn getButtons(self: Joystick) ?[]const u8 {
 ///
 /// @return An array of hat states, or null if the joystick is not present.
 ///
-/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum and glfw.ErrorCode.PlatformError.
 /// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned array is allocated and freed by GLFW. You should not free it
@@ -214,7 +212,7 @@ pub inline fn getHats(self: Joystick) ?[]const Hat {
 /// @return The UTF-8 encoded name of the joystick, or null if the joystick is not present or an
 /// error occurred.
 ///
-/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum and glfw.ErrorCode.PlatformError.
 /// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
@@ -251,7 +249,7 @@ pub inline fn getName(self: Joystick) ?[:0]const u8 {
 ///
 /// @return The UTF-8 encoded GUID of the joystick, or null if the joystick is not present.
 ///
-/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum and glfw.ErrorCode.PlatformError.
 /// null is additionally returned in the event of an error.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
@@ -364,7 +362,7 @@ pub inline fn setCallback(comptime callback: ?fn (joystick: Joystick, event: Eve
 ///
 /// @param[in] string The string containing the gamepad mappings.
 ///
-/// Possible errors include glfw.Error.InvalidValue.
+/// Possible errors include glfw.ErrorCode.InvalidValue.
 /// Returns a boolean indicating success.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -388,7 +386,7 @@ pub inline fn updateGamepadMappings(gamepad_mappings: [*:0]const u8) bool {
 ///
 /// @return `true` if a joystick is both present and has a gamepad mapping, or `false` otherwise.
 ///
-/// Possible errors include glfw.Error.InvalidEnum.
+/// Possible errors include glfw.ErrorCode.InvalidEnum.
 /// Additionally returns false in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -412,7 +410,7 @@ pub inline fn isGamepad(self: Joystick) bool {
 /// @return The UTF-8 encoded name of the gamepad, or null if the joystick is not present or does
 /// not have a mapping.
 ///
-/// Possible errors include glfw.Error.InvalidEnum.
+/// Possible errors include glfw.ErrorCode.InvalidEnum.
 /// Additionally returns null in the event of an error.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
@@ -450,7 +448,7 @@ pub inline fn getGamepadName(self: Joystick) ?[:0]const u8 {
 /// @return the gamepad input state if successful, or null if no joystick is connected or it has no
 /// gamepad mapping.
 ///
-/// Possible errors include glfw.Error.InvalidEnum.
+/// Possible errors include glfw.ErrorCode.InvalidEnum.
 /// Returns null in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -465,7 +463,7 @@ pub inline fn getGamepadState(self: Joystick) ?GamepadState {
 
 test "present" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -478,7 +476,7 @@ test "present" {
 
 test "getAxes" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -491,7 +489,7 @@ test "getAxes" {
 
 test "getButtons" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -504,7 +502,7 @@ test "getButtons" {
 
 test "getHats" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -524,7 +522,7 @@ test "getHats" {
 
 test "getName" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -537,7 +535,7 @@ test "getName" {
 
 test "getGUID" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -550,7 +548,7 @@ test "getGUID" {
 
 test "setUserPointer_syntax" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -566,7 +564,7 @@ test "setUserPointer_syntax" {
 
 test "getUserPointer_syntax" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -582,7 +580,7 @@ test "getUserPointer_syntax" {
 
 test "setCallback" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -604,7 +602,7 @@ test "updateGamepadMappings_syntax" {
 
 test "isGamepad" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -617,7 +615,7 @@ test "isGamepad" {
 
 test "getGamepadName" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -630,7 +628,7 @@ test "getGamepadName" {
 
 test "getGamepadState" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);

--- a/libs/glfw/src/Monitor.zig
+++ b/libs/glfw/src/Monitor.zig
@@ -5,8 +5,6 @@ const mem = std.mem;
 const testing = std.testing;
 const c = @import("c.zig").c;
 
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 const GammaRamp = @import("GammaRamp.zig");
 const VideoMode = @import("VideoMode.zig");
 
@@ -27,7 +25,7 @@ const Pos = struct {
 
 /// Returns the position of the monitor's viewport on the virtual screen.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -55,7 +53,7 @@ const Workarea = struct {
 
 /// Retrieves the work area of the monitor.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// A zero value is returned in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -114,7 +112,7 @@ const ContentScale = struct {
 
 /// Returns the content scale for the monitor.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// A zero value is returned in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -188,7 +186,7 @@ pub inline fn getUserPointer(self: Monitor, comptime T: type) ?*T {
 /// then by resolution area (the product of width and height), then resolution width and finally
 /// by refresh rate.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Returns null in the event of an error.
 ///
 /// The returned slice memory is owned by the caller.
@@ -218,7 +216,7 @@ pub inline fn getVideoModes(self: Monitor, allocator: mem.Allocator) mem.Allocat
 /// full screen window for that monitor, the return value will depend on whether that window is
 /// iconified.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Additionally returns null in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -241,10 +239,10 @@ pub inline fn getVideoMode(self: Monitor) ?VideoMode {
 ///
 /// For gamma correct rendering with OpenGL or OpenGL ES, see the glfw.srgb_capable hint.
 ///
-/// Possible errors include glfw.Error.InvalidValue and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidValue and glfw.ErrorCode.PlatformError.
 ///
 /// wayland: Gamma handling is a privileged protocol, this function will thus never be implemented
-/// and emits glfw.Error.PlatformError.
+/// and emits glfw.ErrorCode.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -263,11 +261,11 @@ pub inline fn setGamma(self: Monitor, gamma: f32) void {
 ///
 /// This function returns the current gamma ramp of the specified monitor.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Additionally returns null in the event of an error.
 ///
 /// wayland: Gamma handling is a privileged protocol, this function will thus never be implemented
-/// and returns glfw.Error.PlatformError.
+/// and returns glfw.ErrorCode.PlatformError.
 /// TODO: Is the documentation obsolete? On wayland the error returned is FeatureUnavailable
 ///
 /// The returned gamma ramp is `.owned = true` by GLFW, and is valid until the monitor is
@@ -294,13 +292,13 @@ pub inline fn getGammaRamp(self: Monitor) ?GammaRamp {
 ///
 /// For gamma correct rendering with OpenGL or OpenGL ES, see the glfw.srgb_capable hint.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// The size of the specified gamma ramp should match the size of the current ramp for that
 /// monitor. On win32, the gamma ramp size must be 256.
 ///
 /// wayland: Gamma handling is a privileged protocol, this function will thus never be implemented
-/// and emits glfw.Error.PlatformError.
+/// and emits glfw.ErrorCode.PlatformError.
 ///
 /// @pointer_lifetime The specified gamma ramp is copied before this function returns.
 ///
@@ -402,7 +400,7 @@ pub inline fn setCallback(comptime callback: ?fn (monitor: Monitor, event: Event
 
 test "getAll" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -416,7 +414,7 @@ test "getAll" {
 
 test "getPrimary" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -428,7 +426,7 @@ test "getPrimary" {
 
 test "getPos" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -443,7 +441,7 @@ test "getPos" {
 
 test "getWorkarea" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -458,7 +456,7 @@ test "getWorkarea" {
 
 test "getPhysicalSize" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -473,7 +471,7 @@ test "getPhysicalSize" {
 
 test "getContentScale" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -488,7 +486,7 @@ test "getContentScale" {
 
 test "getName" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -503,7 +501,7 @@ test "getName" {
 
 test "userPointer" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -523,7 +521,7 @@ test "userPointer" {
 
 test "setCallback" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -540,7 +538,7 @@ test "setCallback" {
 
 test "getVideoModes" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -559,7 +557,7 @@ test "getVideoModes" {
 
 test "getVideoMode" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -575,7 +573,7 @@ test "getVideoMode" {
 test "set_getGammaRamp" {
     const allocator = testing.allocator;
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);

--- a/libs/glfw/src/Window.zig
+++ b/libs/glfw/src/Window.zig
@@ -6,8 +6,6 @@ const mem = std.mem;
 const c = @import("c.zig").c;
 
 const glfw = @import("main.zig");
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 const Image = @import("Image.zig");
 const Monitor = @import("Monitor.zig");
 const Cursor = @import("Cursor.zig");
@@ -295,9 +293,9 @@ pub const Hints = struct {
 /// The swap interval is not set during window creation and the initial value may vary depending on
 /// driver settings and defaults.
 ///
-/// Possible errors include glfw.Error.InvalidEnum, glfw.Error.InvalidValue,
-/// glfw.Error.APIUnavailable, glfw.Error.VersionUnavailable, glfw.Error.FormatUnavailable and
-/// glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum, glfw.ErrorCode.InvalidValue,
+/// glfw.ErrorCode.APIUnavailable, glfw.ErrorCode.VersionUnavailable, glfw.ErrorCode.FormatUnavailable and
+/// glfw.ErrorCode.PlatformError.
 /// Returns null in the event of an error.
 ///
 /// Parameters are as follows:
@@ -402,7 +400,7 @@ var testing_ignore_window_hints_struct = if (@import("builtin").is_test) false e
 /// note: The context of the specified window must not be current on any other thread when this
 /// function is called.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// @reentrancy This function must not be called from a callback.
 ///
@@ -445,7 +443,7 @@ pub inline fn setShouldClose(self: Window, value: bool) void {
 ///
 /// This function sets the window title, encoded as UTF-8, of the specified window.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// macos: The window title will not be updated until the next time you process events.
 ///
@@ -478,9 +476,9 @@ pub inline fn setTitle(self: Window, title: [*:0]const u8) void {
 /// in the Mac Developer Library.
 ///
 /// wayland: There is no existing protocol to change an icon, the window will thus inherit the one
-/// defined in the application's desktop file. This function will emit glfw.Error.FeatureUnavailable.
+/// defined in the application's desktop file. This function will emit glfw.ErrorCode.FeatureUnavailable.
 ///
-/// Possible errors include glfw.Error.InvalidValue, glfw.Error.FeatureUnavailable
+/// Possible errors include glfw.ErrorCode.InvalidValue, glfw.ErrorCode.FeatureUnavailable
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -505,11 +503,11 @@ pub const Pos = struct {
 /// This function retrieves the position, in screen coordinates, of the upper-left corner of the
 /// content area of the specified window.
 ///
-/// Possible errors include glfw.Error.FeatureUnavailable.
+/// Possible errors include glfw.ErrorCode.FeatureUnavailable.
 /// Additionally returns a zero value in the event of an error.
 ///
 /// wayland: There is no way for an application to retrieve the global position of its windows,
-/// this function will always emit glfw.Error.FeatureUnavailable.
+/// this function will always emit glfw.ErrorCode.FeatureUnavailable.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -534,10 +532,10 @@ pub inline fn getPos(self: Window) Pos {
 /// The window manager may put limits on what positions are allowed. GLFW cannot and should not
 /// override these limits.
 ///
-/// Possible errors include glfw.Error.FeatureUnavailable.
+/// Possible errors include glfw.ErrorCode.FeatureUnavailable.
 ///
 /// wayland: There is no way for an application to set the global position of its windows, this
-/// function will always emit glfw.Error.FeatureUnavailable.
+/// function will always emit glfw.ErrorCode.FeatureUnavailable.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -558,7 +556,7 @@ pub const Size = struct {
 /// window. If you wish to retrieve the size of the framebuffer of the window in pixels, see
 /// glfw.Window.getFramebufferSize.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Additionally returns a zero value in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -586,7 +584,7 @@ pub inline fn getSize(self: Window) Size {
 /// The window manager may put limits on what sizes are allowed. GLFW cannot and should not
 /// override these limits.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// wayland: A full screen window will not attempt to change the mode, no matter what the requested
 /// size.
@@ -617,7 +615,7 @@ pub const SizeOptional = struct {
 /// The maximum dimensions must be greater than or equal to the minimum dimensions. glfw.dont_care
 /// may be used for any width/height parameter.
 ///
-/// Possible errors include glfw.Error.InvalidValue and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidValue and glfw.ErrorCode.PlatformError.
 ///
 /// If you set size limits and an aspect ratio that conflict, the results are undefined.
 ///
@@ -661,7 +659,7 @@ pub inline fn setSizeLimits(self: Window, min: SizeOptional, max: SizeOptional) 
 /// The aspect ratio is applied immediately to a windowed mode window and may cause it to be
 /// resized.
 ///
-/// Possible errors include glfw.Error.InvalidValue and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidValue and glfw.ErrorCode.PlatformError.
 ///
 /// If you set size limits and an aspect ratio that conflict, the results are undefined.
 ///
@@ -672,7 +670,7 @@ pub inline fn setSizeLimits(self: Window, min: SizeOptional, max: SizeOptional) 
 ///
 /// see also: window_sizelimits, glfw.Window.setSizeLimits
 ///
-/// WARNING: on wayland it will return Error.FeatureUnimplemented
+/// WARNING: on wayland it will return glfw.ErrorCode.FeatureUnimplemented
 pub inline fn setAspectRatio(self: Window, numerator: ?u32, denominator: ?u32) void {
     internal_debug.assertInitialized();
 
@@ -693,7 +691,7 @@ pub inline fn setAspectRatio(self: Window, numerator: ?u32, denominator: ?u32) v
 /// This function retrieves the size, in pixels, of the framebuffer of the specified window. If you
 /// wish to retrieve the size of the window in screen coordinates, see @ref glfwGetWindowSize.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Additionally returns a zero value in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -723,7 +721,7 @@ pub const FrameSize = struct {
 /// Because this function retrieves the size of each window frame edge and not the offset along a
 /// particular coordinate axis, the retrieved values will always be zero or positive.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Additionally returns a zero value in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -761,7 +759,7 @@ pub const ContentScale = struct {
 /// On platforms where each monitors can have its own content scale, the window content scale will
 /// depend on which monitor the system considers the window to be on.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Additionally returns a zero value in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -785,7 +783,7 @@ pub inline fn getContentScale(self: Window) ContentScale {
 ///
 /// The initial opacity value for newly created windows is one.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Additionally returns a zero value in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -825,7 +823,7 @@ pub inline fn setOpacity(self: Window, opacity: f32) void {
 /// If the specified window is a full screen window, the original monitor resolution is restored
 /// until the window is restored.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// wayland: Once a window is iconified, glfw.Window.restorebe able to restore it. This is a design
 /// decision of the xdg-shell protocol.
@@ -846,7 +844,7 @@ pub inline fn iconify(self: Window) void {
 /// If the specified window is a full screen window, the resolution chosen for the window is
 /// restored on the selected monitor.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -863,7 +861,7 @@ pub inline fn restore(self: Window) void {
 ///
 /// If the specified window is a full screen window, this function does nothing.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -890,7 +888,7 @@ pub inline fn maximize(self: Window) void {
 ///
 /// see also: window_hide, glfw.Window.hide
 ///
-/// WARNING: on wayland it will return Error.FeatureUnavailable
+/// WARNING: on wayland it will return glfw.ErrorCode.FeatureUnavailable
 pub inline fn show(self: Window) void {
     internal_debug.assertInitialized();
     c.glfwShowWindow(self.handle);
@@ -901,7 +899,7 @@ pub inline fn show(self: Window) void {
 /// This function hides the specified window if it was previously visible. If the window is already
 /// hidden or is in full screen mode, this function does nothing.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -927,7 +925,8 @@ pub inline fn hide(self: Window) void {
 ///
 /// For a less disruptive way of getting the user's attention, see [attention requests (window_attention).
 ///
-/// wayland It is not possible for an application to set the input focus. This function will emit glfw.Error.FeatureUnavailable.
+/// wayland It is not possible for an application to set the input focus. This function will emit
+/// glfw.ErrorCode.FeatureUnavailable.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -944,7 +943,7 @@ pub inline fn focus(self: Window) void {
 ///
 /// Once the user has given attention, usually by focusing the window or application, the system will end the request automatically.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// macos: Attention is requested to the application as a whole, not the
 /// specific window.
@@ -953,7 +952,7 @@ pub inline fn focus(self: Window) void {
 ///
 /// see also: window_attention
 ///
-/// WARNING: on wayland it will return Error.FeatureUnimplemented
+/// WARNING: on wayland it will return glfw.ErrorCode.FeatureUnimplemented
 pub inline fn requestAttention(self: Window) void {
     internal_debug.assertInitialized();
     c.glfwRequestWindowAttention(self.handle);
@@ -966,14 +965,14 @@ pub inline fn requestAttention(self: Window) void {
 /// specified number of screen updates before swapping the buffers.
 ///
 /// The specified window must have an OpenGL or OpenGL ES context. Specifying a window without a
-/// context will generate Error.NoWindowContext.
+/// context will generate glfw.ErrorCode.NoWindowContext.
 ///
 /// This function does not apply to Vulkan. If you are rendering with Vulkan, see `vkQueuePresentKHR`
 /// instead.
 ///
 /// @param[in] window The window whose buffers to swap.
 ///
-/// Possible errors include glfw.Error.NoWindowContext and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.NoWindowContext and glfw.ErrorCode.PlatformError.
 ///
 /// __EGL:__ The context of the specified window must be current on the calling thread.
 ///
@@ -1027,7 +1026,7 @@ pub inline fn getMonitor(self: Window) ?Monitor {
 /// @param[in] height The desired height, in screen coordinates, of the content area or video mode.
 /// @param[in] refreshRate The desired refresh rate, in Hz, of the video mode, or `glfw.dont_care`.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// The OpenGL or OpenGL ES context will not be destroyed or otherwise affected by any resizing or
 /// mode switching, although you may need to update your viewport if the framebuffer size has
@@ -1094,7 +1093,7 @@ pub const Attrib = enum(c_int) {
 /// @param[in] attrib The window attribute (see window_attribs) whose value to return.
 /// @return The value of the attribute, or zero if an error occurred.
 ///
-/// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum and glfw.ErrorCode.PlatformError.
 /// Additionally returns a zero value in the event of an error.
 ///
 /// Framebuffer related hints are not window attributes. See window_attribs_fb for more information.
@@ -1126,7 +1125,8 @@ pub inline fn getAttrib(self: Window, attrib: Attrib) i32 {
 ///
 /// @param[in] attrib A supported window attribute.
 ///
-/// Possible errors include glfw.Error.InvalidEnum, glfw.Error.InvalidValue and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.InvalidEnum, glfw.ErrorCode.InvalidValue and
+/// glfw.ErrorCode.PlatformError.
 ///
 /// Calling glfw.Window.getAttrib will always return the latest
 /// value, even if that value is ignored by the current mode of the window.
@@ -1584,8 +1584,8 @@ pub inline fn getInputModeLockKeyMods(self: Window) bool {
 /// mouse motion events will be sent, otherwise standard mouse motion events respecting the user's
 /// OS settings will be sent.
 ///
-/// If raw motion is not supported, attempting to set this will emit glfw.Error.FeatureUnavailable. Call
-/// glfw.rawMouseMotionSupported to check for support.
+/// If raw motion is not supported, attempting to set this will emit glfw.ErrorCode.FeatureUnavailable.
+/// Call glfw.rawMouseMotionSupported to check for support.
 pub inline fn setInputModeRawMouseMotion(self: Window, enabled: bool) void {
     return self.setInputMode(InputMode.raw_mouse_motion, enabled);
 }
@@ -1702,7 +1702,7 @@ pub inline fn getKey(self: Window, key: Key) Action {
 /// @param[in] button The desired mouse button.
 /// @return One of `true` (if pressed) or `false` (if released)
 ///
-/// Possible errors include glfw.Error.InvalidEnum.
+/// Possible errors include glfw.ErrorCode.InvalidEnum.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -1738,7 +1738,7 @@ pub const CursorPos = struct {
 /// @param[out] ypos Where to store the cursor y-coordinate, relative to the to top edge of the
 /// content area, or null.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 /// Additionally returns a zero value in the event of an error.
 ///
 /// @thread_safety This function must only be called from the main thread.
@@ -1768,7 +1768,7 @@ pub inline fn getCursorPos(self: Window) CursorPos {
 /// @param[in] xpos The desired x-coordinate, relative to the left edge of the content area.
 /// @param[in] ypos The desired y-coordinate, relative to the top edge of the content area.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// wayland: This function will only work when the cursor mode is `glfw.cursor_disabled`, otherwise
 /// it will do nothing.
@@ -1791,7 +1791,7 @@ pub inline fn setCursorPos(self: Window, xpos: f64, ypos: f64) void {
 ///
 /// @param[in] cursor The cursor to set, or null to switch back to the default arrow cursor.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// @thread_safety This function must only be called from the main thread.
 ///
@@ -2106,7 +2106,7 @@ pub inline fn setDropCallback(self: Window, comptime callback: ?fn (window: Wind
 /// Some hints are platform specific. These may be set on any platform but they will only affect
 /// their specific platform. Other platforms will ignore them.
 ///
-/// Possible errors include glfw.Error.InvalidEnum.
+/// Possible errors include glfw.ErrorCode.InvalidEnum.
 ///
 /// @pointer_lifetime in the event that value is of a str type, the specified string is copied before this function returns.
 ///
@@ -2156,7 +2156,7 @@ inline fn hint(h: Hint, value: anytype) void {
 }
 
 test "defaultHints" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2167,7 +2167,7 @@ test "defaultHints" {
 }
 
 test "hint comptime int" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2179,7 +2179,7 @@ test "hint comptime int" {
 }
 
 test "hint int" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2193,7 +2193,7 @@ test "hint int" {
 }
 
 test "hint bool" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2205,7 +2205,7 @@ test "hint bool" {
 }
 
 test "hint enum(u1)" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2222,7 +2222,7 @@ test "hint enum(u1)" {
 }
 
 test "hint enum(i32)" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2239,7 +2239,7 @@ test "hint enum(i32)" {
 }
 
 test "hint array str" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2253,7 +2253,7 @@ test "hint array str" {
 }
 
 test "hint pointer str" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2264,7 +2264,7 @@ test "hint pointer str" {
 }
 
 test "createWindow" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2272,14 +2272,14 @@ test "createWindow" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 }
 
 test "setShouldClose" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2287,15 +2287,15 @@ test "setShouldClose" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     window.setShouldClose(true);
     defer window.destroy();
 }
 
 test "setTitle" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2303,8 +2303,8 @@ test "setTitle" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2313,7 +2313,7 @@ test "setTitle" {
 
 test "setIcon" {
     const allocator = testing.allocator;
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2321,8 +2321,8 @@ test "setIcon" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2346,7 +2346,7 @@ test "setIcon" {
 }
 
 test "getPos" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2354,8 +2354,8 @@ test "getPos" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2363,7 +2363,7 @@ test "getPos" {
 }
 
 test "setPos" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2371,8 +2371,8 @@ test "setPos" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2380,7 +2380,7 @@ test "setPos" {
 }
 
 test "getSize" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2388,8 +2388,8 @@ test "getSize" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2397,7 +2397,7 @@ test "getSize" {
 }
 
 test "setSize" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2405,8 +2405,8 @@ test "setSize" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2414,7 +2414,7 @@ test "setSize" {
 }
 
 test "setSizeLimits" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2422,8 +2422,8 @@ test "setSizeLimits" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2434,7 +2434,7 @@ test "setSizeLimits" {
 }
 
 test "setAspectRatio" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2442,8 +2442,8 @@ test "setAspectRatio" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2451,7 +2451,7 @@ test "setAspectRatio" {
 }
 
 test "getFramebufferSize" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2459,8 +2459,8 @@ test "getFramebufferSize" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2468,7 +2468,7 @@ test "getFramebufferSize" {
 }
 
 test "getFrameSize" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2476,8 +2476,8 @@ test "getFrameSize" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2485,7 +2485,7 @@ test "getFrameSize" {
 }
 
 test "getContentScale" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2493,8 +2493,8 @@ test "getContentScale" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2502,7 +2502,7 @@ test "getContentScale" {
 }
 
 test "getOpacity" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2510,8 +2510,8 @@ test "getOpacity" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2519,7 +2519,7 @@ test "getOpacity" {
 }
 
 test "iconify" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2527,8 +2527,8 @@ test "iconify" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2536,7 +2536,7 @@ test "iconify" {
 }
 
 test "restore" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2544,8 +2544,8 @@ test "restore" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2553,7 +2553,7 @@ test "restore" {
 }
 
 test "maximize" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2561,8 +2561,8 @@ test "maximize" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2570,7 +2570,7 @@ test "maximize" {
 }
 
 test "show" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2578,8 +2578,8 @@ test "show" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2587,7 +2587,7 @@ test "show" {
 }
 
 test "hide" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2595,8 +2595,8 @@ test "hide" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2604,7 +2604,7 @@ test "hide" {
 }
 
 test "focus" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2612,8 +2612,8 @@ test "focus" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2621,7 +2621,7 @@ test "focus" {
 }
 
 test "requestAttention" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2629,8 +2629,8 @@ test "requestAttention" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2638,7 +2638,7 @@ test "requestAttention" {
 }
 
 test "swapBuffers" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2646,8 +2646,8 @@ test "swapBuffers" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2655,7 +2655,7 @@ test "swapBuffers" {
 }
 
 test "getMonitor" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2663,8 +2663,8 @@ test "getMonitor" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2672,7 +2672,7 @@ test "getMonitor" {
 }
 
 test "setMonitor" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2680,8 +2680,8 @@ test "setMonitor" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2689,7 +2689,7 @@ test "setMonitor" {
 }
 
 test "getAttrib" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2697,8 +2697,8 @@ test "getAttrib" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2706,7 +2706,7 @@ test "getAttrib" {
 }
 
 test "setAttrib" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2714,8 +2714,8 @@ test "setAttrib" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2723,7 +2723,7 @@ test "setAttrib" {
 }
 
 test "setUserPointer" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2731,8 +2731,8 @@ test "setUserPointer" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2743,7 +2743,7 @@ test "setUserPointer" {
 }
 
 test "getUserPointer" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2751,8 +2751,8 @@ test "getUserPointer" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2765,7 +2765,7 @@ test "getUserPointer" {
 }
 
 test "setPosCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2773,8 +2773,8 @@ test "setPosCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2788,7 +2788,7 @@ test "setPosCallback" {
 }
 
 test "setSizeCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2796,8 +2796,8 @@ test "setSizeCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2811,7 +2811,7 @@ test "setSizeCallback" {
 }
 
 test "setCloseCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2819,8 +2819,8 @@ test "setCloseCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2832,7 +2832,7 @@ test "setCloseCallback" {
 }
 
 test "setRefreshCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2840,8 +2840,8 @@ test "setRefreshCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2853,7 +2853,7 @@ test "setRefreshCallback" {
 }
 
 test "setFocusCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2861,8 +2861,8 @@ test "setFocusCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2875,7 +2875,7 @@ test "setFocusCallback" {
 }
 
 test "setIconifyCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2883,8 +2883,8 @@ test "setIconifyCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2897,7 +2897,7 @@ test "setIconifyCallback" {
 }
 
 test "setMaximizeCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2905,8 +2905,8 @@ test "setMaximizeCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2919,7 +2919,7 @@ test "setMaximizeCallback" {
 }
 
 test "setFramebufferSizeCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2927,8 +2927,8 @@ test "setFramebufferSizeCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2942,7 +2942,7 @@ test "setFramebufferSizeCallback" {
 }
 
 test "setContentScaleCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2950,8 +2950,8 @@ test "setContentScaleCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2965,7 +2965,7 @@ test "setContentScaleCallback" {
 }
 
 test "setDropCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2973,8 +2973,8 @@ test "setDropCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -2987,7 +2987,7 @@ test "setDropCallback" {
 }
 
 test "getInputModeCursor" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -2995,8 +2995,8 @@ test "getInputModeCursor" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3004,7 +3004,7 @@ test "getInputModeCursor" {
 }
 
 test "setInputModeCursor" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3012,8 +3012,8 @@ test "setInputModeCursor" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3021,7 +3021,7 @@ test "setInputModeCursor" {
 }
 
 test "getInputModeStickyKeys" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3029,8 +3029,8 @@ test "getInputModeStickyKeys" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3038,7 +3038,7 @@ test "getInputModeStickyKeys" {
 }
 
 test "setInputModeStickyKeys" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3046,8 +3046,8 @@ test "setInputModeStickyKeys" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3055,7 +3055,7 @@ test "setInputModeStickyKeys" {
 }
 
 test "getInputModeStickyMouseButtons" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3063,8 +3063,8 @@ test "getInputModeStickyMouseButtons" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3072,7 +3072,7 @@ test "getInputModeStickyMouseButtons" {
 }
 
 test "setInputModeStickyMouseButtons" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3080,8 +3080,8 @@ test "setInputModeStickyMouseButtons" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3089,7 +3089,7 @@ test "setInputModeStickyMouseButtons" {
 }
 
 test "getInputModeLockKeyMods" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3097,8 +3097,8 @@ test "getInputModeLockKeyMods" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3106,7 +3106,7 @@ test "getInputModeLockKeyMods" {
 }
 
 test "setInputModeLockKeyMods" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3114,8 +3114,8 @@ test "setInputModeLockKeyMods" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3123,7 +3123,7 @@ test "setInputModeLockKeyMods" {
 }
 
 test "getInputModeRawMouseMotion" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3131,8 +3131,8 @@ test "getInputModeRawMouseMotion" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3140,7 +3140,7 @@ test "getInputModeRawMouseMotion" {
 }
 
 test "setInputModeRawMouseMotion" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3148,8 +3148,8 @@ test "setInputModeRawMouseMotion" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3157,7 +3157,7 @@ test "setInputModeRawMouseMotion" {
 }
 
 test "getInputMode" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3165,8 +3165,8 @@ test "getInputMode" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3174,7 +3174,7 @@ test "getInputMode" {
 }
 
 test "setInputMode" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3182,8 +3182,8 @@ test "setInputMode" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3195,7 +3195,7 @@ test "setInputMode" {
 }
 
 test "getKey" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3203,8 +3203,8 @@ test "getKey" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3212,7 +3212,7 @@ test "getKey" {
 }
 
 test "getMouseButton" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3220,8 +3220,8 @@ test "getMouseButton" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3229,7 +3229,7 @@ test "getMouseButton" {
 }
 
 test "getCursorPos" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3237,8 +3237,8 @@ test "getCursorPos" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3246,7 +3246,7 @@ test "getCursorPos" {
 }
 
 test "setCursorPos" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3254,8 +3254,8 @@ test "setCursorPos" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3263,7 +3263,7 @@ test "setCursorPos" {
 }
 
 test "setCursor" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3271,8 +3271,8 @@ test "setCursor" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3284,7 +3284,7 @@ test "setCursor" {
 }
 
 test "setKeyCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3292,8 +3292,8 @@ test "setKeyCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3309,7 +3309,7 @@ test "setKeyCallback" {
 }
 
 test "setCharCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3317,8 +3317,8 @@ test "setCharCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3331,7 +3331,7 @@ test "setCharCallback" {
 }
 
 test "setMouseButtonCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3339,8 +3339,8 @@ test "setMouseButtonCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3355,7 +3355,7 @@ test "setMouseButtonCallback" {
 }
 
 test "setCursorPosCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3363,8 +3363,8 @@ test "setCursorPosCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3378,7 +3378,7 @@ test "setCursorPosCallback" {
 }
 
 test "setCursorEnterCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3386,8 +3386,8 @@ test "setCursorEnterCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3400,7 +3400,7 @@ test "setCursorEnterCallback" {
 }
 
 test "setScrollCallback" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3408,8 +3408,8 @@ test "setScrollCallback" {
     defer glfw.terminate();
 
     const window = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window.destroy();
 
@@ -3423,7 +3423,7 @@ test "setScrollCallback" {
 }
 
 test "hint-attribute default value parity" {
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -3432,15 +3432,15 @@ test "hint-attribute default value parity" {
 
     testing_ignore_window_hints_struct = true;
     const window_a = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window_a: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window_a: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window_a.destroy();
 
     testing_ignore_window_hints_struct = false;
     const window_b = Window.create(640, 480, "GLFW example", null, null, .{}) orelse {
-        std.log.err("failed to create window_b: {?s}", .{glfw.getErrorString()});
-        std.process.exit(0); // note: we don't exit(1) here because our CI can't open windows
+        std.log.warn("failed to create window_b: {?s}", .{glfw.getErrorString()});
+        return error.SkipZigTest; // note: we don't exit(1) here because our CI can't open windows
     };
     defer window_b.destroy();
 

--- a/libs/glfw/src/clipboard.zig
+++ b/libs/glfw/src/clipboard.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
 const c = @import("c.zig").c;
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 
 const internal_debug = @import("internal_debug.zig");
 
@@ -12,7 +10,7 @@ const internal_debug = @import("internal_debug.zig");
 ///
 /// @param[in] string A UTF-8 encoded string.
 ///
-/// Possible errors include glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.PlatformError.
 ///
 /// @pointer_lifetime The specified string is copied before this function returns.
 ///
@@ -28,11 +26,11 @@ pub inline fn setClipboardString(value: [*:0]const u8) void {
 ///
 /// This function returns the contents of the system clipboard, if it contains or is convertible to
 /// a UTF-8 encoded string. If the clipboard is empty or if its contents cannot be converted,
-/// glfw.Error.FormatUnavailable is returned.
+/// glfw.ErrorCode.FormatUnavailable is returned.
 ///
 /// @return The contents of the clipboard as a UTF-8 encoded string.
 ///
-/// Possible errors include glfw.Error.FormatUnavailable and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.FormatUnavailable and glfw.ErrorCode.PlatformError.
 /// null is returned in the event of an error.
 ///
 /// @pointer_lifetime The returned string is allocated and freed by GLFW. You should not free it
@@ -50,7 +48,7 @@ pub inline fn getClipboardString() ?[:0]const u8 {
 
 test "setClipboardString" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -62,7 +60,7 @@ test "setClipboardString" {
 
 test "getClipboardString" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);

--- a/libs/glfw/src/key.zig
+++ b/libs/glfw/src/key.zig
@@ -17,8 +17,6 @@
 const std = @import("std");
 
 const cc = @import("c.zig").c;
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 
 const internal_debug = @import("internal_debug.zig");
 
@@ -204,7 +202,7 @@ pub const Key = enum(c_int) {
     /// @param[in] scancode The scancode of the key to query.
     /// @return The UTF-8 encoded, layout-specific name of the key, or null.
     ///
-    /// Possible errors include glfw.Error.PlatformError.
+    /// Possible errors include glfw.ErrorCode.PlatformError.
     /// Also returns null in the event of an error.
     ///
     /// The contents of the returned string may change when a keyboard layout change event is received.
@@ -233,7 +231,7 @@ pub const Key = enum(c_int) {
     /// @param[in] key Any named key (see keys).
     /// @return The platform-specific scancode for the key.
     ///
-    /// Possible errors include glfw.Error.InvalidEnum and glfw.Error.PlatformError.
+    /// Possible errors include glfw.ErrorCode.InvalidEnum and glfw.ErrorCode.PlatformError.
     /// Additionally returns -1 in the event of an error.
     ///
     /// @thread_safety This function may be called from any thread.
@@ -245,7 +243,7 @@ pub const Key = enum(c_int) {
 
 test "getName" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -257,7 +255,7 @@ test "getName" {
 
 test "getScancode" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);

--- a/libs/glfw/src/native.zig
+++ b/libs/glfw/src/native.zig
@@ -3,8 +3,6 @@ const std = @import("std");
 
 const Window = @import("Window.zig");
 const Monitor = @import("Monitor.zig");
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 
 const internal_debug = @import("internal_debug.zig");
 
@@ -114,7 +112,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// ```
         /// This DC is private and does not need to be released.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext
+        /// Possible errors include glfw.ErrorCode.NoWindowContext
         /// null is returned in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
@@ -146,7 +144,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Returns the `NSWindow` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.ErrorCode.NoWindowContext.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getNSGLContext(window: Window) u32 {
@@ -203,7 +201,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Sets the current primary selection to the specified string.
         ///
-        /// Possible errors include glfw.Error.PlatformError.
+        /// Possible errors include glfw.ErrorCode.PlatformError.
         ///
         /// The specified string is copied before this function returns.
         ///
@@ -215,7 +213,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Returns the contents of the current primary selection as a string.
         ///
-        /// Possible errors include glfw.Error.PlatformError.
+        /// Possible errors include glfw.ErrorCode.PlatformError.
         /// Returns null in the event of an error.
         ///
         /// The returned string is allocated and freed by GLFW. You should not free it
@@ -231,7 +229,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Returns the `GLXContext` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.ErrorCode.NoWindowContext.
         /// Returns null in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
@@ -243,7 +241,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Returns the `GLXWindow` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.ErrorCode.NoWindowContext.
         /// Returns null in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
@@ -304,7 +302,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Returns the `EGLContext` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.ErrorCode.NoWindowContext.
         /// Returns null in the event of an error.
         ///
         /// thread_safety This function may be called from any thread. Access is not synchronized.
@@ -317,7 +315,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Returns the `EGLSurface` of the specified window.
         ///
-        /// Possible errors include glfw.Error.NotInitalized and glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.ErrorCode.NotInitalized and glfw.ErrorCode.NoWindowContext.
         ///
         /// thread_safety This function may be called from any thread. Access is not synchronized.
         pub fn getEGLSurface(window: Window) ?*anyopaque {
@@ -336,7 +334,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Retrieves the color buffer associated with the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext and glfw.Error.PlatformError.
+        /// Possible errors include glfw.ErrorCode.NoWindowContext and glfw.ErrorCode.PlatformError.
         /// Returns null in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
@@ -362,7 +360,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Retrieves the depth buffer associated with the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext and glfw.Error.PlatformError.
+        /// Possible errors include glfw.ErrorCode.NoWindowContext and glfw.ErrorCode.PlatformError.
         /// Returns null in the event of an error.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
@@ -381,7 +379,7 @@ pub fn Native(comptime options: BackendOptions) type {
 
         /// Returns the 'OSMesaContext' of the specified window.
         ///
-        /// Possible errors include glfw.Error.NoWindowContext.
+        /// Possible errors include glfw.ErrorCode.NoWindowContext.
         ///
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getOSMesaContext(window: Window) ?*anyopaque {

--- a/libs/glfw/src/time.zig
+++ b/libs/glfw/src/time.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
 const c = @import("c.zig").c;
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 
 const internal_debug = @import("internal_debug.zig");
 
@@ -46,7 +44,7 @@ pub inline fn getTime() f64 {
 ///
 /// @param[in] time The new value, in seconds.
 ///
-/// Possible errors include glfw.Error.InvalidValue.
+/// Possible errors include glfw.ErrorCode.InvalidValue.
 ///
 /// The upper limit of GLFW time is calculated as `floor((2^64 - 1) / 10^9)` and is due to
 /// implementations storing nanoseconds in 64 bits. The limit may be increased in the future.
@@ -108,7 +106,7 @@ pub inline fn getTimerFrequency() u64 {
 
 test "getTime" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -120,7 +118,7 @@ test "getTime" {
 
 test "setTime" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -132,7 +130,7 @@ test "setTime" {
 
 test "getTimerValue" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -144,7 +142,7 @@ test "getTimerValue" {
 
 test "getTimerFrequency" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);

--- a/libs/glfw/src/vulkan.zig
+++ b/libs/glfw/src/vulkan.zig
@@ -1,8 +1,6 @@
 const std = @import("std");
 
 const c = @import("c.zig").c;
-const Error = @import("errors.zig").Error;
-const getError = @import("errors.zig").getError;
 const Window = @import("Window.zig");
 
 const internal_debug = @import("internal_debug.zig");
@@ -64,13 +62,13 @@ pub inline fn vulkanSupported() bool {
 /// directly to the `VkInstanceCreateInfo` struct.
 ///
 /// If Vulkan is not available on the machine, this function returns null and generates a
-/// glfw.Error.APIUnavailable error. Call glfw.vulkanSupported to check whether Vulkan is at least
-/// minimally available.
+/// glfw.ErrorCode.APIUnavailable error. Call glfw.vulkanSupported to check whether Vulkan is at
+/// least minimally available.
 ///
 /// If Vulkan is available but no set of extensions allowing window surface creation was found,
 /// this function returns null. You may still use Vulkan for off-screen rendering and compute work.
 ///
-/// Possible errors include glfw.Error.APIUnavailable.
+/// Possible errors include glfw.ErrorCode.APIUnavailable.
 /// Returns null in the event of an error.
 ///
 /// Additional extensions may be required by future versions of GLFW. You should check if any
@@ -109,8 +107,8 @@ pub const VKProc = *const fn () callconv(.C) void;
 /// - `vkGetInstanceProcAddr`
 ///
 /// If Vulkan is not available on the machine, this function returns null and generates a
-/// glfw.Error.APIUnavailable error. Call glfw.vulkanSupported to check whether Vulkan is at least
-/// minimally available.
+/// glfw.ErrorCode.APIUnavailable error. Call glfw.vulkanSupported to check whether Vulkan is at
+/// least minimally available.
 ///
 /// This function is equivalent to calling `vkGetInstanceProcAddr` with a platform-specific query
 /// of the Vulkan loader as a fallback.
@@ -122,7 +120,7 @@ pub const VKProc = *const fn () callconv(.C) void;
 ///
 /// To maintain ABI compatability with the C glfwGetInstanceProcAddress, as it is commonly passed
 /// into libraries expecting that exact ABI, this function does not return an error. Instead, if
-/// glfw.Error.NotInitialized or glfw.Error.APIUnavailable would occur this function will panic.
+/// glfw.ErrorCode.NotInitialized or glfw.ErrorCode.APIUnavailable would occur this function will panic.
 /// You may check glfw.vulkanSupported prior to invoking this function.
 ///
 /// @pointer_lifetime The returned function pointer is valid until the library is terminated.
@@ -141,7 +139,7 @@ pub fn getInstanceProcAddress(vk_instance: ?*anyopaque, proc_name: [*:0]const u8
 ///
 /// If Vulkan or the required window surface creation instance extensions are not available on the
 /// machine, or if the specified instance was not created with the required extensions, this
-/// function returns `GLFW_FALSE` and generates a glfw.Error.APIUnavailable error. Call
+/// function returns `GLFW_FALSE` and generates a glfw.ErrorCode.APIUnavailable error. Call
 /// glfw.vulkanSupported to check whether Vulkan is at least minimally available and
 /// glfw.getRequiredInstanceExtensions to check what instance extensions are required.
 ///
@@ -150,7 +148,7 @@ pub fn getInstanceProcAddress(vk_instance: ?*anyopaque, proc_name: [*:0]const u8
 /// @param[in] queuefamily The index of the queue family to query.
 /// @return `true` if the queue family supports presentation, or `false` otherwise.
 ///
-/// Possible errors include glfw.Error.APIUnavailable and glfw.Error.PlatformError.
+/// Possible errors include glfw.ErrorCode.APIUnavailable and glfw.ErrorCode.PlatformError.
 /// Returns false in the event of an error.
 ///
 /// macos: This function currently always returns `true`, as the `VK_MVK_macos_surface` and
@@ -178,16 +176,16 @@ pub inline fn getPhysicalDevicePresentationSupport(
 /// This function creates a Vulkan surface for the specified window.
 ///
 /// If the Vulkan loader or at least one minimally functional ICD were not found, this function
-/// returns `VK_ERROR_INITIALIZATION_FAILED` and generates a glfw.Error.APIUnavailable error. Call
+/// returns `VK_ERROR_INITIALIZATION_FAILED` and generates a glfw.ErrorCode.APIUnavailable error. Call
 /// glfw.vulkanSupported to check whether Vulkan is at least minimally available.
 ///
 /// If the required window surface creation instance extensions are not available or if the
 /// specified instance was not created with these extensions enabled, this function returns `VK_ERROR_EXTENSION_NOT_PRESENT`
-/// and generates a glfw.Error.APIUnavailable error. Call glfw.getRequiredInstanceExtensions to
+/// and generates a glfw.ErrorCode.APIUnavailable error. Call glfw.getRequiredInstanceExtensions to
 /// check what instance extensions are required.
 ///
 /// The window surface cannot be shared with another API so the window must have been created with
-/// the client api hint set to `GLFW_NO_API` otherwise it generates a glfw.Error.InvalidValue error
+/// the client api hint set to `GLFW_NO_API` otherwise it generates a glfw.ErrorCode.InvalidValue error
 /// and returns `VK_ERROR_NATIVE_WINDOW_IN_USE_KHR`.
 ///
 /// The window surface must be destroyed before the specified Vulkan instance. It is the
@@ -203,7 +201,7 @@ pub inline fn getPhysicalDevicePresentationSupport(
 /// @return `VkResult` type, `VK_SUCCESS` if successful, or a Vulkan error code if an
 /// error occurred.
 ///
-/// Possible errors include glfw.Error.APIUnavailable, glfw.Error.PlatformError and glfw.Error.InvalidValue
+/// Possible errors include glfw.ErrorCode.APIUnavailable, glfw.ErrorCode.PlatformError and glfw.ErrorCode.InvalidValue
 /// Returns a bool indicating success.
 ///
 /// If an error occurs before the creation call is made, GLFW returns the Vulkan error code most
@@ -247,7 +245,7 @@ pub inline fn createWindowSurface(vk_instance: anytype, window: Window, vk_alloc
 
 test "vulkanSupported" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -259,7 +257,7 @@ test "vulkanSupported" {
 
 test "getRequiredInstanceExtensions" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);
@@ -271,7 +269,7 @@ test "getRequiredInstanceExtensions" {
 
 test "getInstanceProcAddress" {
     const glfw = @import("main.zig");
-    defer glfw.getError() catch {}; // clear any error we generate
+    defer glfw.clearError(); // clear any error we generate
     if (!glfw.init(.{})) {
         std.log.err("failed to initialize GLFW: {?s}", .{glfw.getErrorString()});
         std.process.exit(1);

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -54,8 +54,9 @@ pub const Platform = struct {
         const options = core.options;
         const backend_type = try util.detectBackendType(allocator);
 
+        defer glfw.clearError();
         glfw.setErrorCallback(Platform.errorCallback);
-        if (!glfw.init(.{})) try glfw.getError();
+        if (!glfw.init(.{})) try glfw.getErrorCode();
 
         // Create the test window and discover adapters using it (esp. for OpenGL)
         var hints = util.glfwWindowHintsForBackend(backend_type);
@@ -67,13 +68,13 @@ pub const Platform = struct {
             null,
             null,
             hints,
-        ) orelse return glfw.mustGetError();
+        ) orelse return glfw.mustGetErrorCode();
 
         if (backend_type == .opengl) glfw.makeContextCurrent(window);
         if (backend_type == .opengles) glfw.makeContextCurrent(window);
         const window_size = window.getSize();
         const framebuffer_size = window.getFramebufferSize();
-        try glfw.getError();
+        try glfw.getErrorCode();
 
         const instance = gpu.createInstance(null);
         if (instance == null) {
@@ -144,7 +145,7 @@ pub const Platform = struct {
         core.target_desc = descriptor;
         core.swap_chain = null;
         const cursor_pos = window.getCursorPos();
-        try glfw.getError();
+        try glfw.getErrorCode();
 
         return Platform{
             .window = window,
@@ -324,7 +325,7 @@ pub const Platform = struct {
 
         if (options.borderless_window) {
             glfw.Window.setAttrib(platform.window, .decorated, false);
-            try glfw.getError();
+            try glfw.getErrorCode();
         }
 
         if (options.fullscreen) {
@@ -650,7 +651,7 @@ pub fn coreUpdate(core: *Core, resize: ?CoreResizeCallback) !void {
         // Don't wait for events
         glfw.pollEvents();
     }
-    try glfw.getError();
+    try glfw.getErrorCode();
 
     core.delta_time_ns = core.timer.lapPrecise();
     core.delta_time = @intToFloat(f32, core.delta_time_ns) / @intToFloat(f32, std.time.ns_per_s);

--- a/src/platform/native.zig
+++ b/src/platform/native.zig
@@ -575,7 +575,7 @@ pub const Platform = struct {
     }
 
     /// Default GLFW error handling callback
-    fn errorCallback(error_code: glfw.Error, description: [:0]const u8) void {
+    fn errorCallback(error_code: glfw.ErrorCode, description: [:0]const u8) void {
         std.log.err("glfw: {}: {s}\n", .{ error_code, description });
     }
 };


### PR DESCRIPTION
`getError()` now returns a struct `Error` containing `error_code` and `description`. Rationale: retrieving the error code with the previous implementation of `getError()` caused `getErrorString()` to return null (the reverse is also true), so it was difficult to obtain both values at the same time. The new implementation allows both values to be retrieved at once.

The previous `getError()` function has been renamed to `getErrorCode()` to reflect the fact that it returns a simple Zig error rather than the `Error` struct. The error set returned by `getErrorCode()` is now named `ErrorCode` rather than `Error`.

The behavior of the `getError()` family of functions clearing the stored error is unchanged. However, since all code that used `defer glfw.getError() catch {}` to explicitly clear errors had to be refactored, a new `glfw.clearError()` function that returns void is now available to make this operation more explicit.

Additionally, `mustGetError()` is now `mustGetErrorCode()`, and new functions `mustGetError()` and `mustGetErrorString()` have been added which wrap `getError()` and `getErrorString()` but panic if no error is actually available.

Tests and API documentation had to be refactored across all of `mach/glfw`. This commit also takes the opportunity to skip tests involving window creation on CI so that other tests may still execute normally.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.