### PR TITLE
gpu: add glfw dependency to example and fix issue

### DIFF
--- a/libs/gpu/build.zig
+++ b/libs/gpu/build.zig
@@ -29,6 +29,7 @@ pub fn build(b: *std.build.Builder) !void {
     example.addPackage(gpu.pkg);
     example.addPackage(glfw.pkg);
     try gpu.link(b, example, .{ .gpu_dawn_options = gpu_dawn_options });
+    try glfw.link(b, example, .{});
     example.install();
 
     const example_run_cmd = example.run();

--- a/libs/gpu/examples/sample_utils.zig
+++ b/libs/gpu/examples/sample_utils.zig
@@ -109,7 +109,7 @@ pub fn setup(allocator: std.mem.Allocator) !Setup {
     }
 
     // Print which adapter we are using.
-    var props: gpu.Adapter.Properties = undefined;
+    var props = std.mem.zeroes(gpu.Adapter.Properties);
     response.?.adapter.getProperties(&props);
     std.debug.print("found {s} backend on {s} adapter: {s}, {s}\n", .{
         props.backend_type.name(),


### PR DESCRIPTION
I noticed the triangle example in `libs/gpu` stopped working (ran with `zig build run-example`).

It looks like https://github.com/hexops/mach/commit/a52c6e5f5c92ae0f83f919dd6fd088db0dce34db accidentally removed glfw from `libs/gpu/build.zig` and `libs/gpu/sdk.zig`. I could be missing something, but re-adding the dependency got the `libs/gpu` example building again.

One other issue was the change to Dawn that requires the next chain to be null needed handled. I blindly copied the change discussed here:  https://github.com/hexops/mach/pull/672#pullrequestreview-1248810820

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.