### PR TITLE
mach: eliminate heap allocation of Core

### DIFF
--- a/shaderexp/main.zig
+++ b/shaderexp/main.zig
@@ -25,7 +25,7 @@ fragment_shader_code: [:0]const u8,
 last_mtime: i128,
 
 pub fn init(app: *App) !void {
-    app.core = try mach.Core.init(allocator, .{ .title = "shaderexp" });
+    try app.core.init(allocator, .{ .title = "shaderexp" });
 
     var fragment_file: std.fs.File = undefined;
     var last_mtime: i128 = undefined;

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -5,7 +5,7 @@ const platform = @import("platform.zig");
 
 pub const Core = @This();
 
-internal: *platform.Core,
+internal: platform.Core,
 
 pub const Options = struct {
     is_app: bool = false,
@@ -16,10 +16,8 @@ pub const Options = struct {
     required_limits: ?gpu.Limits = null,
 };
 
-pub fn init(allocator: std.mem.Allocator, options: Options) !Core {
-    return .{
-        .internal = try platform.Core.init(allocator, options),
-    };
+pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
+    try platform.Core.init(&core.internal, allocator, options);
 }
 
 pub fn deinit(core: *Core) void {

--- a/src/engine.zig
+++ b/src/engine.zig
@@ -25,15 +25,16 @@ pub fn App(
 
     return struct {
         engine: ecs.World(modules),
+        core: Core,
 
         pub fn init(app: *@This()) !void {
+            try app.core.init(allocator, .{});
             app.* = .{
+                .core = app.core,
                 .engine = try ecs.World(modules).init(allocator),
             };
-            var core = try allocator.create(Core);
-            core.* = try Core.init(allocator, .{});
-            app.engine.set(.mach, .core, core);
-            app.engine.set(.mach, .device, core.device());
+            app.engine.set(.mach, .core, &app.core);
+            app.engine.set(.mach, .device, app.core.device());
             try app_init(&app.engine);
         }
 

--- a/src/platform/libmach.zig
+++ b/src/platform/libmach.zig
@@ -24,7 +24,13 @@ const allocator = gpa.allocator();
 // Will return a null pointer if an error occurred while initializing Core
 pub export fn mach_core_init() ?*native.Core {
     gpu.Impl.init();
-    const core = native.Core.init(allocator, .{}) catch {
+    // TODO(libmach): eliminate this allocation
+    var core = allocator.create(native.Core) catch {
+        return @intToPtr(?*native.Core, 0);
+    };
+    // TODO(libmach): allow passing init options
+    core.init(allocator, .{}) catch {
+        // TODO(libmach): better error handling
         return @intToPtr(?*native.Core, 0);
     };
     return core;

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -52,7 +52,7 @@ const UserPtr = struct {
     self: *Core,
 };
 
-pub fn init(allocator: std.mem.Allocator, options: Options) !*Core {
+pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     const backend_type = try util.detectBackendType(allocator);
 
     glfw.setErrorCallback(errorCallback);
@@ -153,9 +153,7 @@ pub fn init(allocator: std.mem.Allocator, options: Options) !*Core {
     };
     const swap_chain = gpu_device.createSwapChain(surface, &swap_chain_desc);
 
-    const self: *Core = try allocator.create(Core);
-    errdefer allocator.destroy(self);
-    self.* = .{
+    core.* = .{
         .allocator = allocator,
         .window = window,
         .backend_type = backend_type,
@@ -186,14 +184,12 @@ pub fn init(allocator: std.mem.Allocator, options: Options) !*Core {
         .linux_gamemode = null,
     };
 
-    self.setSizeLimit(self.size_limit);
+    core.setSizeLimit(core.size_limit);
 
-    self.initCallbacks();
+    core.initCallbacks();
     if (builtin.os.tag == .linux and !options.is_app and
-        self.linux_gamemode == null and try activateGamemode(self.allocator))
-        self.linux_gamemode = initLinuxGamemode();
-
-    return self;
+        core.linux_gamemode == null and try activateGamemode(core.allocator))
+        core.linux_gamemode = initLinuxGamemode();
 }
 
 fn initCallbacks(self: *Core) void {
@@ -316,8 +312,6 @@ pub fn deinit(self: *Core) void {
         self.linux_gamemode != null and
         self.linux_gamemode.?)
         deinitLinuxGamemode();
-
-    self.allocator.destroy(self);
 }
 
 pub fn hasEvent(self: *Core) bool {

--- a/src/platform/wasm/Core.zig
+++ b/src/platform/wasm/Core.zig
@@ -25,7 +25,7 @@ id: js.CanvasId,
 last_cursor_position: Position,
 last_key_mods: KeyMods,
 
-pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !*Core {
+pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     _ = options;
     var selector = [1]u8{0} ** 15;
     const id = js.machCanvasInit(&selector[0]);

--- a/src/platform/wasm/Core.zig
+++ b/src/platform/wasm/Core.zig
@@ -25,14 +25,12 @@ id: js.CanvasId,
 last_cursor_position: Position,
 last_key_mods: KeyMods,
 
-pub fn init(allocator: std.mem.Allocator, options: Options) !*Core {
+pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !*Core {
     _ = options;
     var selector = [1]u8{0} ** 15;
     const id = js.machCanvasInit(&selector[0]);
 
-    const self: *Core = try allocator.create(Core);
-    errdefer allocator.destroy(self);
-    self.* = Core{
+    core.* = Core{
         .allocator = allocator,
         .id = id,
 
@@ -50,8 +48,6 @@ pub fn init(allocator: std.mem.Allocator, options: Options) !*Core {
             .num_lock = false,
         },
     };
-
-    return self;
 }
 
 pub fn deinit(self: *Core) void {


### PR DESCRIPTION
Prior to this change `mach.Core.init` would heap allocate the structure, returning `*Core`:

```zig
app.core = try mach.Core.init(allocator, .{});
```

This was obviously not ideal, but wasn't possible to eliminate before due to how Core was entangled with the platform abstraction. Now that it has been removed, we can reduce Core initialization to take a `*Core` to initialize. In practice this means initialization looks something like this:

```zig
try mach.Core.init(&app.core, alloctor, .{});
```

Or more simply:

```zig
try app.core.init(allocator, .{});
```

And we eliminate the `*Core` allocation entirely in most cases.

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.