### PR TITLE
core: make Core.pollEvents return an iterator; remove Core.hasEvent

### DIFF
--- a/libs/core/src/Core.zig
+++ b/libs/core/src/Core.zig
@@ -24,12 +24,16 @@ pub fn deinit(core: *Core) void {
     return core.internal.deinit();
 }
 
-pub fn hasEvent(core: *Core) bool {
-    return core.internal.hasEvent();
-}
+pub const EventIterator = struct {
+    internal: platform.Core.EventIterator,
 
-pub fn pollEvents(core: *Core) ?Event {
-    return core.internal.pollEvents();
+    pub inline fn next(self: *EventIterator) ?Event {
+        return self.internal.next();
+    }
+};
+
+pub inline fn pollEvents(core: *Core) EventIterator {
+    return .{ .internal = core.internal.pollEvents() };
 }
 
 /// Returns the framebuffer size, in subpixel units.

--- a/libs/core/src/platform.zig
+++ b/libs/core/src/platform.zig
@@ -14,7 +14,6 @@ comptime {
     // Core
     assertHasDecl(@This().Core, "init");
     assertHasDecl(@This().Core, "deinit");
-    assertHasDecl(@This().Core, "hasEvent");
     assertHasDecl(@This().Core, "pollEvents");
     assertHasDecl(@This().Core, "framebufferSize");
 

--- a/libs/core/src/platform/wasm/Core.zig
+++ b/libs/core/src/platform/wasm/Core.zig
@@ -25,6 +25,114 @@ id: js.CanvasId,
 last_cursor_position: Position,
 last_key_mods: KeyMods,
 
+pub const EventIterator = struct {
+    core: *Core,
+
+    pub inline fn next(self: *EventIterator) ?Event {
+        const event_int = js.machEventShift();
+        if (event_int == -1) return null;
+
+        const event_type = @intToEnum(std.meta.Tag(Event), event_int);
+        return switch (event_type) {
+            .key_press, .key_repeat => blk: {
+                const key = @intToEnum(Key, js.machEventShift());
+                switch (key) {
+                    .left_shift, .right_shift => self.last_key_mods.shift = true,
+                    .left_control, .right_control => self.last_key_mods.control = true,
+                    .left_alt, .right_alt => self.last_key_mods.alt = true,
+                    .left_super, .right_super => self.last_key_mods.super = true,
+                    .caps_lock => self.last_key_mods.caps_lock = true,
+                    .num_lock => self.last_key_mods.num_lock = true,
+                    else => {},
+                }
+                break :blk switch (event_type) {
+                    .key_press => Event{
+                        .key_press = .{
+                            .key = key,
+                            .mods = self.last_key_mods,
+                        },
+                    },
+                    .key_repeat => Event{
+                        .key_repeat = .{
+                            .key = key,
+                            .mods = self.last_key_mods,
+                        },
+                    },
+                    else => unreachable,
+                };
+            },
+            .key_release => blk: {
+                const key = @intToEnum(Key, js.machEventShift());
+                switch (key) {
+                    .left_shift, .right_shift => self.last_key_mods.shift = false,
+                    .left_control, .right_control => self.last_key_mods.control = false,
+                    .left_alt, .right_alt => self.last_key_mods.alt = false,
+                    .left_super, .right_super => self.last_key_mods.super = false,
+                    .caps_lock => self.last_key_mods.caps_lock = false,
+                    .num_lock => self.last_key_mods.num_lock = false,
+                    else => {},
+                }
+                break :blk Event{
+                    .key_release = .{
+                        .key = key,
+                        .mods = self.last_key_mods,
+                    },
+                };
+            },
+            .mouse_motion => blk: {
+                const x = @intToFloat(f64, js.machEventShift());
+                const y = @intToFloat(f64, js.machEventShift());
+                self.last_cursor_position = .{
+                    .x = x,
+                    .y = y,
+                };
+                break :blk Event{
+                    .mouse_motion = .{
+                        .pos = .{
+                            .x = x,
+                            .y = y,
+                        },
+                    },
+                };
+            },
+            .mouse_press => Event{
+                .mouse_press = .{
+                    .button = toMachButton(js.machEventShift()),
+                    .pos = self.last_cursor_position,
+                    .mods = self.last_key_mods,
+                },
+            },
+            .mouse_release => Event{
+                .mouse_release = .{
+                    .button = toMachButton(js.machEventShift()),
+                    .pos = self.last_cursor_position,
+                    .mods = self.last_key_mods,
+                },
+            },
+            .mouse_scroll => Event{
+                .mouse_scroll = .{
+                    .xoffset = @floatCast(f32, std.math.sign(js.machEventShiftFloat())),
+                    .yoffset = @floatCast(f32, std.math.sign(js.machEventShiftFloat())),
+                },
+            },
+            .framebuffer_resize => blk: {
+                const width = @intCast(u32, js.machEventShift());
+                const height = @intCast(u32, js.machEventShift());
+                const pixel_ratio = @intCast(u32, js.machEventShift());
+                break :blk Event{
+                    .framebuffer_resize = .{
+                        .width = width * pixel_ratio,
+                        .height = height * pixel_ratio,
+                    },
+                };
+            },
+            .focus_gained => Event.focus_gained,
+            .focus_lost => Event.focus_lost,
+            else => null,
+        };
+    }
+};
+
 pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     _ = options;
     var selector = [1]u8{0} ** 15;
@@ -54,112 +162,8 @@ pub fn deinit(self: *Core) void {
     js.machCanvasDeinit(self.id);
 }
 
-pub fn hasEvent(_: *Core) bool {
-    return js.machHasEvent();
-}
-
-pub fn pollEvents(self: *Core) ?Event {
-    const event_int = js.machEventShift();
-    if (event_int == -1) return null;
-
-    const event_type = @intToEnum(std.meta.Tag(Event), event_int);
-    return switch (event_type) {
-        .key_press, .key_repeat => blk: {
-            const key = @intToEnum(Key, js.machEventShift());
-            switch (key) {
-                .left_shift, .right_shift => self.last_key_mods.shift = true,
-                .left_control, .right_control => self.last_key_mods.control = true,
-                .left_alt, .right_alt => self.last_key_mods.alt = true,
-                .left_super, .right_super => self.last_key_mods.super = true,
-                .caps_lock => self.last_key_mods.caps_lock = true,
-                .num_lock => self.last_key_mods.num_lock = true,
-                else => {},
-            }
-            break :blk switch (event_type) {
-                .key_press => Event{
-                    .key_press = .{
-                        .key = key,
-                        .mods = self.last_key_mods,
-                    },
-                },
-                .key_repeat => Event{
-                    .key_repeat = .{
-                        .key = key,
-                        .mods = self.last_key_mods,
-                    },
-                },
-                else => unreachable,
-            };
-        },
-        .key_release => blk: {
-            const key = @intToEnum(Key, js.machEventShift());
-            switch (key) {
-                .left_shift, .right_shift => self.last_key_mods.shift = false,
-                .left_control, .right_control => self.last_key_mods.control = false,
-                .left_alt, .right_alt => self.last_key_mods.alt = false,
-                .left_super, .right_super => self.last_key_mods.super = false,
-                .caps_lock => self.last_key_mods.caps_lock = false,
-                .num_lock => self.last_key_mods.num_lock = false,
-                else => {},
-            }
-            break :blk Event{
-                .key_release = .{
-                    .key = key,
-                    .mods = self.last_key_mods,
-                },
-            };
-        },
-        .mouse_motion => blk: {
-            const x = @intToFloat(f64, js.machEventShift());
-            const y = @intToFloat(f64, js.machEventShift());
-            self.last_cursor_position = .{
-                .x = x,
-                .y = y,
-            };
-            break :blk Event{
-                .mouse_motion = .{
-                    .pos = .{
-                        .x = x,
-                        .y = y,
-                    },
-                },
-            };
-        },
-        .mouse_press => Event{
-            .mouse_press = .{
-                .button = toMachButton(js.machEventShift()),
-                .pos = self.last_cursor_position,
-                .mods = self.last_key_mods,
-            },
-        },
-        .mouse_release => Event{
-            .mouse_release = .{
-                .button = toMachButton(js.machEventShift()),
-                .pos = self.last_cursor_position,
-                .mods = self.last_key_mods,
-            },
-        },
-        .mouse_scroll => Event{
-            .mouse_scroll = .{
-                .xoffset = @floatCast(f32, std.math.sign(js.machEventShiftFloat())),
-                .yoffset = @floatCast(f32, std.math.sign(js.machEventShiftFloat())),
-            },
-        },
-        .framebuffer_resize => blk: {
-            const width = @intCast(u32, js.machEventShift());
-            const height = @intCast(u32, js.machEventShift());
-            const pixel_ratio = @intCast(u32, js.machEventShift());
-            break :blk Event{
-                .framebuffer_resize = .{
-                    .width = width * pixel_ratio,
-                    .height = height * pixel_ratio,
-                },
-            };
-        },
-        .focus_gained => Event.focus_gained,
-        .focus_lost => Event.focus_lost,
-        else => null,
-    };
+pub inline fn pollEvents(self: *Core) EventIterator {
+    return EventIterator{ .core = self };
 }
 
 pub fn framebufferSize(self: *Core) Size {

--- a/shaderexp/main.zig
+++ b/shaderexp/main.zig
@@ -92,7 +92,8 @@ pub fn deinit(app: *App) void {
 }
 
 pub fn update(app: *App) !bool {
-    while (app.core.pollEvents()) |event| {
+    var iter = app.core.pollEvents();
+    while (iter.next()) |event| {
         switch (event) {
             .key_press => |ev| {
                 if (ev.key == .space) return true;


### PR DESCRIPTION
After this change:
    
* `Core.pollEvents` returns an iterator. At the time of polling events, Mach core will perform work to poll for events, handle resizing of the framebuffer, etc. and the iterator allows the caller to consume all available events.
* The event queue is now baced by a `std.fifo.LinearFifo`, which removes the need for dynamic allocation of each event. Instead, the event queue starts with a generous size suitable for most high-end gaming setups (high-precision mouse, etc.) and can grow, but never shrink, up to the maximum event queue size experienced by the app within any given frame. Effectively, this means we find the maximum capacity needed to store events and avoid runtime allocations.
* `Core.hasEvent` is removed.

Notably, since event polling on Desktop platforms is now done inside of `Core.pollEvents` instead of once-per-call to `pollEvents`, this is much faster. It additionally still allows for one to poll for events multiple times per frame if you like, for handling events mid-frame if you desire.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.