### PR TITLE
gpu-dawn: update gzip decompression to use latest stdlib API

### DIFF
--- a/libs/gpu-dawn/sdk.zig
+++ b/libs/gpu-dawn/sdk.zig
@@ -457,7 +457,7 @@ pub fn Sdk(comptime deps: anytype) type {
             defer file.close();
 
             var buf_stream = std.io.bufferedReader(file.reader());
-            var gzip_stream = try std.compress.gzip.gzipStream(allocator, buf_stream.reader());
+            var gzip_stream = try std.compress.gzip.decompress(allocator, buf_stream.reader());
             defer gzip_stream.deinit();
 
             // Read and decompress the whole file


### PR DESCRIPTION
A simple rename of a function from the standard library.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.