### PR TITLE
gpu-dawn: fix git error when fetching Dawn source

### DIFF
--- a/libs/gpu-dawn/sdk.zig
+++ b/libs/gpu-dawn/sdk.zig
@@ -145,7 +145,7 @@ pub fn Sdk(comptime deps: anytype) type {
                 if (!std.mem.eql(u8, current_revision, revision)) {
                     // Reset to the desired revision
                     exec(allocator, &[_][]const u8{ "git", "fetch" }, dir) catch |err| std.debug.print("warning: failed to 'git fetch' in {s}: {s}\n", .{ dir, @errorName(err) });
-                    try exec(allocator, &[_][]const u8{ "git", "reset", "--quiet", "--hard", revision }, dir);
+                    try exec(allocator, &[_][]const u8{ "git", "checkout", "--quiet", "--force", revision }, dir);
                     try exec(allocator, &[_][]const u8{ "git", "submodule", "update", "--init", "--recursive" }, dir);
                 }
                 return;
@@ -154,7 +154,7 @@ pub fn Sdk(comptime deps: anytype) type {
                     std.log.info("cloning required dependency..\ngit clone {s} {s}..\n", .{ clone_url, dir });
 
                     try exec(allocator, &[_][]const u8{ "git", "clone", "-c", "core.longpaths=true", clone_url, dir }, sdkPath("/"));
-                    try exec(allocator, &[_][]const u8{ "git", "reset", "--quiet", "--hard", revision }, dir);
+                    try exec(allocator, &[_][]const u8{ "git", "checkout", "--quiet", "--force", revision }, dir);
                     try exec(allocator, &[_][]const u8{ "git", "submodule", "update", "--init", "--recursive" }, dir);
                     return;
                 },


### PR DESCRIPTION
Previously, when the gpu-dawn SDK attempted to fetch Dawn sources, Git failed with this error:

```
fatal: ambiguous argument 'generated-*': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

This caused the whole build to fail as the gpu-dawn SDK is unable to check out the intended revision of the generated Dawn sources. This commit fixes the issue by using `git checkout --force` instead of `git reset --hard`, which works because you can checkout to a detached commit hash (used by DirectXShaderCompiler, for example) as well as an actual branch.

The alternative would be to do `git reset --hard origin/generated-*` rather than `git reset --hard generated-*`, but that would require modifying Wrench unlike this solution.



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.