### PR TITLE
autodoc bug demonstration

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -117,6 +117,7 @@ fn testStep(b: *std.Build, optimize: std.builtin.OptimizeMode, target: std.zig.C
         .target = target,
         .optimize = optimize,
     });
+    main_tests.emit_docs = .emit;
     var iter = module(b).dependencies.iterator();
     while (iter.next()) |e| {
         main_tests.addModule(e.key_ptr.*, e.value_ptr.*);


### PR DESCRIPTION
```
git clone https://github.com/hexops/mach
git checkout sg/api-docs
zig build
```

```
thread 7117982 panic: attempt to unwrap error
Unable to dump stack trace: debug info stripped
error: mach-tests...
error: The following command terminated unexpectedly:
/Users/slimsag/zig-macos-aarch64-0.11.0-dev.1605+abc9530a8/zig test /Users/slimsag/Desktop/hexops/mach/src/main.zig -femit-docs --cache-dir /Users/slimsag/Desktop/hexops/mach/zig-cache --global-cache-dir /Users/slimsag/.cache/zig --name mach-tests --test-no-exec --pkg-begin core /Users/slimsag/Desktop/hexops/mach/libs/core/src/main.zig --pkg-begin gpu /Users/slimsag/Desktop/hexops/mach/libs/gpu/src/main.zig --pkg-end --pkg-end --pkg-begin ecs /Users/slimsag/Desktop/hexops/mach/libs/ecs/src/main.zig --pkg-end --pkg-begin sysaudio /Users/slimsag/Desktop/hexops/mach/libs/sysaudio/src/main.zig --pkg-begin sysjs /Users/slimsag/Desktop/hexops/mach/libs/sysjs/src/main.zig --pkg-end --pkg-end --pkg-begin earcut /Users/slimsag/Desktop/hexops/mach/libs/earcut/src/main.zig --pkg-end --enable-cache 
error: the following build command failed with exit code 6:
/Users/slimsag/Desktop/hexops/mach/zig-cache/o/a34b6c5f6da4538cd60e93a93df90571/build /Users/slimsag/zig-macos-aarch64-0.11.0-dev.1605+abc9530a8/zig /Users/slimsag/Desktop/hexops/mach /Users/slimsag/Desktop/hexops/mach/zig-cache /Users/slimsag/.cache/zig

```

- [ ] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.