### PR TITLE
freetype, harfbuzz: Fix string-related types

### DIFF
--- a/libs/freetype/src/Face.zig
+++ b/libs/freetype/src/Face.zig
@@ -58,7 +58,7 @@ pub fn deinit(self: Face) void {
     _ = c.FT_Done_Face(self.handle);
 }
 
-pub fn attachFile(self: Face, path: []const u8) Error!void {
+pub fn attachFile(self: Face, path: [*:0]const u8) Error!void {
     return self.attachStream(.{
         .flags = .{ .path = true },
         .data = .{ .path = path },

--- a/libs/freetype/src/Library.zig
+++ b/libs/freetype/src/Library.zig
@@ -30,7 +30,7 @@ pub fn deinit(self: Library) void {
     _ = c.FT_Done_FreeType(self.handle);
 }
 
-pub fn createFace(self: Library, path: []const u8, face_index: i32) Error!Face {
+pub fn createFace(self: Library, path: [*:0]const u8, face_index: i32) Error!Face {
     return self.openFace(.{
         .flags = .{ .path = true },
         .data = .{ .path = path },

--- a/libs/freetype/src/freetype.zig
+++ b/libs/freetype/src/freetype.zig
@@ -159,7 +159,7 @@ pub const OpenArgs = struct {
     flags: OpenFlags,
     data: union(enum) {
         memory: []const u8,
-        path: []const u8,
+        path: [*:0]const u8,
         stream: c.FT_Stream,
         driver: c.FT_Module,
         params: []const c.FT_Parameter,
@@ -173,7 +173,9 @@ pub const OpenArgs = struct {
                 oa.memory_base = d.ptr;
                 oa.memory_size = @intCast(u31, d.len);
             },
-            .path => |*d| oa.pathname = @intToPtr(*u8, @ptrToInt(d.ptr)),
+            // The Freetype API requires a mutable string.
+            // This is an oversight, Freetype actually never writes to this string.
+            .path => |d| oa.pathname = @constCast(d),
             .stream => |d| oa.stream = d,
             .driver => |d| oa.driver = d,
             .params => |*d| {

--- a/libs/freetype/src/harfbuzz/common.zig
+++ b/libs/freetype/src/harfbuzz/common.zig
@@ -276,6 +276,8 @@ pub const Tag = struct {
     }
 };
 
+pub const Shapers = ?[*:null]const ?[*:0]const u8;
+
 pub extern fn hb_feature_from_string(str: [*c]const u8, len: c_int, feature: [*c]Feature) u8;
 pub extern fn hb_feature_to_string(feature: [*c]Feature, buf: [*c]u8, size: c_uint) void;
 pub extern fn hb_variation_from_string(str: [*c]const u8, len: c_int, variation: [*c]Variation) u8;

--- a/libs/freetype/src/harfbuzz/font.zig
+++ b/libs/freetype/src/harfbuzz/font.zig
@@ -5,6 +5,7 @@ const Face = @import("face.zig").Face;
 const Buffer = @import("buffer.zig").Buffer;
 const Feature = @import("common.zig").Feature;
 const SegmentProps = @import("buffer.zig").SegmentProps;
+const Shapers = @import("common.zig").Shapers;
 
 pub const Font = struct {
     handle: *c.hb_font_t,
@@ -86,13 +87,13 @@ pub const Font = struct {
         );
     }
 
-    pub fn shapeFull(self: Font, buf: Buffer, features: ?[]const Feature, shapers: []const []const u8) error{ShapingFailed}!void {
+    pub fn shapeFull(self: Font, buf: Buffer, features: ?[]const Feature, shapers: Shapers) error{ShapingFailed}!void {
         if (hb_shape_full(
             self.handle,
             buf.handle,
             if (features) |f| f.ptr else null,
             if (features) |f| @intCast(c_uint, f.len) else 0,
-            @ptrCast([*c]const [*c]const u8, shapers),
+            shapers,
         ) < 1) return error.ShapingFailed;
     }
 };

--- a/libs/freetype/src/harfbuzz/shape.zig
+++ b/libs/freetype/src/harfbuzz/shape.zig
@@ -3,7 +3,7 @@ const c = @import("c.zig");
 
 pub const ListShapers = struct {
     index: usize,
-    list: [*c][*c]const u8,
+    list: [*:null]const ?[*:0]const u8,
 
     pub fn init() ListShapers {
         return .{ .index = 0, .list = c.hb_shape_list_shapers() };
@@ -11,9 +11,8 @@ pub const ListShapers = struct {
 
     pub fn next(self: *ListShapers) ?[:0]const u8 {
         self.index += 1;
-        return std.mem.span(@ptrCast(
-            ?[*:0]const u8,
+        return std.mem.span(
             self.list[self.index - 1] orelse return null,
-        ));
+        );
     }
 };

--- a/libs/freetype/src/harfbuzz/shape_plan.zig
+++ b/libs/freetype/src/harfbuzz/shape_plan.zig
@@ -5,31 +5,32 @@ const Font = @import("font.zig").Font;
 const Face = @import("face.zig").Face;
 const SegmentProps = @import("buffer.zig").SegmentProps;
 const Feature = @import("common.zig").Feature;
+const Shapers = @import("common.zig").Shapers;
 
 pub const ShapePlan = struct {
     handle: *c.hb_shape_plan_t,
 
-    pub fn init(face: Face, props: SegmentProps, features: ?[]const Feature, shapers: []const []const u8) ShapePlan {
+    pub fn init(face: Face, props: SegmentProps, features: ?[]const Feature, shapers: Shapers) ShapePlan {
         return .{ .handle = hb_shape_plan_create(
             face.handle,
             &props.cast(),
             if (features) |f| f.ptr else null,
             if (features) |f| @intCast(c_uint, f.len) else 0,
-            @ptrCast([*c]const [*c]const u8, shapers),
+            shapers,
         ).? };
     }
 
-    pub fn initCached(face: Face, props: SegmentProps, features: ?[]const Feature, shapers: []const []const u8) ShapePlan {
+    pub fn initCached(face: Face, props: SegmentProps, features: ?[]const Feature, shapers: Shapers) ShapePlan {
         return .{ .handle = hb_shape_plan_create_cached(
             face.handle,
             &props.cast(),
             if (features) |f| f.ptr else null,
             if (features) |f| @intCast(c_uint, f.len) else 0,
-            @ptrCast([*c]const [*c]const u8, shapers),
+            shapers,
         ).? };
     }
 
-    pub fn init2(face: Face, props: SegmentProps, features: ?[]const Feature, cords: []const i32, shapers: []const []const u8) ShapePlan {
+    pub fn init2(face: Face, props: SegmentProps, features: ?[]const Feature, cords: []const i32, shapers: Shapers) ShapePlan {
         return .{ .handle = hb_shape_plan_create2(
             face.handle,
             &props.cast(),
@@ -37,11 +38,11 @@ pub const ShapePlan = struct {
             if (features) |f| @intCast(c_uint, f.len) else 0,
             cords.ptr,
             @intCast(c_uint, cords.len),
-            @ptrCast([*c]const [*c]const u8, shapers),
+            shapers,
         ).? };
     }
 
-    pub fn initCached2(face: Face, props: SegmentProps, features: ?[]const Feature, cords: []const i32, shapers: []const []const u8) ShapePlan {
+    pub fn initCached2(face: Face, props: SegmentProps, features: ?[]const Feature, cords: []const i32, shapers: Shapers) ShapePlan {
         return .{ .handle = hb_shape_plan_create_cached2(
             face.handle,
             &props.cast(),
@@ -49,7 +50,7 @@ pub const ShapePlan = struct {
             if (features) |f| @intCast(c_uint, f.len) else 0,
             cords.ptr,
             @intCast(c_uint, cords.len),
-            @ptrCast([*c]const [*c]const u8, shapers),
+            shapers,
         ).? };
     }
 

--- a/libs/freetype/src/main.zig
+++ b/libs/freetype/src/main.zig
@@ -13,7 +13,7 @@ const std = @import("std");
 const testing = std.testing;
 const ft = @import("freetype.zig");
 
-fn sdkPath(comptime suffix: []const u8) []const u8 {
+fn sdkPath(comptime suffix: [*:0]const u8) [*:0]const u8 {
     if (suffix[0] != '/') @compileError("suffix must be an absolute path");
     return comptime blk: {
         const root_dir = std.fs.path.dirname(@src().file) orelse ".";


### PR DESCRIPTION
This fixes some ill-defined string types in Freetype and Harfbuzz.
For example, `createFace` previously accepted non zero-terminated font paths, which would cause a runtime error.

I've checked all usages of type `[]const u8` in Freetype and Harbuzz.
After this PR, all type bugs related to zero-terminated strings should be fixed.

#### For reviewers
The Harfbuzz `Shapers` type is a bit tricky. Some references:
- [`hb_shape_full` rendered doc](https://harfbuzz.github.io/harfbuzz-hb-shape.html#hb-shape-full), see `shaper_list`
- [`hb_shape_full` src](https://github.com/harfbuzz/harfbuzz/blob/04a47932a3844f7e73e3af8b05fb98c8b54fb779/src/hb-shape.cc#L125)
- [Definition of a `Shapers` list](https://github.com/harfbuzz/harfbuzz/blob/04a47932a3844f7e73e3af8b05fb98c8b54fb779/src/hb-shape.cc#L55)

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.