### PR TITLE
mach: fix deprecated mem.set() call

### DIFF
--- a/src/gfx/util.zig
+++ b/src/gfx/util.zig
@@ -42,7 +42,7 @@ pub fn VertexWriter(comptime VertexType: type, comptime IndexType: type) type {
             result.next_collision_index = sparse_vertices_count;
             result.next_packed_index = 0;
             result.written_indices_count = 0;
-            std.mem.set(MapEntry, result.sparse_to_packed_map, .{});
+            @memset(result.sparse_to_packed_map, .{});
             return result;
         }
 


### PR DESCRIPTION
Update to the @memset builtin fixes the cubemap and pbr-basic examples assuming zigimg is also up to date

mem.set() appears to have been deprecated

This change gets the cubemap and pbr-basic demos running again with zig11-dev

The zigimg dependency also calls the mem.set() function, and it looks like they have already updated on their end, but I'm not experienced enough with the codebase or github to know how that would get pulled in

This is my first pull request so I'm not sure if I'm following all the correct procedures here

Let me know if any additional changes are necessary :)


- [ ] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.