### PR TITLE
mach: update to @min/@max (std.math.min/max is going away)

### DIFF
--- a/libs/dusk/src/Parser.zig
+++ b/libs/dusk/src/Parser.zig
@@ -1880,7 +1880,7 @@ pub fn peekToken(
 
 pub fn advanceToken(p: *Parser) Ast.Index {
     const prev = p.tok_i;
-    p.tok_i = std.math.min(prev +| 1, p.tokens.len);
+    p.tok_i = @min(prev +| 1, p.tokens.len);
     return prev;
 }
 

--- a/libs/sysaudio/src/pipewire.zig
+++ b/libs/sysaudio/src/pipewire.zig
@@ -311,10 +311,7 @@ pub const Player = struct {
         }
 
         const stride = self.format.frameSize(self.channels.len);
-        const n_frames = std.math.min(
-            buf.*.requested,
-            buf.*.buffer.*.datas[0].maxsize / stride,
-        );
+        const n_frames = @min(buf.*.requested, buf.*.buffer.*.datas[0].maxsize / stride);
         buf.*.buffer.*.datas[0].chunk.*.stride = stride;
         buf.*.buffer.*.datas[0].chunk.*.size = n_frames * stride;
 


### PR DESCRIPTION
This PR resolves #771 by removing Zig's stdlib `std.math.min()`/`.max()` functions and replacing them with the `@min()`/`@max()` compiler builtin functions.

Please note that this PR will move from being a draft to RFR status once the other repositories have been effectively updated, therefore making this part of the issue tracker.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.