### PR TITLE
update to latest Zig version

### DIFF
--- a/libs/gpu-dawn/sdk.zig
+++ b/libs/gpu-dawn/sdk.zig
@@ -431,12 +431,12 @@ pub fn Sdk(comptime deps: anytype) type {
             const contents = try std.fs.cwd().readFileAlloc(allocator, json_file, std.math.maxInt(usize));
             defer allocator.free(contents);
 
-            var parser = std.json.Parser.init(allocator, false);
+            var parser = std.json.Parser.init(allocator, .alloc_if_needed);
             defer parser.deinit();
             var tree = try parser.parse(contents);
             defer tree.deinit();
 
-            var iter = tree.root.Object.iterator();
+            var iter = tree.root.object.iterator();
             while (iter.next()) |f| {
                 const out_path = try std.fs.path.join(allocator, &.{ out_dir, f.key_ptr.* });
                 defer allocator.free(out_path);
@@ -444,7 +444,7 @@ pub fn Sdk(comptime deps: anytype) type {
 
                 var new_file = try std.fs.createFileAbsolute(out_path, .{});
                 defer new_file.close();
-                try new_file.writeAll(f.value_ptr.*.String);
+                try new_file.writeAll(f.value_ptr.*.string);
             }
         }
 

--- a/libs/gpu/src/dawn_impl.zig
+++ b/libs/gpu/src/dawn_impl.zig
@@ -769,7 +769,7 @@ pub const Interface = struct {
         procs.queueSetLabel.?(@ptrCast(c.WGPUQueue, queue), label);
     }
 
-    pub inline fn queueSubmit(queue: *gpu.Queue, command_count: u32, commands: [*]*const gpu.CommandBuffer) void {
+    pub inline fn queueSubmit(queue: *gpu.Queue, command_count: u32, commands: [*]const *const gpu.CommandBuffer) void {
         procs.queueSubmit.?(
             @ptrCast(c.WGPUQueue, queue),
             command_count,

--- a/libs/gpu/src/interface.zig
+++ b/libs/gpu/src/interface.zig
@@ -137,7 +137,7 @@ pub fn Interface(comptime T: type) type {
     assertDecl(T, "queueCopyTextureForBrowser", fn (queue: *gpu.Queue, source: *const gpu.ImageCopyTexture, destination: *const gpu.ImageCopyTexture, copy_size: *const gpu.Extent3D, options: *const gpu.CopyTextureForBrowserOptions) callconv(.Inline) void);
     assertDecl(T, "queueOnSubmittedWorkDone", fn (queue: *gpu.Queue, signal_value: u64, callback: gpu.Queue.WorkDoneCallback, userdata: ?*anyopaque) callconv(.Inline) void);
     assertDecl(T, "queueSetLabel", fn (queue: *gpu.Queue, label: [*:0]const u8) callconv(.Inline) void);
-    assertDecl(T, "queueSubmit", fn (queue: *gpu.Queue, command_count: u32, commands: [*]*const gpu.CommandBuffer) callconv(.Inline) void);
+    assertDecl(T, "queueSubmit", fn (queue: *gpu.Queue, command_count: u32, commands: [*]const *const gpu.CommandBuffer) callconv(.Inline) void);
     assertDecl(T, "queueWriteBuffer", fn (queue: *gpu.Queue, buffer: *gpu.Buffer, buffer_offset: u64, data: *const anyopaque, size: usize) callconv(.Inline) void);
     assertDecl(T, "queueWriteTexture", fn (queue: *gpu.Queue, destination: *const gpu.ImageCopyTexture, data: *const anyopaque, data_size: usize, data_layout: *const gpu.Texture.DataLayout, write_size: *const gpu.Extent3D) callconv(.Inline) void);
     assertDecl(T, "queueReference", fn (queue: *gpu.Queue) callconv(.Inline) void);
@@ -823,7 +823,7 @@ pub fn Export(comptime T: type) type {
         }
 
         // WGPU_EXPORT void wgpuQueueSubmit(WGPUQueue queue, uint32_t commandCount, WGPUCommandBuffer const * commands);
-        export fn wgpuQueueSubmit(queue: *gpu.Queue, command_count: u32, commands: [*]*const gpu.CommandBuffer) void {
+        export fn wgpuQueueSubmit(queue: *gpu.Queue, command_count: u32, commands: [*]const *const gpu.CommandBuffer) void {
             T.queueSubmit(queue, command_count, commands);
         }
 
@@ -1950,7 +1950,7 @@ pub const StubInterface = Interface(struct {
         unreachable;
     }
 
-    pub inline fn queueSubmit(queue: *gpu.Queue, command_count: u32, commands: [*]*const gpu.CommandBuffer) void {
+    pub inline fn queueSubmit(queue: *gpu.Queue, command_count: u32, commands: [*]const *const gpu.CommandBuffer) void {
         _ = queue;
         _ = command_count;
         _ = commands;

--- a/libs/gpu/src/queue.zig
+++ b/libs/gpu/src/queue.zig
@@ -55,7 +55,7 @@ pub const Queue = opaque {
         Impl.queueSetLabel(queue, label);
     }
 
-    pub inline fn submit(queue: *Queue, commands: []*const CommandBuffer) void {
+    pub inline fn submit(queue: *Queue, commands: []const *const CommandBuffer) void {
         Impl.queueSubmit(queue, @intCast(u32, commands.len), commands.ptr);
     }
 


### PR DESCRIPTION
This is a WIP PR to update us to the latest Zig version.

Nightly Zig has some large regressions right now in peer type resolution behavior; so we cannot upgrade yet. Once https://github.com/ziglang/zig/pull/15726 lands, we probably can.

```
shaderexp/main.zig:150:22: error: expected type '[]*const command_buffer.CommandBuffer', found '*const [1]*command_buffer.CommandBuffer'
    app.queue.submit(&[_]*gpu.CommandBuffer{command});
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
shaderexp/main.zig:150:22: note: cast discards const qualifier
libs/gpu/src/queue.zig:58:51: note: parameter type declared here
    pub inline fn submit(queue: *Queue, commands: []*const CommandBuffer) void {
                                                  ^~~~~~~~~~~~~~~~~~~~~~

```


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.