### PR TITLE
core/gpu: start on usingnamespace issue and new zig split usage

### DIFF
--- a/app/Builder.zig
+++ b/app/Builder.zig
@@ -235,7 +235,7 @@ fn handleConn(self: *Builder, conn: std.net.StreamServer.Connection) void {
             else => sendError(conn.stream, .bad_request),
         };
     };
-    var first_line_iter = std.mem.split(u8, first_line, " ");
+    var first_line_iter = std.mem.splitScalar(u8, first_line, ' ');
     _ = first_line_iter.next(); // skip method
     if (first_line_iter.next()) |uri_str| {
         const uri = std.Uri.parseWithoutScheme(uri_str) catch {
@@ -300,7 +300,7 @@ fn notify(self: *Builder, stream: std.net.Stream) void {
     };
     switch (self.status) {
         .compile_error => |msg| {
-            var lines = std.mem.split(u8, msg, "\n");
+            var lines = std.mem.splitScalar(u8, msg, '\n');
             while (lines.next()) |line| {
                 stream.writer().print("data: {s}\n", .{line}) catch {
                     stream.close();

--- a/app/main.zig
+++ b/app/main.zig
@@ -48,7 +48,7 @@ pub fn main() !void {
                     std.os.exit(1);
                 };
             } else if (argOption("-watch-path")) |value| {
-                var paths = std.mem.split(u8, value, ",");
+                var paths = std.mem.splitScalar(u8, value, ',');
                 builder.watch_paths = try allocator.alloc([]const u8, std.mem.count(u8, value, ",") + 1);
                 for (0..255) |i| {
                     const path = paths.next() orelse break;

--- a/libs/core/src/platform.zig
+++ b/libs/core/src/platform.zig
@@ -1,9 +1,12 @@
 const builtin = @import("builtin");
 
-pub usingnamespace if (builtin.cpu.arch == .wasm32)
+const platform = if (builtin.cpu.arch == .wasm32)
     @import("platform/wasm.zig")
 else
     @import("platform/native.zig");
+
+pub const Core = platform.Core;
+pub const Timer = platform.Timer;
 
 // Verifies that a platform implementation exposes the expected function declarations.
 comptime {

--- a/libs/gpu/src/main.zig
+++ b/libs/gpu/src/main.zig
@@ -1,77 +1,53 @@
 const std = @import("std");
 
-pub usingnamespace @import("adapter.zig");
-pub usingnamespace @import("bind_group.zig");
-pub usingnamespace @import("bind_group_layout.zig");
-pub usingnamespace @import("buffer.zig");
+pub const Adapter = @import("adapter.zig").Adapter;
+pub const BindGroup = @import("bind_group.zig").BindGroup;
+pub const BindGroupLayout = @import("bind_group_layout.zig").BindGroupLayout;
+pub const Buffer = @import("buffer.zig").Buffer;
 pub usingnamespace @import("callbacks.zig");
-pub usingnamespace @import("command_buffer.zig");
-pub usingnamespace @import("command_encoder.zig");
-pub usingnamespace @import("compute_pass_encoder.zig");
-pub usingnamespace @import("compute_pipeline.zig");
-pub usingnamespace @import("device.zig");
-pub usingnamespace @import("external_texture.zig");
-pub usingnamespace @import("instance.zig");
-pub usingnamespace @import("pipeline_layout.zig");
-pub usingnamespace @import("query_set.zig");
-pub usingnamespace @import("queue.zig");
-pub usingnamespace @import("render_bundle.zig");
-pub usingnamespace @import("render_bundle_encoder.zig");
-pub usingnamespace @import("render_pass_encoder.zig");
-pub usingnamespace @import("render_pipeline.zig");
-pub usingnamespace @import("sampler.zig");
-pub usingnamespace @import("shader_module.zig");
-pub usingnamespace @import("surface.zig");
-pub usingnamespace @import("swap_chain.zig");
-pub usingnamespace @import("texture.zig");
-pub usingnamespace @import("texture_view.zig");
+pub const CommandBuffer = @import("command_buffer.zig").CommandBuffer;
+pub const CommandEncoder = @import("command_encoder.zig").CommandEncoder;
+pub const ComputePassEncoder = @import("compute_pass_encoder.zig").ComputePassEncoder;
+pub const ComputePipeline = @import("compute_pipeline.zig").ComputePipeline;
+pub const Device = @import("device.zig").Device;
+pub const ExternalTexture = @import("external_texture.zig").ExternalTexture;
+pub const Instance = @import("instance.zig").Instance;
+pub const PipelineLayout = @import("pipeline_layout.zig").PipelineLayout;
+pub const QuerySet = @import("query_set.zig").QuerySet;
+pub const Queue = @import("queue.zig").Queue;
+pub const RenderBundle = @import("render_bundle.zig").RenderBundle;
+pub const RenderBundleEncoder = @import("render_bundle_encoder.zig").RenderBundleEncoder;
+pub const RenderPassEncoder = @import("render_pass_encoder.zig").RenderPassEncoder;
+pub const RenderPipeline = @import("render_pipeline.zig").RenderPipeline;
+pub const Sampler = @import("sampler.zig").Sampler;
+pub const ShaderModule = @import("shader_module.zig").ShaderModule;
+pub const Surface = @import("surface.zig").Surface;
+pub const SwapChain = @import("swap_chain.zig").SwapChain;
+pub const Texture = @import("texture.zig").Texture;
+pub const TextureView = @import("texture_view.zig").TextureView;
 
 pub const dawn = @import("dawn.zig");
 
 pub usingnamespace @import("types.zig");
-pub usingnamespace @import("interface.zig");
 
 const instance = @import("instance.zig");
 const device = @import("device.zig");
 const interface = @import("interface.zig");
 const types = @import("types.zig");
 
+pub const Impl = interface.Impl;
+pub const StubInterface = interface.StubInterface;
+pub const Export = interface.Export;
+pub const Interface = interface.Interface;
+
 pub inline fn createInstance(descriptor: ?*const instance.Instance.Descriptor) ?*instance.Instance {
-    return interface.Impl.createInstance(descriptor);
+    return Impl.createInstance(descriptor);
 }
 
 pub inline fn getProcAddress(_device: *device.Device, proc_name: [*:0]const u8) ?types.Proc {
-    return interface.Impl.getProcAddress(_device, proc_name);
+    return Impl.getProcAddress(_device, proc_name);
 }
 
 test {
     std.testing.refAllDeclsRecursive(@This());
-
-    // Due to usingnamespace imports, these are not referenceable via @This()
-    std.testing.refAllDeclsRecursive(@import("adapter.zig"));
-    std.testing.refAllDeclsRecursive(@import("bind_group.zig"));
-    std.testing.refAllDeclsRecursive(@import("bind_group_layout.zig"));
-    std.testing.refAllDeclsRecursive(@import("buffer.zig"));
-    std.testing.refAllDeclsRecursive(@import("command_buffer.zig"));
-    std.testing.refAllDeclsRecursive(@import("command_encoder.zig"));
-    std.testing.refAllDeclsRecursive(@import("compute_pass_encoder.zig"));
-    std.testing.refAllDeclsRecursive(@import("compute_pipeline.zig"));
-    std.testing.refAllDeclsRecursive(@import("device.zig"));
-    std.testing.refAllDeclsRecursive(@import("external_texture.zig"));
-    std.testing.refAllDeclsRecursive(@import("instance.zig"));
-    std.testing.refAllDeclsRecursive(@import("pipeline_layout.zig"));
-    std.testing.refAllDeclsRecursive(@import("query_set.zig"));
-    std.testing.refAllDeclsRecursive(@import("queue.zig"));
-    std.testing.refAllDeclsRecursive(@import("render_bundle.zig"));
-    std.testing.refAllDeclsRecursive(@import("render_bundle_encoder.zig"));
-    std.testing.refAllDeclsRecursive(@import("render_pass_encoder.zig"));
-    std.testing.refAllDeclsRecursive(@import("render_pipeline.zig"));
-    std.testing.refAllDeclsRecursive(@import("sampler.zig"));
-    std.testing.refAllDeclsRecursive(@import("shader_module.zig"));
-    std.testing.refAllDeclsRecursive(@import("surface.zig"));
-    std.testing.refAllDeclsRecursive(@import("swap_chain.zig"));
-    std.testing.refAllDeclsRecursive(@import("texture.zig"));
-    std.testing.refAllDeclsRecursive(@import("texture_view.zig"));
-    std.testing.refAllDeclsRecursive(@import("types.zig"));
-    std.testing.refAllDeclsRecursive(@import("interface.zig"));
 }


### PR DESCRIPTION
beginning work on https://github.com/hexops/mach/issues/796, wasnt sure how to handle `callbacks.zig` and `types.zig` since they have so many more decls than the others so just left as is for now.

just merged was slightly new usage of `std.mem.split` https://github.com/ziglang/zig/pull/15579. The old `split` function still works but is just an alias for `splitSequence` and is being deprecated.
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.