### PR TITLE
freetype: fix and re-enable harfbuzz

### DIFF
--- a/libs/freetype/build.zig
+++ b/libs/freetype/build.zig
@@ -96,32 +96,29 @@ pub fn testStep(b: *Build, optimize: std.builtin.OptimizeMode, target: std.zig.C
         .freetype = .{
             .brotli = true,
         },
-        // TODO: harfbuzz is broken
-        // .harfbuzz = .{},
+        .harfbuzz = .{},
     });
     main_tests.main_pkg_path = sdkPath("/");
     b.installArtifact(main_tests);
 
-    // TODO: harfbuzz is broken
-    // const harfbuzz_tests = b.addTest(.{
-    //     .name = "harfbuzz-tests",
-    //     .root_source_file = .{ .path = sdkPath("/src/harfbuzz/main.zig") },
-    //     .target = target,
-    //     .optimize = optimize,
-    // });
-    // harfbuzz_tests.addModule("freetype", module(b));
-    // link(b, harfbuzz_tests, .{
-    //     .freetype = .{
-    //         .brotli = true,
-    //     },
-    //     .harfbuzz = .{},
-    // });
-    // harfbuzz_tests.main_pkg_path = sdkPath("/");
-    // b.installArtifact(harfbuzz_tests);
+    const harfbuzz_tests = b.addTest(.{
+        .name = "harfbuzz-tests",
+        .root_source_file = .{ .path = sdkPath("/src/harfbuzz/main.zig") },
+        .target = target,
+        .optimize = optimize,
+    });
+    harfbuzz_tests.addModule("freetype", module(b));
+    link(b, harfbuzz_tests, .{
+        .freetype = .{
+            .brotli = true,
+        },
+        .harfbuzz = .{},
+    });
+    harfbuzz_tests.main_pkg_path = sdkPath("/");
+    b.installArtifact(harfbuzz_tests);
 
     const main_tests_run = b.addRunArtifact(main_tests);
-    // TODO: harfbuzz is broken
-    // main_tests_run.step.dependOn(&b.addRunArtifact(harfbuzz_tests).step);
+    main_tests_run.step.dependOn(&b.addRunArtifact(harfbuzz_tests).step);
     return main_tests_run;
 }
 
@@ -200,12 +197,12 @@ pub fn buildHarfbuzz(b: *Build, optimize: std.builtin.OptimizeMode, target: std.
         .target = target,
         .optimize = optimize,
     });
-    // TODO: `-Wno-error` is not respected for some reason; as a result harfbuzz builds are broken.
-    lib.addCSourceFile(hb_root ++ "/src/harfbuzz.cc", &.{"-Wno-error=cast-function-type-strict"});
+    lib.addCSourceFile(hb_root ++ "/src/harfbuzz.cc", &.{});
     lib.linkLibCpp();
     lib.addIncludePath(hb_include_path);
     lib.addIncludePath(ft_include_path);
     lib.defineCMacro("HAVE_FREETYPE", "1");
+    lib.defineCMacro("HB_NO_PRAGMA_GCC_DIAGNOSTIC_ERROR", "1");
 
     if (options.install_libs)
         b.installArtifact(lib);


### PR DESCRIPTION
This wasn't actually broken due to a Zig bug, but rather due to some pragmas in Harfbuzz which forcibly enable this -Werror. Luckily, there's a macro you can define to disable them.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.