### PR TITLE
gpu-dawn: begin building latest Dawn version again

### DIFF
--- a/libs/gpu-dawn/README.md
+++ b/libs/gpu-dawn/README.md
@@ -65,8 +65,8 @@ When you call a Dawn `webgpu.h` function, Dawn internally diverts this call thro
 
 `mach/gpu-dawn` builds since Oct 17th 2022 no longer include the `webgpu.h` symbols by default. If you intend to actually call the WebGPU API, you should build these two source files as part of your application:
 
-1. [`dawn_proc.c`](https://raw.githubusercontent.com/hexops/dawn/generated-2023-01-28.1674950134/out/Debug/gen/src/dawn/dawn_proc.c)
-2. [`webgpu_dawn_native_proc.cpp`](https://raw.githubusercontent.com/hexops/dawn/generated-2023-01-28.1674950134/out/Debug/gen/src/dawn/native/webgpu_dawn_native_proc.cpp)
+1. [`dawn_proc.c`](https://raw.githubusercontent.com/hexops/dawn/generated-2023-06-18.1687119009/out/Debug/gen/src/dawn/dawn_proc.c)
+2. [`webgpu_dawn_native_proc.cpp`](https://raw.githubusercontent.com/hexops/dawn/generated-2023-06-18.1687119009/out/Debug/gen/src/dawn/native/webgpu_dawn_native_proc.cpp)
 
 And call `dawnProcSetProcs` to set up the proc table.
 

--- a/libs/gpu-dawn/sdk.zig
+++ b/libs/gpu-dawn/sdk.zig
@@ -69,7 +69,7 @@ pub fn Sdk(comptime deps: anytype) type {
         }
 
         fn linkFromSource(b: *Build, step: *std.build.CompileStep, options: Options) !void {
-            try ensureGitRepoCloned(b.allocator, "https://github.com/hexops/dawn", "generated-2023-01-28.1674950134", sdkPath("/libs/dawn"));
+            try ensureGitRepoCloned(b.allocator, "https://github.com/hexops/dawn", "generated-2023-06-18.1687119009", sdkPath("/libs/dawn"));
 
             // branch: mach
             try ensureGitRepoCloned(b.allocator, "https://github.com/hexops/DirectXShaderCompiler", "cff9a6f0b7f961748b822e1d313a7205dfdecf9d", sdkPath("/libs/DirectXShaderCompiler"));

--- a/libs/gpu/README.md
+++ b/libs/gpu/README.md
@@ -204,7 +204,7 @@ There may be other opportunities for helpers, to improve the existing APIs, or a
 
 ## WebGPU version
 
-Dawn's `webgpu.h` is the **authoritative source** for our API. You can find [the current version we use here](https://github.com/hexops/dawn/blob/generated-2023-01-28.1674950134/out/Debug/gen/include/dawn/webgpu.h).
+Dawn's `webgpu.h` is the **authoritative source** for our API. You can find [the current version we use here](https://github.com/hexops/dawn/blob/generated-2023-06-18.1687119009/out/Debug/gen/include/dawn/webgpu.h).
 
 ## Development rules
 


### PR DESCRIPTION
Supersedes https://github.com/hexops/mach/pull/703 and updates us to the latest Dawn version / API `generated-2023-06-18.1687119009`. This [include ~800 commits](https://github.com/hexops/dawn/compare/9b071ba3cf12eaed09616bc1dd1307b158a94814...1a6339511862c55761652038310f80b31fdd824f) since we last updated (2023-01-28).

Confirmed working on aarch64-macos, should work on others but will need to verify + potentially fix minor `sdk.zig` issues for other platforms.

A second PR will be sent for the `mach-gpu` interface changes that are needed once this is building in CI.

Once merged, Wrench should keep us up-to-date more quickly again - every two weeks or so.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.