### PR TITLE
mach: entry fix for overriding logging scope levels and exposed option for custom function

### DIFF
--- a/libs/core/src/platform/native/entry.zig
+++ b/libs/core/src/platform/native/entry.zig
@@ -17,6 +17,11 @@ pub const std_options = struct {
         app_std_options.log_scope_levels
     else
         &[0]std.log.ScopeLevel{};
+
+    pub const logFn = if (@hasDecl(app_std_options, "logFn"))
+        app_std_options.logFn
+    else
+        std.log.defaultLog;
 };
 
 pub fn main() !void {

--- a/libs/core/src/platform/native/entry.zig
+++ b/libs/core/src/platform/native/entry.zig
@@ -13,7 +13,7 @@ pub const std_options = struct {
     else
         std.log.default_level;
 
-    pub const log_scope_levels = if (@hasDecl(App, "log_scope_levels"))
+    pub const log_scope_levels = if (@hasDecl(app_std_options, "log_scope_levels"))
         app_std_options.log_scope_levels
     else
         &[0]std.log.ScopeLevel{};


### PR DESCRIPTION
I fixed logging override options in `native/entry.zig` and added functionality to define the logging function.

The reason is that users can define in `main.zig` their own logging scope levels and logging function. For example something along the lines of:

```zig
pub const App = @This();

pub const std_options = struct {
    pub const log_scope_levels = &[_]std.log.ScopeLevel{ 
      .{ .scope = .rendering, .level = .debug }, 
      .{ .scope = .gameplay, .level = .info },
      .{ .scope = .animations, .level = .err } };
    pub const logFn = customLogFn;
};

pub fn customLogFn(
    comptime level: std.log.Level,
    comptime scope: @TypeOf(.EnumLiteral),
    comptime format: []const u8,
    args: anytype,
) void {
    // Custom formating
}
```

I also checked `wasm/entry.zig` and saw that there was no issue and it already has some custom logging functions.

Reference used:
- [zig std.log](https://ziglang.org/documentation/master/std/#A;std:log)
- [Overview of std.log](https://gist.github.com/leecannon/d6f5d7e5af5881c466161270347ce84d)




- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.