### PR TITLE
core: add is_headless to specify hidden window before init

### DIFF
--- a/libs/core/src/Core.zig
+++ b/libs/core/src/Core.zig
@@ -8,7 +8,7 @@ pub const Core = @This();
 internal: platform.Core,
 
 pub const Options = struct {
-    is_app: bool = true,
+    is_app: bool = false,
     is_headless: bool = false,
     title: [*:0]const u8 = "Mach Engine",
     size: Size = .{ .width = 1920 / 2, .height = 1080 / 2 },

--- a/libs/core/src/Core.zig
+++ b/libs/core/src/Core.zig
@@ -8,7 +8,8 @@ pub const Core = @This();
 internal: platform.Core,
 
 pub const Options = struct {
-    is_app: bool = false,
+    is_app: bool = true,
+    is_headless: bool = false,
     title: [*:0]const u8 = "Mach Engine",
     size: Size = .{ .width = 1920 / 2, .height = 1080 / 2 },
     power_preference: gpu.PowerPreference = .undefined,

--- a/libs/core/src/platform/native/Core.zig
+++ b/libs/core/src/platform/native/Core.zig
@@ -78,6 +78,10 @@ pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     // Create the test window and discover adapters using it (esp. for OpenGL)
     var hints = util.glfwWindowHintsForBackend(backend_type);
     hints.cocoa_retina_framebuffer = true;
+    if (options.is_headless) {
+        hints.visible = false; // Hiding window before creation otherwise you get the window showing up for a little bit then hiding.
+    }
+
     const window = glfw.Window.create(
         options.size.width,
         options.size.height,


### PR DESCRIPTION
I hope it's no trouble 

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.