### PR TITLE
Latest Zig infers casts using result type

### DIFF
--- a/libs/glfw/src/Cursor.zig
+++ b/libs/glfw/src/Cursor.zig
@@ -115,7 +115,7 @@ pub const Shape = enum(i32) {
 pub inline fn create(image: Image, xhot: i32, yhot: i32) ?Cursor {
     internal_debug.assertInitialized();
     const img = image.toC();
-    if (c.glfwCreateCursor(&img, @intCast(c_int, xhot), @intCast(c_int, yhot))) |cursor| return Cursor{ .ptr = cursor };
+    if (c.glfwCreateCursor(&img, @intCast(xhot), @intCast(yhot))) |cursor| return Cursor{ .ptr = cursor };
     return null;
 }
 
@@ -153,7 +153,7 @@ pub inline fn create(image: Image, xhot: i32, yhot: i32) ?Cursor {
 /// see also: cursor_object, glfwCreateCursor
 pub inline fn createStandard(shape: Shape) ?Cursor {
     internal_debug.assertInitialized();
-    if (c.glfwCreateStandardCursor(@intCast(c_int, @intFromEnum(shape)))) |cursor| return Cursor{ .ptr = cursor };
+    if (c.glfwCreateStandardCursor(@intCast(@intFromEnum(shape)))) |cursor| return Cursor{ .ptr = cursor };
     return null;
 }
 

--- a/libs/glfw/src/GammaRamp.zig
+++ b/libs/glfw/src/GammaRamp.zig
@@ -54,7 +54,7 @@ pub inline fn toC(self: GammaRamp) c.GLFWgammaramp {
         .red = &self.red[0],
         .green = &self.green[0],
         .blue = &self.blue[0],
-        .size = @intCast(c_uint, self.red.len),
+        .size = @intCast(self.red.len),
     };
 }
 

--- a/libs/glfw/src/Image.zig
+++ b/libs/glfw/src/Image.zig
@@ -48,8 +48,8 @@ pub inline fn init(allocator: mem.Allocator, width: u32, height: u32, pixel_data
 /// The returned memory is valid for as long as the GLFW C memory is valid.
 pub inline fn fromC(native: c.GLFWimage, pixel_data_len: usize) Image {
     return Image{
-        .width = @intCast(u32, native.width),
-        .height = @intCast(u32, native.height),
+        .width = @intCast(native.width),
+        .height = @intCast(native.height),
         .pixels = native.pixels[0..pixel_data_len],
         .owned = false,
     };
@@ -60,8 +60,8 @@ pub inline fn fromC(native: c.GLFWimage, pixel_data_len: usize) Image {
 /// The returned memory is valid for as long as the Zig memory is valid.
 pub inline fn toC(self: Image) c.GLFWimage {
     return c.GLFWimage{
-        .width = @intCast(c_int, self.width),
-        .height = @intCast(c_int, self.height),
+        .width = @intCast(self.width),
+        .height = @intCast(self.height),
         .pixels = &self.pixels[0],
     };
 }

--- a/libs/glfw/src/Joystick.zig
+++ b/libs/glfw/src/Joystick.zig
@@ -39,7 +39,7 @@ pub const Id = enum(c_int) {
     fourteen = c.GLFW_JOYSTICK_14,
     fifteen = c.GLFW_JOYSTICK_15,
     sixteen = c.GLFW_JOYSTICK_16,
-    pub const last = @enumFromInt(@This(), c.GLFW_JOYSTICK_LAST);
+    pub const last: @This() = @enumFromInt(c.GLFW_JOYSTICK_LAST);
 };
 
 /// Gamepad input state
@@ -60,12 +60,12 @@ const GamepadState = extern struct {
 
     /// Returns the state of the specified gamepad button.
     pub fn getButton(self: @This(), which: GamepadButton) Action {
-        return @enumFromInt(Action, self.buttons[@intCast(u32, @intFromEnum(which))]);
+        return @enumFromInt(self.buttons[@intCast(@intFromEnum(which))]);
     }
 
     /// Returns the status of the specified gamepad axis, in the range -1.0 to 1.0 inclusive.
     pub fn getAxis(self: @This(), which: GamepadAxis) f32 {
-        return self.axes[@intCast(u32, @intFromEnum(which))];
+        return self.axes[@intCast(@intFromEnum(which))];
     }
 };
 
@@ -115,7 +115,7 @@ pub inline fn getAxes(self: Joystick) ?[]const f32 {
     var count: c_int = undefined;
     const axes = c.glfwGetJoystickAxes(@intFromEnum(self.jid), &count);
     if (axes == null) return null;
-    return axes[0..@intCast(u32, count)];
+    return axes[0..@intCast(count)];
 }
 
 /// Returns the state of all buttons of the specified joystick.
@@ -148,7 +148,7 @@ pub inline fn getButtons(self: Joystick) ?[]const u8 {
     var count: c_int = undefined;
     const buttons = c.glfwGetJoystickButtons(@intFromEnum(self.jid), &count);
     if (buttons == null) return null;
-    return buttons[0..@intCast(u32, count)];
+    return buttons[0..@intCast(count)];
 }
 
 /// Returns the state of all hats of the specified joystick.
@@ -197,8 +197,8 @@ pub inline fn getHats(self: Joystick) ?[]const Hat {
     var count: c_int = undefined;
     const hats = c.glfwGetJoystickHats(@intFromEnum(self.jid), &count);
     if (hats == null) return null;
-    const slice = hats[0..@intCast(u32, count)];
-    return @ptrCast(*const []const Hat, &slice).*;
+    const slice = hats[0..@intCast(count)];
+    return @as(*const []const Hat, @ptrCast(&slice)).*;
 }
 
 /// Returns the name of the specified joystick.
@@ -225,7 +225,7 @@ pub inline fn getName(self: Joystick) ?[:0]const u8 {
     internal_debug.assertInitialized();
     const name_opt = c.glfwGetJoystickName(@intFromEnum(self.jid));
     return if (name_opt) |name|
-        std.mem.span(@ptrCast([*:0]const u8, name))
+        std.mem.span(@as([*:0]const u8, @ptrCast(name)))
     else
         null;
 }
@@ -262,7 +262,7 @@ pub inline fn getGUID(self: Joystick) ?[:0]const u8 {
     internal_debug.assertInitialized();
     const guid_opt = c.glfwGetJoystickGUID(@intFromEnum(self.jid));
     return if (guid_opt) |guid|
-        std.mem.span(@ptrCast([*:0]const u8, guid))
+        std.mem.span(@as([*:0]const u8, @ptrCast(guid)))
     else
         null;
 }
@@ -279,7 +279,7 @@ pub inline fn getGUID(self: Joystick) ?[:0]const u8 {
 /// see also: joystick_userptr, glfw.Joystick.getUserPointer
 pub inline fn setUserPointer(self: Joystick, comptime T: type, pointer: *T) void {
     internal_debug.assertInitialized();
-    c.glfwSetJoystickUserPointer(@intFromEnum(self.jid), @ptrCast(*anyopaque, pointer));
+    c.glfwSetJoystickUserPointer(@intFromEnum(self.jid), @ptrCast(pointer));
 }
 
 /// Returns the user pointer of the specified joystick.
@@ -296,7 +296,7 @@ pub inline fn setUserPointer(self: Joystick, comptime T: type, pointer: *T) void
 pub inline fn getUserPointer(self: Joystick, comptime PointerType: type) ?PointerType {
     internal_debug.assertInitialized();
     const ptr = c.glfwGetJoystickUserPointer(@intFromEnum(self.jid));
-    if (ptr) |p| return @ptrCast(PointerType, @alignCast(@alignOf(std.meta.Child(PointerType)), p));
+    if (ptr) |p| return @ptrCast(@alignCast(p));
     return null;
 }
 
@@ -335,8 +335,8 @@ pub inline fn setCallback(comptime callback: ?fn (joystick: Joystick, event: Eve
         const CWrapper = struct {
             pub fn joystickCallbackWrapper(jid: c_int, event: c_int) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
-                    Joystick{ .jid = @enumFromInt(Joystick.Id, jid) },
-                    @enumFromInt(Event, event),
+                    Joystick{ .jid = @enumFromInt(jid) },
+                    @as(Event, @enumFromInt(event)),
                 });
             }
         };
@@ -424,7 +424,7 @@ pub inline fn getGamepadName(self: Joystick) ?[:0]const u8 {
     internal_debug.assertInitialized();
     const name_opt = c.glfwGetGamepadName(@intFromEnum(self.jid));
     return if (name_opt) |name|
-        std.mem.span(@ptrCast([*:0]const u8, name))
+        std.mem.span(@as([*:0]const u8, @ptrCast(name)))
     else
         null;
 }
@@ -457,7 +457,7 @@ pub inline fn getGamepadName(self: Joystick) ?[:0]const u8 {
 pub inline fn getGamepadState(self: Joystick) ?GamepadState {
     internal_debug.assertInitialized();
     var state: GamepadState = undefined;
-    const success = c.glfwGetGamepadState(@intFromEnum(self.jid), @ptrCast(*c.GLFWgamepadstate, &state));
+    const success = c.glfwGetGamepadState(@intFromEnum(self.jid), @ptrCast(&state));
     return if (success == c.GLFW_TRUE) state else null;
 }
 

--- a/libs/glfw/src/Monitor.zig
+++ b/libs/glfw/src/Monitor.zig
@@ -35,7 +35,7 @@ pub inline fn getPos(self: Monitor) Pos {
     var xpos: c_int = 0;
     var ypos: c_int = 0;
     c.glfwGetMonitorPos(self.handle, &xpos, &ypos);
-    return Pos{ .x = @intCast(u32, xpos), .y = @intCast(u32, ypos) };
+    return Pos{ .x = @intCast(xpos), .y = @intCast(ypos) };
 }
 
 /// The monitor workarea, in screen coordinates.
@@ -66,7 +66,7 @@ pub inline fn getWorkarea(self: Monitor) Workarea {
     var width: c_int = 0;
     var height: c_int = 0;
     c.glfwGetMonitorWorkarea(self.handle, &xpos, &ypos, &width, &height);
-    return Workarea{ .x = @intCast(u32, xpos), .y = @intCast(u32, ypos), .width = @intCast(u32, width), .height = @intCast(u32, height) };
+    return Workarea{ .x = @intCast(xpos), .y = @intCast(ypos), .width = @intCast(width), .height = @intCast(height) };
 }
 
 /// The physical size, in millimetres, of the display area of a monitor.
@@ -91,7 +91,7 @@ pub inline fn getPhysicalSize(self: Monitor) PhysicalSize {
     var width_mm: c_int = 0;
     var height_mm: c_int = 0;
     c.glfwGetMonitorPhysicalSize(self.handle, &width_mm, &height_mm);
-    return PhysicalSize{ .width_mm = @intCast(u32, width_mm), .height_mm = @intCast(u32, height_mm) };
+    return PhysicalSize{ .width_mm = @intCast(width_mm), .height_mm = @intCast(height_mm) };
 }
 
 /// The content scale for a monitor.
@@ -123,7 +123,7 @@ pub inline fn getContentScale(self: Monitor) ContentScale {
     var x_scale: f32 = 0;
     var y_scale: f32 = 0;
     c.glfwGetMonitorContentScale(self.handle, &x_scale, &y_scale);
-    return ContentScale{ .x_scale = @floatCast(f32, x_scale), .y_scale = @floatCast(f32, y_scale) };
+    return ContentScale{ .x_scale = @floatCast(x_scale), .y_scale = @floatCast(y_scale) };
 }
 
 /// Returns the name of the specified monitor.
@@ -140,7 +140,7 @@ pub inline fn getContentScale(self: Monitor) ContentScale {
 /// see also: monitor_properties
 pub inline fn getName(self: Monitor) [*:0]const u8 {
     internal_debug.assertInitialized();
-    if (c.glfwGetMonitorName(self.handle)) |name| return @ptrCast([*:0]const u8, name);
+    if (c.glfwGetMonitorName(self.handle)) |name| return @ptrCast(name);
     // `glfwGetMonitorName` returns `null` only for errors, but the only error is unreachable
     // (NotInitialized)
     unreachable;
@@ -176,7 +176,7 @@ pub inline fn getUserPointer(self: Monitor, comptime T: type) ?*T {
     internal_debug.assertInitialized();
     const ptr = c.glfwGetMonitorUserPointer(self.handle);
     if (ptr == null) return null;
-    return @ptrCast(*T, @alignCast(@alignOf(T), ptr.?));
+    return @ptrCast(@alignCast(ptr.?));
 }
 
 /// Returns the available video modes for the specified monitor.
@@ -200,10 +200,10 @@ pub inline fn getVideoModes(self: Monitor, allocator: mem.Allocator) mem.Allocat
     internal_debug.assertInitialized();
     var count: c_int = 0;
     if (c.glfwGetVideoModes(self.handle, &count)) |modes| {
-        const slice = try allocator.alloc(VideoMode, @intCast(u32, count));
+        const slice = try allocator.alloc(VideoMode, @intCast(count));
         var i: u32 = 0;
         while (i < count) : (i += 1) {
-            slice[i] = VideoMode{ .handle = @ptrCast([*c]const c.GLFWvidmode, modes)[i] };
+            slice[i] = VideoMode{ .handle = @as([*c]const c.GLFWvidmode, @ptrCast(modes))[i] };
         }
         return slice;
     }
@@ -325,10 +325,10 @@ pub inline fn getAll(allocator: mem.Allocator) mem.Allocator.Error![]Monitor {
     internal_debug.assertInitialized();
     var count: c_int = 0;
     if (c.glfwGetMonitors(&count)) |monitors| {
-        const slice = try allocator.alloc(Monitor, @intCast(u32, count));
+        const slice = try allocator.alloc(Monitor, @intCast(count));
         var i: u32 = 0;
         while (i < count) : (i += 1) {
-            slice[i] = Monitor{ .handle = @ptrCast([*c]const ?*c.GLFWmonitor, monitors)[i].? };
+            slice[i] = Monitor{ .handle = @as([*c]const ?*c.GLFWmonitor, @ptrCast(monitors))[i].? };
         }
         return slice;
     }
@@ -387,7 +387,7 @@ pub inline fn setCallback(comptime callback: ?fn (monitor: Monitor, event: Event
             pub fn monitorCallbackWrapper(monitor: ?*c.GLFWmonitor, event: c_int) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
                     Monitor{ .handle = monitor.? },
-                    @enumFromInt(Event, event),
+                    @as(Event, @enumFromInt(event)),
                 });
             }
         };

--- a/libs/glfw/src/VideoMode.zig
+++ b/libs/glfw/src/VideoMode.zig
@@ -11,32 +11,32 @@ handle: c.GLFWvidmode,
 
 /// Returns the width of the video mode, in screen coordinates.
 pub inline fn getWidth(self: VideoMode) u32 {
-    return @intCast(u32, self.handle.width);
+    return @intCast(self.handle.width);
 }
 
 /// Returns the height of the video mode, in screen coordinates.
 pub inline fn getHeight(self: VideoMode) u32 {
-    return @intCast(u32, self.handle.height);
+    return @intCast(self.handle.height);
 }
 
 /// Returns the bit depth of the red channel of the video mode.
 pub inline fn getRedBits(self: VideoMode) u32 {
-    return @intCast(u32, self.handle.redBits);
+    return @intCast(self.handle.redBits);
 }
 
 /// Returns the bit depth of the green channel of the video mode.
 pub inline fn getGreenBits(self: VideoMode) u32 {
-    return @intCast(u32, self.handle.greenBits);
+    return @intCast(self.handle.greenBits);
 }
 
 /// Returns the bit depth of the blue channel of the video mode.
 pub inline fn getBlueBits(self: VideoMode) u32 {
-    return @intCast(u32, self.handle.blueBits);
+    return @intCast(self.handle.blueBits);
 }
 
 /// Returns the refresh rate of the video mode, in Hz.
 pub inline fn getRefreshRate(self: VideoMode) u32 {
-    return @intCast(u32, self.handle.refreshRate);
+    return @intCast(self.handle.refreshRate);
 }
 
 test "getters" {

--- a/libs/glfw/src/Window.zig
+++ b/libs/glfw/src/Window.zig
@@ -22,7 +22,7 @@ handle: *c.GLFWwindow,
 
 /// Returns a Zig GLFW window from an underlying C GLFW window handle.
 pub inline fn from(handle: *anyopaque) Window {
-    return Window{ .handle = @ptrCast(*c.GLFWwindow, @alignCast(@alignOf(*c.GLFWwindow), handle)) };
+    return Window{ .handle = @ptrCast(@alignCast(handle)) };
 }
 
 /// Resets all window hints to their default values.
@@ -378,8 +378,8 @@ pub inline fn create(
     if (!ignore_hints_struct) hints.set();
 
     if (c.glfwCreateWindow(
-        @intCast(c_int, width),
-        @intCast(c_int, height),
+        @intCast(width),
+        @intCast(height),
         &title[0],
         if (monitor) |m| m.handle else null,
         if (share) |w| w.handle else null,
@@ -489,7 +489,7 @@ pub inline fn setIcon(self: Window, allocator: mem.Allocator, images: ?[]const I
         const tmp = try allocator.alloc(c.GLFWimage, im.len);
         defer allocator.free(tmp);
         for (im, 0..) |img, index| tmp[index] = img.toC();
-        c.glfwSetWindowIcon(self.handle, @intCast(c_int, im.len), &tmp[0]);
+        c.glfwSetWindowIcon(self.handle, @intCast(im.len), &tmp[0]);
     } else c.glfwSetWindowIcon(self.handle, 0, null);
 }
 
@@ -517,7 +517,7 @@ pub inline fn getPos(self: Window) Pos {
     var x: c_int = 0;
     var y: c_int = 0;
     c.glfwGetWindowPos(self.handle, &x, &y);
-    return Pos{ .x = @intCast(i64, x), .y = @intCast(i64, y) };
+    return Pos{ .x = @intCast(x), .y = @intCast(y) };
 }
 
 /// Sets the position of the content area of the specified window.
@@ -542,7 +542,7 @@ pub inline fn getPos(self: Window) Pos {
 /// see also: window_pos, glfw.Window.getPos
 pub inline fn setPos(self: Window, pos: Pos) void {
     internal_debug.assertInitialized();
-    c.glfwSetWindowPos(self.handle, @intCast(c_int, pos.x), @intCast(c_int, pos.y));
+    c.glfwSetWindowPos(self.handle, @intCast(pos.x), @intCast(pos.y));
 }
 
 pub const Size = struct {
@@ -567,7 +567,7 @@ pub inline fn getSize(self: Window) Size {
     var width: c_int = 0;
     var height: c_int = 0;
     c.glfwGetWindowSize(self.handle, &width, &height);
-    return Size{ .width = @intCast(u32, width), .height = @intCast(u32, height) };
+    return Size{ .width = @intCast(width), .height = @intCast(height) };
 }
 
 /// Sets the size of the content area of the specified window.
@@ -594,7 +594,7 @@ pub inline fn getSize(self: Window) Size {
 /// see also: window_size, glfw.Window.getSize, glfw.Window.SetMonitor
 pub inline fn setSize(self: Window, size: Size) void {
     internal_debug.assertInitialized();
-    c.glfwSetWindowSize(self.handle, @intCast(c_int, size.width), @intCast(c_int, size.height));
+    c.glfwSetWindowSize(self.handle, @intCast(size.width), @intCast(size.height));
 }
 
 /// A size with option width/height, used to represent e.g. constraints on a windows size while
@@ -637,10 +637,10 @@ pub inline fn setSizeLimits(self: Window, min: SizeOptional, max: SizeOptional) 
 
     c.glfwSetWindowSizeLimits(
         self.handle,
-        if (min.width) |min_width| @intCast(c_int, min_width) else glfw.dont_care,
-        if (min.height) |min_height| @intCast(c_int, min_height) else glfw.dont_care,
-        if (max.width) |max_width| @intCast(c_int, max_width) else glfw.dont_care,
-        if (max.height) |max_height| @intCast(c_int, max_height) else glfw.dont_care,
+        if (min.width) |min_width| @intCast(min_width) else glfw.dont_care,
+        if (min.height) |min_height| @intCast(min_height) else glfw.dont_care,
+        if (max.width) |max_width| @intCast(max_width) else glfw.dont_care,
+        if (max.height) |max_height| @intCast(max_height) else glfw.dont_care,
     );
 }
 
@@ -681,8 +681,8 @@ pub inline fn setAspectRatio(self: Window, numerator: ?u32, denominator: ?u32) v
 
     c.glfwSetWindowAspectRatio(
         self.handle,
-        if (numerator) |numerator_unwrapped| @intCast(c_int, numerator_unwrapped) else glfw.dont_care,
-        if (denominator) |denominator_unwrapped| @intCast(c_int, denominator_unwrapped) else glfw.dont_care,
+        if (numerator) |numerator_unwrapped| @intCast(numerator_unwrapped) else glfw.dont_care,
+        if (denominator) |denominator_unwrapped| @intCast(denominator_unwrapped) else glfw.dont_care,
     );
 }
 
@@ -702,7 +702,7 @@ pub inline fn getFramebufferSize(self: Window) Size {
     var width: c_int = 0;
     var height: c_int = 0;
     c.glfwGetFramebufferSize(self.handle, &width, &height);
-    return Size{ .width = @intCast(u32, width), .height = @intCast(u32, height) };
+    return Size{ .width = @intCast(width), .height = @intCast(height) };
 }
 
 pub const FrameSize = struct {
@@ -735,10 +735,10 @@ pub inline fn getFrameSize(self: Window) FrameSize {
     var bottom: c_int = 0;
     c.glfwGetWindowFrameSize(self.handle, &left, &top, &right, &bottom);
     return FrameSize{
-        .left = @intCast(u32, left),
-        .top = @intCast(u32, top),
-        .right = @intCast(u32, right),
-        .bottom = @intCast(u32, bottom),
+        .left = @intCast(left),
+        .top = @intCast(top),
+        .right = @intCast(right),
+        .bottom = @intCast(bottom),
     };
 }
 
@@ -1046,11 +1046,11 @@ pub inline fn setMonitor(self: Window, monitor: ?Monitor, xpos: i32, ypos: i32, 
     c.glfwSetWindowMonitor(
         self.handle,
         if (monitor) |m| m.handle else null,
-        @intCast(c_int, xpos),
-        @intCast(c_int, ypos),
-        @intCast(c_int, width),
-        @intCast(c_int, height),
-        if (refresh_rate) |refresh_rate_unwrapped| @intCast(c_int, refresh_rate_unwrapped) else glfw.dont_care,
+        @intCast(xpos),
+        @intCast(ypos),
+        @intCast(width),
+        @intCast(height),
+        if (refresh_rate) |refresh_rate_unwrapped| @intCast(refresh_rate_unwrapped) else glfw.dont_care,
     );
 }
 
@@ -1174,7 +1174,7 @@ pub inline fn setUserPointer(self: Window, pointer: ?*anyopaque) void {
 /// see also: window_userptr, glfw.Window.setUserPointer
 pub inline fn getUserPointer(self: Window, comptime T: type) ?*T {
     internal_debug.assertInitialized();
-    if (c.glfwGetWindowUserPointer(self.handle)) |user_pointer| return @ptrCast(?*T, @alignCast(@alignOf(T), user_pointer));
+    if (c.glfwGetWindowUserPointer(self.handle)) |user_pointer| return @ptrCast(@alignCast(user_pointer));
     return null;
 }
 
@@ -1206,8 +1206,8 @@ pub inline fn setPosCallback(self: Window, comptime callback: ?fn (window: Windo
             pub fn posCallbackWrapper(handle: ?*c.GLFWwindow, xpos: c_int, ypos: c_int) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
-                    @intCast(i32, xpos),
-                    @intCast(i32, ypos),
+                    @as(i32, @intCast(xpos)),
+                    @as(i32, @intCast(ypos)),
                 });
             }
         };
@@ -1239,8 +1239,8 @@ pub inline fn setSizeCallback(self: Window, comptime callback: ?fn (window: Wind
             pub fn sizeCallbackWrapper(handle: ?*c.GLFWwindow, width: c_int, height: c_int) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
-                    @intCast(i32, width),
-                    @intCast(i32, height),
+                    @as(i32, @intCast(width)),
+                    @as(i32, @intCast(height)),
                 });
             }
         };
@@ -1459,8 +1459,8 @@ pub inline fn setFramebufferSizeCallback(self: Window, comptime callback: ?fn (w
             pub fn framebufferSizeCallbackWrapper(handle: ?*c.GLFWwindow, width: c_int, height: c_int) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
-                    @intCast(u32, width),
-                    @intCast(u32, height),
+                    @as(u32, @intCast(width)),
+                    @as(u32, @intCast(height)),
                 });
             }
         };
@@ -1541,7 +1541,7 @@ pub inline fn setInputModeCursor(self: Window, value: InputModeCursor) void {
 
 /// Gets the current input mode of the cursor.
 pub inline fn getInputModeCursor(self: Window) InputModeCursor {
-    return @enumFromInt(InputModeCursor, self.getInputMode(InputMode.cursor));
+    return @enumFromInt(self.getInputMode(InputMode.cursor));
 }
 
 /// Sets the input mode of sticky keys, if enabled a key press will ensure that `glfw.Window.getKey`
@@ -1623,7 +1623,7 @@ pub inline fn getInputModeRawMouseMotion(self: Window) bool {
 pub inline fn getInputMode(self: Window, mode: InputMode) i32 {
     internal_debug.assertInitialized();
     const value = c.glfwGetInputMode(self.handle, @intFromEnum(mode));
-    return @intCast(i32, value);
+    return @intCast(value);
 }
 
 /// Sets an input option for the specified window.
@@ -1693,7 +1693,7 @@ pub inline fn setInputMode(self: Window, mode: InputMode, value: anytype) void {
 pub inline fn getKey(self: Window, key: Key) Action {
     internal_debug.assertInitialized();
     const state = c.glfwGetKey(self.handle, @intFromEnum(key));
-    return @enumFromInt(Action, state);
+    return @enumFromInt(state);
 }
 
 /// Returns the last reported state of a mouse button for the specified window.
@@ -1715,7 +1715,7 @@ pub inline fn getKey(self: Window, key: Key) Action {
 pub inline fn getMouseButton(self: Window, button: MouseButton) Action {
     internal_debug.assertInitialized();
     const state = c.glfwGetMouseButton(self.handle, @intFromEnum(button));
-    return @enumFromInt(Action, state);
+    return @enumFromInt(state);
 }
 
 pub const CursorPos = struct {
@@ -1848,9 +1848,9 @@ pub inline fn setKeyCallback(self: Window, comptime callback: ?fn (window: Windo
             pub fn keyCallbackWrapper(handle: ?*c.GLFWwindow, key: c_int, scancode: c_int, action: c_int, mods: c_int) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
-                    @enumFromInt(Key, key),
-                    @intCast(i32, scancode),
-                    @enumFromInt(Action, action),
+                    @as(Key, @enumFromInt(key)),
+                    @as(i32, @intCast(scancode)),
+                    @as(Action, @enumFromInt(action)),
                     Mods.fromInt(mods),
                 });
             }
@@ -1894,7 +1894,7 @@ pub inline fn setCharCallback(self: Window, comptime callback: ?fn (window: Wind
             pub fn charCallbackWrapper(handle: ?*c.GLFWwindow, codepoint: c_uint) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
-                    @intCast(u21, codepoint),
+                    @as(u21, @intCast(codepoint)),
                 });
             }
         };
@@ -1935,8 +1935,8 @@ pub inline fn setMouseButtonCallback(self: Window, comptime callback: ?fn (windo
             pub fn mouseButtonCallbackWrapper(handle: ?*c.GLFWwindow, button: c_int, action: c_int, mods: c_int) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
-                    @enumFromInt(MouseButton, button),
-                    @enumFromInt(Action, action),
+                    @as(MouseButton, @enumFromInt(button)),
+                    @as(Action, @enumFromInt(action)),
                     Mods.fromInt(mods),
                 });
             }
@@ -2087,7 +2087,7 @@ pub inline fn setDropCallback(self: Window, comptime callback: ?fn (window: Wind
             pub fn dropCallbackWrapper(handle: ?*c.GLFWwindow, path_count: c_int, paths: [*c][*c]const u8) callconv(.C) void {
                 @call(.always_inline, user_callback, .{
                     from(handle.?),
-                    @ptrCast([*][*:0]const u8, paths)[0..@intCast(u32, path_count)],
+                    @as([*][*:0]const u8, @ptrCast(paths))[0..@intCast(path_count)],
                 });
             }
         };
@@ -2125,15 +2125,15 @@ inline fn hint(h: Hint, value: anytype) void {
 
     switch (value_type_info) {
         .Int, .ComptimeInt => {
-            c.glfwWindowHint(@intFromEnum(h), @intCast(c_int, value));
+            c.glfwWindowHint(@intFromEnum(h), @intCast(value));
         },
         .Bool => {
             const int_value = @intFromBool(value);
-            c.glfwWindowHint(@intFromEnum(h), @intCast(c_int, int_value));
+            c.glfwWindowHint(@intFromEnum(h), @intCast(int_value));
         },
         .Enum => {
             const int_value = @intFromEnum(value);
-            c.glfwWindowHint(@intFromEnum(h), @intCast(c_int, int_value));
+            c.glfwWindowHint(@intFromEnum(h), @intCast(int_value));
         },
         .Array => |arr_type| {
             if (arr_type.child != u8) {

--- a/libs/glfw/src/clipboard.zig
+++ b/libs/glfw/src/clipboard.zig
@@ -42,7 +42,7 @@ pub inline fn setClipboardString(value: [*:0]const u8) void {
 /// see also: clipboard, glfwSetClipboardString
 pub inline fn getClipboardString() ?[:0]const u8 {
     internal_debug.assertInitialized();
-    if (c.glfwGetClipboardString(null)) |c_str| return std.mem.span(@ptrCast([*:0]const u8, c_str));
+    if (c.glfwGetClipboardString(null)) |c_str| return std.mem.span(@as([*:0]const u8, @ptrCast(c_str)));
     return null;
 }
 

--- a/libs/glfw/src/hat.zig
+++ b/libs/glfw/src/hat.zig
@@ -26,12 +26,12 @@ pub const Hat = packed struct(u8) {
 
     pub inline fn toInt(self: Hat, comptime IntType: type) IntType {
         verifyIntType(IntType);
-        return @intCast(IntType, @bitCast(u8, self));
+        return @intCast(@as(u8, @bitCast(self)));
     }
 
     pub inline fn fromInt(flags: anytype) Hat {
         verifyIntType(@TypeOf(flags));
-        return @bitCast(Hat, @intCast(u8, flags));
+        return @bitCast(@as(u8, @intCast(flags)));
     }
 };
 

--- a/libs/glfw/src/key.zig
+++ b/libs/glfw/src/key.zig
@@ -150,7 +150,7 @@ pub const Key = enum(c_int) {
     menu = cc.GLFW_KEY_MENU,
 
     pub inline fn last() Key {
-        return @enumFromInt(Key, cc.GLFW_KEY_LAST);
+        return @enumFromInt(cc.GLFW_KEY_LAST);
     }
 
     /// Returns the layout-specific name of the specified printable key.
@@ -215,9 +215,9 @@ pub const Key = enum(c_int) {
     /// see also: input_key_name
     pub inline fn getName(self: Key, scancode: i32) ?[:0]const u8 {
         internal_debug.assertInitialized();
-        const name_opt = cc.glfwGetKeyName(@intFromEnum(self), @intCast(c_int, scancode));
+        const name_opt = cc.glfwGetKeyName(@intFromEnum(self), @intCast(scancode));
         return if (name_opt) |name|
-            std.mem.span(@ptrCast([*:0]const u8, name))
+            std.mem.span(@as([*:0]const u8, @ptrCast(name)))
         else
             null;
     }

--- a/libs/glfw/src/main.zig
+++ b/libs/glfw/src/main.zig
@@ -273,9 +273,9 @@ pub const PlatformType = enum(c_int) {
 fn initHint(hint: InitHint, value: anytype) void {
     switch (@typeInfo(@TypeOf(value))) {
         .Int, .ComptimeInt => {
-            c.glfwInitHint(@intFromEnum(hint), @intCast(c_int, value));
+            c.glfwInitHint(@intFromEnum(hint), @intCast(value));
         },
-        .Bool => c.glfwInitHint(@intFromEnum(hint), @intCast(c_int, @intFromBool(value))),
+        .Bool => c.glfwInitHint(@intFromEnum(hint), @intCast(@intFromBool(value))),
         else => @compileError("expected a int or bool, got " ++ @typeName(@TypeOf(value))),
     }
 }
@@ -301,7 +301,7 @@ fn initHint(hint: InitHint, value: anytype) void {
 ///
 /// thread_safety: This function may be called from any thread.
 pub inline fn getVersionString() [:0]const u8 {
-    return std.mem.span(@ptrCast([*:0]const u8, c.glfwGetVersionString()));
+    return std.mem.span(@as([*:0]const u8, @ptrCast(c.glfwGetVersionString())));
 }
 
 /// Returns the currently selected platform.
@@ -313,7 +313,7 @@ pub inline fn getVersionString() [:0]const u8 {
 /// thread_safety: This function may be called from any thread.
 pub fn getPlatform() PlatformType {
     internal_debug.assertInitialized();
-    return @enumFromInt(PlatformType, c.glfwGetPlatform());
+    return @enumFromInt(c.glfwGetPlatform());
 }
 
 /// Returns whether the library includes support for the specified platform.

--- a/libs/glfw/src/mod.zig
+++ b/libs/glfw/src/mod.zig
@@ -26,12 +26,12 @@ pub const Mods = packed struct(u8) {
 
     pub inline fn toInt(self: Mods, comptime IntType: type) IntType {
         verifyIntType(IntType);
-        return @intCast(IntType, @bitCast(u8, self));
+        return @intCast(@as(u8, @bitCast(self)));
     }
 
     pub inline fn fromInt(flags: anytype) Mods {
         verifyIntType(@TypeOf(flags));
-        return @bitCast(Mods, @intCast(u8, flags));
+        return @bitCast(@as(u8, @intCast(flags)));
     }
 };
 

--- a/libs/glfw/src/native.zig
+++ b/libs/glfw/src/native.zig
@@ -61,7 +61,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWin32Adapter(monitor: Monitor) [*:0]const u8 {
             internal_debug.assertInitialized();
-            if (native.glfwGetWin32Adapter(@ptrCast(*native.GLFWmonitor, monitor.handle))) |adapter| return adapter;
+            if (native.glfwGetWin32Adapter(@ptrCast(monitor.handle))) |adapter| return adapter;
             // `glfwGetWin32Adapter` returns `null` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -75,7 +75,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWin32Monitor(monitor: Monitor) [*:0]const u8 {
             internal_debug.assertInitialized();
-            if (native.glfwGetWin32Monitor(@ptrCast(*native.GLFWmonitor, monitor.handle))) |mon| return mon;
+            if (native.glfwGetWin32Monitor(@ptrCast(monitor.handle))) |mon| return mon;
             // `glfwGetWin32Monitor` returns `null` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -94,8 +94,8 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWin32Window(window: Window) std.os.windows.HWND {
             internal_debug.assertInitialized();
-            if (native.glfwGetWin32Window(@ptrCast(*native.GLFWwindow, window.handle))) |win|
-                return @ptrCast(std.os.windows.HWND, win);
+            if (native.glfwGetWin32Window(@ptrCast(window.handle))) |win|
+                return @ptrCast(win);
             // `glfwGetWin32Window` returns `null` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -117,7 +117,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWGLContext(window: Window) ?std.os.windows.HGLRC {
             internal_debug.assertInitialized();
-            if (native.glfwGetWGLContext(@ptrCast(*native.GLFWwindow, window.handle))) |context| return context;
+            if (native.glfwGetWGLContext(@ptrCast(window.handle))) |context| return context;
             return null;
         }
 
@@ -126,7 +126,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getCocoaMonitor(monitor: Monitor) u32 {
             internal_debug.assertInitialized();
-            const mon = native.glfwGetCocoaMonitor(@ptrCast(*native.GLFWmonitor, monitor.handle));
+            const mon = native.glfwGetCocoaMonitor(@ptrCast(monitor.handle));
             if (mon != native.kCGNullDirectDisplay) return mon;
             // `glfwGetCocoaMonitor` returns `kCGNullDirectDisplay` only for errors
             // but the only potential error is unreachable (NotInitialized)
@@ -138,7 +138,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getCocoaWindow(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
-            return native.glfwGetCocoaWindow(@ptrCast(*native.GLFWwindow, window.handle));
+            return native.glfwGetCocoaWindow(@ptrCast(window.handle));
         }
 
         /// Returns the `NSWindow` of the specified window.
@@ -148,7 +148,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getNSGLContext(window: Window) u32 {
             internal_debug.assertInitialized();
-            return native.glfwGetNSGLContext(@ptrCast(*native.GLFWwindow, window.handle));
+            return native.glfwGetNSGLContext(@ptrCast(window.handle));
         }
 
         /// Returns the `Display` used by GLFW.
@@ -156,7 +156,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getX11Display() *anyopaque {
             internal_debug.assertInitialized();
-            if (native.glfwGetX11Display()) |display| return @ptrCast(*anyopaque, display);
+            if (native.glfwGetX11Display()) |display| return @ptrCast(display);
             // `glfwGetX11Display` returns `null` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -167,7 +167,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getX11Adapter(monitor: Monitor) u32 {
             internal_debug.assertInitialized();
-            const adapter = native.glfwGetX11Adapter(@ptrCast(*native.GLFWMonitor, monitor.handle));
+            const adapter = native.glfwGetX11Adapter(@ptrCast(monitor.handle));
             if (adapter != 0) return adapter;
             // `glfwGetX11Adapter` returns `0` only for errors
             // but the only potential error is unreachable (NotInitialized)
@@ -179,7 +179,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getX11Monitor(monitor: Monitor) u32 {
             internal_debug.assertInitialized();
-            const mon = native.glfwGetX11Monitor(@ptrCast(*native.GLFWmonitor, monitor.handle));
+            const mon = native.glfwGetX11Monitor(@ptrCast(monitor.handle));
             if (mon != 0) return mon;
             // `glfwGetX11Monitor` returns `0` only for errors
             // but the only potential error is unreachable (NotInitialized)
@@ -191,8 +191,8 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getX11Window(window: Window) u32 {
             internal_debug.assertInitialized();
-            const win = native.glfwGetX11Window(@ptrCast(*native.GLFWwindow, window.handle));
-            if (win != 0) return @intCast(u32, win);
+            const win = native.glfwGetX11Window(@ptrCast(window.handle));
+            if (win != 0) return @intCast(win);
             // `glfwGetX11Window` returns `0` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -234,7 +234,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getGLXContext(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
-            if (native.glfwGetGLXContext(@ptrCast(*native.GLFWwindow, window.handle))) |context| return @ptrCast(*anyopaque, context);
+            if (native.glfwGetGLXContext(@ptrCast(window.handle))) |context| return @ptrCast(context);
             return null;
         }
 
@@ -246,8 +246,8 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getGLXWindow(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
-            const win = native.glfwGetGLXWindow(@ptrCast(*native.GLFWwindow, window.handle));
-            if (win != 0) return @ptrCast(*anyopaque, win);
+            const win = native.glfwGetGLXWindow(@ptrCast(window.handle));
+            if (win != 0) return @ptrCast(win);
             return null;
         }
 
@@ -256,7 +256,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWaylandDisplay() *anyopaque {
             internal_debug.assertInitialized();
-            if (native.glfwGetWaylandDisplay()) |display| return @ptrCast(*anyopaque, display);
+            if (native.glfwGetWaylandDisplay()) |display| return @ptrCast(display);
             // `glfwGetWaylandDisplay` returns `null` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -267,7 +267,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWaylandMonitor(monitor: Monitor) *anyopaque {
             internal_debug.assertInitialized();
-            if (native.glfwGetWaylandMonitor(@ptrCast(*native.GLFWmonitor, monitor.handle))) |mon| return @ptrCast(*anyopaque, mon);
+            if (native.glfwGetWaylandMonitor(@ptrCast(monitor.handle))) |mon| return @ptrCast(mon);
             // `glfwGetWaylandMonitor` returns `null` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -278,7 +278,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getWaylandWindow(window: Window) *anyopaque {
             internal_debug.assertInitialized();
-            if (native.glfwGetWaylandWindow(@ptrCast(*native.GLFWwindow, window.handle))) |win| return @ptrCast(*anyopaque, win);
+            if (native.glfwGetWaylandWindow(@ptrCast(window.handle))) |win| return @ptrCast(win);
             // `glfwGetWaylandWindow` returns `null` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -293,7 +293,7 @@ pub fn Native(comptime options: BackendOptions) type {
         pub fn getEGLDisplay() *anyopaque {
             internal_debug.assertInitialized();
             const display = native.glfwGetEGLDisplay();
-            if (display != native.EGL_NO_DISPLAY) return @ptrCast(*anyopaque, display);
+            if (display != native.EGL_NO_DISPLAY) return @ptrCast(display);
             // `glfwGetEGLDisplay` returns `EGL_NO_DISPLAY` only for errors
             // but the only potential error is unreachable (NotInitialized)
             unreachable;
@@ -307,8 +307,8 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety This function may be called from any thread. Access is not synchronized.
         pub fn getEGLContext(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
-            const context = native.glfwGetEGLContext(@ptrCast(*native.GLFWwindow, window.handle));
-            if (context != native.EGL_NO_CONTEXT) return @ptrCast(*anyopaque, context);
+            const context = native.glfwGetEGLContext(@ptrCast(window.handle));
+            if (context != native.EGL_NO_CONTEXT) return @ptrCast(context);
             return null;
         }
 
@@ -319,8 +319,8 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety This function may be called from any thread. Access is not synchronized.
         pub fn getEGLSurface(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
-            const surface = native.glfwGetEGLSurface(@ptrCast(*native.GLFWwindow, window.handle));
-            if (surface != native.EGL_NO_SURFACE) return @ptrCast(*anyopaque, surface);
+            const surface = native.glfwGetEGLSurface(@ptrCast(window.handle));
+            if (surface != native.EGL_NO_SURFACE) return @ptrCast(surface);
             return null;
         }
 
@@ -341,7 +341,7 @@ pub fn Native(comptime options: BackendOptions) type {
             internal_debug.assertInitialized();
             var buf: OSMesaColorBuffer = undefined;
             if (native.glfwGetOSMesaColorBuffer(
-                @ptrCast(*native.GLFWwindow, window.handle),
+                @ptrCast(window.handle),
                 &buf.width,
                 &buf.height,
                 &buf.format,
@@ -367,7 +367,7 @@ pub fn Native(comptime options: BackendOptions) type {
             internal_debug.assertInitialized();
             var buf: OSMesaDepthBuffer = undefined;
             if (native.glfwGetOSMesaDepthBuffer(
-                @ptrCast(*native.GLFWwindow, window.handle),
+                @ptrCast(window.handle),
                 &buf.width,
                 &buf.height,
                 &buf.bytes_per_value,
@@ -383,7 +383,7 @@ pub fn Native(comptime options: BackendOptions) type {
         /// thread_safety: This function may be called from any thread. Access is not synchronized.
         pub fn getOSMesaContext(window: Window) ?*anyopaque {
             internal_debug.assertInitialized();
-            if (native.glfwGetOSMesaContext(@ptrCast(*native.GLFWwindow, window.handle))) |context| return @ptrCast(*anyopaque, context);
+            if (native.glfwGetOSMesaContext(@ptrCast(window.handle))) |context| return @ptrCast(context);
             return null;
         }
     };

--- a/libs/glfw/src/opengl.zig
+++ b/libs/glfw/src/opengl.zig
@@ -85,7 +85,7 @@ pub inline fn getCurrentContext() ?Window {
 /// see also: buffer_swap, glfwSwapBuffers
 pub inline fn swapInterval(interval: i32) void {
     internal_debug.assertInitialized();
-    c.glfwSwapInterval(@intCast(c_int, interval));
+    c.glfwSwapInterval(@intCast(interval));
 }
 
 /// Returns whether the specified extension is available.

--- a/libs/glfw/src/vulkan.zig
+++ b/libs/glfw/src/vulkan.zig
@@ -84,7 +84,7 @@ pub inline fn vulkanSupported() bool {
 pub inline fn getRequiredInstanceExtensions() ?[][*:0]const u8 {
     internal_debug.assertInitialized();
     var count: u32 = 0;
-    if (c.glfwGetRequiredInstanceExtensions(&count)) |extensions| return @ptrCast([*][*:0]const u8, extensions)[0..count];
+    if (c.glfwGetRequiredInstanceExtensions(&count)) |extensions| return @as([*][*:0]const u8, @ptrCast(extensions))[0..count];
     return null;
 }
 
@@ -128,7 +128,7 @@ pub const VKProc = *const fn () callconv(.C) void;
 /// @thread_safety This function may be called from any thread.
 pub fn getInstanceProcAddress(vk_instance: ?*anyopaque, proc_name: [*:0]const u8) callconv(.C) ?VKProc {
     internal_debug.assertInitialized();
-    if (c.glfwGetInstanceProcAddress(if (vk_instance) |v| @ptrCast(c.VkInstance, v) else null, proc_name)) |proc_address| return proc_address;
+    if (c.glfwGetInstanceProcAddress(if (vk_instance) |v| @ptrCast(v) else null, proc_name)) |proc_address| return proc_address;
     return null;
 }
 
@@ -165,8 +165,8 @@ pub inline fn getPhysicalDevicePresentationSupport(
 ) bool {
     internal_debug.assertInitialized();
     return c.glfwGetPhysicalDevicePresentationSupport(
-        @ptrCast(c.VkInstance, vk_instance),
-        @ptrCast(c.VkPhysicalDevice, vk_physical_device),
+        @ptrCast(vk_instance),
+        @ptrCast(vk_physical_device),
         queue_family,
     ) == c.GLFW_TRUE;
 }
@@ -231,15 +231,15 @@ pub inline fn createWindowSurface(vk_instance: anytype, window: Window, vk_alloc
     // zig-vulkan uses enums to represent opaque pointers:
     // pub const Instance = enum(usize) { null_handle = 0, _ };
     const instance: c.VkInstance = switch (@typeInfo(@TypeOf(vk_instance))) {
-        .Enum => @ptrFromInt(c.VkInstance, @intFromEnum(vk_instance)),
-        else => @ptrCast(c.VkInstance, vk_instance),
+        .Enum => @ptrFromInt(@intFromEnum(vk_instance)),
+        else => @ptrCast(vk_instance),
     };
 
     return c.glfwCreateWindowSurface(
         instance,
         window.handle,
-        if (vk_allocation_callbacks == null) null else @ptrCast(*const c.VkAllocationCallbacks, @alignCast(@alignOf(c.VkAllocationCallbacks), vk_allocation_callbacks)),
-        @ptrCast(*c.VkSurfaceKHR, @alignCast(@alignOf(c.VkSurfaceKHR), vk_surface_khr)),
+        if (vk_allocation_callbacks == null) null else @ptrCast(@alignCast(vk_allocation_callbacks)),
+        @ptrCast(@alignCast(vk_surface_khr)),
     );
 }
 


### PR DESCRIPTION
This [Zig PR](https://github.com/ziglang/zig/pull/16163) changes the way casts work in Zig.

This mach-glfw PR updates the code using the new syntax.

For more details about this change in Zig check out [the official wiki](https://github.com/ziglang/zig/wiki/Using-Cast-Result-Type-Inference).



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.