### PR TITLE
glfw: Fixed all uses of the alignCast builtin

### DIFF
--- a/libs/glfw/src/Joystick.zig
+++ b/libs/glfw/src/Joystick.zig
@@ -296,7 +296,7 @@ pub inline fn setUserPointer(self: Joystick, comptime T: type, pointer: *T) void
 pub inline fn getUserPointer(self: Joystick, comptime PointerType: type) ?PointerType {
     internal_debug.assertInitialized();
     const ptr = c.glfwGetJoystickUserPointer(@intFromEnum(self.jid));
-    if (ptr) |p| return @as(PointerType, @ptrCast(@alignCast(@alignOf(std.meta.Child(PointerType)), p)));
+    if (ptr) |p| return @as(PointerType, @ptrCast(@alignCast(p)));
     return null;
 }
 

--- a/libs/glfw/src/Monitor.zig
+++ b/libs/glfw/src/Monitor.zig
@@ -176,7 +176,7 @@ pub inline fn getUserPointer(self: Monitor, comptime T: type) ?*T {
     internal_debug.assertInitialized();
     const ptr = c.glfwGetMonitorUserPointer(self.handle);
     if (ptr == null) return null;
-    return @as(*T, @ptrCast(@alignCast(@alignOf(T), ptr.?)));
+    return @as(*T, @ptrCast(@alignCast(ptr.?)));
 }
 
 /// Returns the available video modes for the specified monitor.

--- a/libs/glfw/src/Window.zig
+++ b/libs/glfw/src/Window.zig
@@ -22,7 +22,7 @@ handle: *c.GLFWwindow,
 
 /// Returns a Zig GLFW window from an underlying C GLFW window handle.
 pub inline fn from(handle: *anyopaque) Window {
-    return Window{ .handle = @as(*c.GLFWwindow, @ptrCast(@alignCast(@alignOf(*c.GLFWwindow), handle))) };
+    return Window{ .handle = @as(*c.GLFWwindow, @ptrCast(@alignCast(handle))) };
 }
 
 /// Resets all window hints to their default values.
@@ -1174,7 +1174,7 @@ pub inline fn setUserPointer(self: Window, pointer: ?*anyopaque) void {
 /// see also: window_userptr, glfw.Window.setUserPointer
 pub inline fn getUserPointer(self: Window, comptime T: type) ?*T {
     internal_debug.assertInitialized();
-    if (c.glfwGetWindowUserPointer(self.handle)) |user_pointer| return @as(?*T, @ptrCast(@alignCast(@alignOf(T), user_pointer)));
+    if (c.glfwGetWindowUserPointer(self.handle)) |user_pointer| return @as(?*T, @ptrCast(@alignCast(user_pointer)));
     return null;
 }
 

--- a/libs/glfw/src/vulkan.zig
+++ b/libs/glfw/src/vulkan.zig
@@ -238,8 +238,8 @@ pub inline fn createWindowSurface(vk_instance: anytype, window: Window, vk_alloc
     return c.glfwCreateWindowSurface(
         instance,
         window.handle,
-        if (vk_allocation_callbacks == null) null else @as(*const c.VkAllocationCallbacks, @ptrCast(@alignCast(@alignOf(c.VkAllocationCallbacks), vk_allocation_callbacks))),
-        @as(*c.VkSurfaceKHR, @ptrCast(@alignCast(@alignOf(c.VkSurfaceKHR), vk_surface_khr))),
+        if (vk_allocation_callbacks == null) null else @as(*const c.VkAllocationCallbacks, @ptrCast(@alignCast(vk_allocation_callbacks))),
+        @as(*c.VkSurfaceKHR, @ptrCast(@alignCast(vk_surface_khr))),
     );
 }
 


### PR DESCRIPTION
Fixed uses of alignCast where zig fmt was unable to.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.