### PR TITLE
math: add initial Quaternion implementation

### DIFF
--- a/src/math/quat.zig
+++ b/src/math/quat.zig
@@ -27,7 +27,7 @@ pub fn Quat(comptime Scalar: type) type {
             const halfAngle = angle * 0.5;
             const s = std.math.sin(halfAngle);
 
-            return init(s * axis[0], s * axis[1], s * axis[2], std.math.cos(halfAngle));
+            return init(s * axis.x(), s * axis.y(), s * axis.z(), std.math.cos(halfAngle));
         }
     };
 }
@@ -46,7 +46,10 @@ test "init" {
 
 test "fromAxisAngle" {
     const expected = math.Quat.init(0.383, 0.0, 0.0, 0.924); // Expected values for a 45-degree rotation around the x-axis
-    const actual = math.Quat.fromAxisAngle(math.Axis{ .x = 1.0 }, 0.785398); // 45 degrees in radians (π/4) around the x-axis
+    const actual = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), 0.785398); // 45 degrees in radians (π/4) around the x-axis
 
-    try testing.expect(math.Quat, actual).eql(expected);
+    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
+    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
+    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
+    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
 }

--- a/src/math/quat.zig
+++ b/src/math/quat.zig
@@ -15,8 +15,19 @@ pub fn Quat(comptime Scalar: type) type {
         /// The underlying Vec type, e.g. math.Vec4, math.Vec4h, math.Vec4d
         pub const Vec = vec.Vec(4, Scalar);
 
+        /// The Vec type used to represent axes, e.g. math.Vec3
+        pub const Axis = vec.Vec(3, Scalar);
+
         pub inline fn init(x: T, y: T, z: T, w: T) Quat(Scalar) {
             return .{ .v = math.vec4(x, y, z, w) };
+        }
+
+        /// Creates a Quaternion based on the given `axis` and `angle`, and returns it.
+        pub inline fn fromAxisAngle(axis: Axis, angle: T) Quat(Scalar) {
+            const halfAngle = angle * 0.5;
+            const s = std.math.sin(halfAngle);
+
+            return init(s * axis[0], s * axis[1], s * axis[2], std.math.cos(halfAngle));
         }
     };
 }
@@ -31,4 +42,11 @@ test "init" {
     try testing.expect(math.Quat, math.quat(1, 2, 3, 4)).eql(math.Quat{
         .v = math.vec4(1, 2, 3, 4),
     });
+}
+
+test "fromAxisAngle" {
+    const expected = math.Quat.init(0.383, 0.0, 0.0, 0.924); // Expected values for a 45-degree rotation around the x-axis
+    const actual = math.Quat.fromAxisAngle(math.Axis{ .x = 1.0 }, 0.785398); // 45 degrees in radians (π/4) around the x-axis
+
+    try testing.expect(math.Quat, actual).eql(expected);
 }

--- a/src/math/quat.zig
+++ b/src/math/quat.zig
@@ -228,7 +228,12 @@ pub fn Quat(comptime Scalar: type) type {
             const sz = std.math.sin(zHalf);
             const cz = std.math.cos(zHalf);
 
-            return init(sx * cy * cz + cx * sy * sz, cx * sy * cz - sx * cy * sz, cx * cy * sz + sx * sy * cz, cx * cy * cz - sx * sy * sz);
+            const xRet = sx * cy * cz + cx * sy * sz;
+            const yRet = cx * sy * cz - sx * cy * sz;
+            const zRet = cx * cy * sz + sx * sy * cz;
+            const wRet = cx * cy * cz - sx * sy * sz;
+
+            return init(xRet, yRet, zRet, wRet);
         }
 
         /// Returns the dot product of two quaternions.
@@ -238,7 +243,12 @@ pub fn Quat(comptime Scalar: type) type {
 
         /// Linearly interpolates between two quaternions.
         pub inline fn lerp(a: *const Quat(T), b: *const Quat(T), t: T) Quat(T) {
-            return init(a.v.x() + t * (b.v.x() - a.v.x()), a.v.y() + t * (b.v.y() - a.v.y()), a.v.z() + t * (b.v.z() - a.v.z()), a.v.w() + t * (b.v.w() - a.v.w()));
+            const xRet = a.v.x() + t * (b.v.x() - a.v.x());
+            const yRet = a.v.y() + t * (b.v.y() - a.v.y());
+            const zRet = a.v.z() + t * (b.v.z() - a.v.z());
+            const wRet = a.v.w() + t * (b.v.w() - a.v.w());
+
+            return init(xRet, yRet, zRet, wRet);
         }
 
         /// Computes the squared length of a given quaternion.
@@ -283,30 +293,32 @@ test "init" {
 
 test "inverse" {
     const q = math.Quat.init(1.0, 2.0, 3.0, 4.0);
-    const expected = math.Quat.init(-0.0333333, -0.0666667, -0.1, 0.133333);
+    const expected = math.Quat.init(-0.0333333, -0.0666667, -0.1, 0.1333333);
     const actual = q.inverse();
+    std.log.debug("actual: {any}", .{actual});
+    std.log.debug("expected: {any}", .{expected});
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "fromAxisAngle" {
-    const expected = math.Quat.init(0.383, 0.0, 0.0, 0.924); // Expected values for a 45-degree rotation around the x-axis
-    const actual = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), 0.785398); // 45 degrees in radians (π/4) around the x-axis
+    const expected = math.Quat.identity().rotateX(math.pi / 4.0);
+    const actual = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), math.pi / 4.0); // 45 degrees in radians (π/4) around the x-axis
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "angleBetween" {
     const a = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), 1.0);
     const b = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), -1.0);
 
-    try testing.expect(f32, math.Quat.angleBetween(&a, &b)).eqlApprox(2.0, 0.001);
+    try testing.expect(f32, math.Quat.angleBetween(&a, &b)).eql(2.0);
 }
 
 test "mul" {
@@ -315,10 +327,10 @@ test "mul" {
     const expected = math.Quat.identity();
     const actual = math.Quat.mul(&a, &b);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "add" {
@@ -327,10 +339,10 @@ test "add" {
     const expected = math.Quat.init(6.0, 8.0, 10.0, 12.0);
     const actual = math.Quat.add(&a, &b);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "sub" {
@@ -339,10 +351,10 @@ test "sub" {
     const expected = math.Quat.init(-4.0, -4.0, -4.0, -4.0);
     const actual = math.Quat.sub(&a, &b);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "mulScalar" {
@@ -350,10 +362,10 @@ test "mulScalar" {
     const expected = math.Quat.init(2.0, 4.0, 6.0, 8.0);
     const actual = math.Quat.mulScalar(&q, 2.0);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "divScalar" {
@@ -361,43 +373,40 @@ test "divScalar" {
     const expected = math.Quat.init(0.5, 1.0, 1.5, 2.0);
     const actual = math.Quat.divScalar(&q, 2.0);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "rotateX" {
-    const q = math.Quat.identity();
-    const expected = math.Quat.init(0.383, 0.0, 0.0, 0.924); // Expected values for a 45-degree rotation around the x-axis
-    const actual = math.Quat.rotateX(&q, 0.785398);
+    const expected = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), math.pi / 4.0);
+    const actual = math.Quat.identity().rotateX(math.pi / 4.0);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "rotateY" {
-    const q = math.Quat.identity();
-    const expected = math.Quat.init(0.0, 0.383, 0.0, 0.924); // Expected values for a 45-degree rotation around the y-axis
-    const actual = math.Quat.rotateY(&q, 0.785398);
+    const expected = math.Quat.fromAxisAngle(math.vec3(0, 1, 0), math.pi / 4.0);
+    const actual = math.Quat.identity().rotateY(math.pi / 4.0);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "rotateZ" {
-    const q = math.Quat.identity();
-    const expected = math.Quat.init(0.0, 0.0, 0.383, 0.924); // Expected values for a 45-degree rotation around the z-axis
-    const actual = math.Quat.rotateZ(&q, 0.785398);
+    const expected = math.Quat.fromAxisAngle(math.vec3(0, 0, 1), math.pi / 4.0);
+    const actual = math.Quat.identity().rotateZ(math.pi / 4.0);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "slerp" {
@@ -406,10 +415,10 @@ test "slerp" {
     const expected = math.Quat.init(3.0, 4.0, 5.0, 6.0);
     const actual = math.Quat.slerp(&a, &b, 0.5);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "conjugate" {
@@ -417,14 +426,14 @@ test "conjugate" {
     const expected = math.Quat.init(-1.0, -2.0, -3.0, 4.0);
     const actual = math.Quat.conjugate(&q);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "fromMat4" {
-    const m = math.Mat4x4.rotateX(0.785398);
+    const m = math.Mat4x4.rotateX(math.pi / 4.0);
     const q = math.Quat.fromMat(math.Mat4x4, &m);
 
     try testing.expect(f32, q.v.x()).eqlApprox(0.383, 0.001);
@@ -434,7 +443,7 @@ test "fromMat4" {
 }
 
 test "fromEuler" {
-    const q = math.Quat.fromEuler(0.785398, 0.0, 0.0);
+    const q = math.Quat.fromEuler(math.pi / 4.0, 0.0, 0.0);
 
     try testing.expect(f32, q.v.x()).eqlApprox(0.383, 0.001);
     try testing.expect(f32, q.v.y()).eqlApprox(0.0, 0.001);
@@ -457,10 +466,10 @@ test "lerp" {
     const expected = math.Quat.init(3.0, 4.0, 5.0, 6.0);
     const actual = math.Quat.lerp(&a, &b, 0.5);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }
 
 test "len2" {
@@ -484,8 +493,8 @@ test "normalize" {
     const expected = math.Quat.init(0.0, 0.0, 0.6, 0.8);
     const actual = math.Quat.normalize(&q);
 
-    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
-    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
-    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
-    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
+    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
+    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
+    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
 }

--- a/src/math/quat.zig
+++ b/src/math/quat.zig
@@ -4,6 +4,7 @@ const mach = @import("../main.zig");
 const testing = mach.testing;
 const math = mach.math;
 const vec = @import("vec.zig");
+const mat = @import("mat.zig");
 
 pub fn Quat(comptime Scalar: type) type {
     return extern struct {
@@ -18,16 +19,197 @@ pub fn Quat(comptime Scalar: type) type {
         /// The Vec type used to represent axes, e.g. math.Vec3
         pub const Axis = vec.Vec(3, Scalar);
 
-        pub inline fn init(x: T, y: T, z: T, w: T) Quat(Scalar) {
+        /// Creates a quaternion from the given x, y, z, and w values
+        pub inline fn init(x: T, y: T, z: T, w: T) Quat(T) {
             return .{ .v = math.vec4(x, y, z, w) };
         }
 
+        /// Returns the identity quaternion.
+        pub inline fn identity() Quat(T) {
+            return init(0, 0, 0, 1);
+        }
+
+        /// Returns the inverse of the quaternion.
+        pub inline fn inverse(q: *const Quat(T)) Quat(T) {
+            const len2 = q.v.len2();
+            const s = 1 / len2;
+            return init(-q.v.x() * s, -q.v.y() * s, -q.v.z() * s, q.v.w() * s);
+        }
+
         /// Creates a Quaternion based on the given `axis` and `angle`, and returns it.
-        pub inline fn fromAxisAngle(axis: Axis, angle: T) Quat(Scalar) {
+        pub inline fn fromAxisAngle(axis: Axis, angle: T) Quat(T) {
             const halfAngle = angle * 0.5;
             const s = std.math.sin(halfAngle);
 
             return init(s * axis.x(), s * axis.y(), s * axis.z(), std.math.cos(halfAngle));
+        }
+
+        /// Calculates the angle between two given quaternions.
+        pub inline fn angleBetween(a: *const Quat(T), b: *const Quat(T)) T {
+            const d = Vec.dot(&a.v, &b.v);
+            return std.math.acos(2 * d * d - 1);
+        }
+
+        /// Multiplies two quaternions
+        pub inline fn mul(a: *const Quat(T), b: *const Quat(T)) Quat(T) {
+            const ax = a.v.x();
+            const ay = a.v.y();
+            const az = a.v.z();
+            const aw = a.v.w();
+            const bx = b.v.x();
+            const by = b.v.y();
+            const bz = b.v.z();
+            const bw = b.v.w();
+
+            const x = aw * bx + ax * bw + ay * bz - az * by;
+            const y = aw * by + ay * bw + az * bx - ax * bz;
+            const z = aw * bz + az * bw + ax * by - ay * bx;
+            const w = aw * bw - ax * bx - ay * by - az * bz;
+
+            return init(x, y, z, w);
+        }
+
+        /// Rotates the give quaternion by the given angle, around the x-axis.
+        pub inline fn rotateX(q: *const Quat(T), angle: T) Quat(T) {
+            const halfAngle = angle * 0.5;
+
+            const qx = q.v.x();
+            const qy = q.v.y();
+            const qz = q.v.z();
+            const qw = q.v.w();
+
+            const bx = std.math.sin(halfAngle);
+            const bw = std.math.cos(halfAngle);
+
+            return init(qx * bw + qw * bx, qy * bw + qz * bx, qz * bw - qy * bx, qw * bw - qx * bx);
+        }
+
+        /// Rotates the give quaternion by the given angle, around the y-axis.
+        pub inline fn rotateY(q: *const Quat(T), angle: T) Quat(T) {
+            const halfAngle = angle * 0.5;
+
+            const qx = q.v.x();
+            const qy = q.v.y();
+            const qz = q.v.z();
+            const qw = q.v.w();
+
+            const by = std.math.sin(halfAngle);
+            const bw = std.math.cos(halfAngle);
+
+            return init(qx * bw - qz * by, qy * bw + qw * by, qz * bw + qx * by, qw * bw - qy * by);
+        }
+
+        /// Rotates the give quaternion by the given angle, around the z-axis.
+        pub inline fn rotateZ(q: *const Quat(T), angle: T) Quat(T) {
+            const halfAngle = angle * 0.5;
+
+            const qx = q.v.x();
+            const qy = q.v.y();
+            const qz = q.v.z();
+            const qw = q.v.w();
+
+            const bz = std.math.sin(halfAngle);
+            const bw = std.math.cos(halfAngle);
+
+            return init(qx * bw - qy * bz, qy * bw + qx * bz, qz * bw + qw * bz, qw * bw - qz * bz);
+        }
+
+        /// Calculates the spherical linear interpolation between two quaternions.
+        pub inline fn slerp(a: *const Quat(T), b: *const Quat(T), t: T) Quat(T) {
+            const ax = a.v.x();
+            const ay = a.v.y();
+            const az = a.v.z();
+            const aw = a.v.w();
+
+            var bx = b.v.x();
+            var by = b.v.y();
+            var bz = b.v.z();
+            var bw = b.v.w();
+
+            var cosOmega = ax * bx + ay * by + az * bz + aw * bw;
+            if (cosOmega < 0) {
+                cosOmega = -cosOmega;
+                bx = -bx;
+                by = -by;
+                bz = -bz;
+                bw = -bw;
+            }
+
+            var scale0: T = 0.0;
+            var scale1: T = 0.0;
+
+            if (1.0 - cosOmega > math.eps_f32) {
+                const omega = std.math.acos(cosOmega);
+                const sinOmega = std.math.sin(omega);
+                scale0 = std.math.sin((1.0 - t) * omega) / sinOmega;
+                scale1 = std.math.sin(t * omega) / sinOmega;
+            } else {
+                scale0 = 1.0 - t;
+                scale1 = t;
+            }
+
+            return init(scale0 * ax + scale1 * bx, scale0 * ay + scale1 * by, scale0 * az + scale1 * bz, scale0 * aw + scale1 * bw);
+        }
+
+        /// Calculates the conjugate of the given quaternion.
+        pub inline fn conjugate(q: *const Quat(T)) Quat(T) {
+            return init(-q.v.x(), -q.v.y(), -q.v.z(), q.v.w());
+        }
+
+        /// Creates a quaternion from the given transformation matrix.
+        pub inline fn fromMat(comptime matT: type, m: *const matT) Quat(T) {
+            var dst = Quat(T).identity();
+            const trace = m.v[0].v[0] + m.v[1].v[1] + m.v[2].v[2];
+
+            if (trace > 0) {
+                const root = std.math.sqrt(trace + 1.0);
+                dst.v.v[3] = 0.5 * root;
+                const rootInv = 0.5 / root;
+
+                dst.v.v[0] = (m.v[1].v[2] - m.v[2].v[1]) * rootInv;
+                dst.v.v[1] = (m.v[2].v[0] - m.v[0].v[2]) * rootInv;
+                dst.v.v[2] = (m.v[0].v[1] - m.v[1].v[0]) * rootInv;
+            } else {
+                var i: usize = 0;
+
+                if (m.v[1].v[1] > m.v[0].v[0]) {
+                    i = 1;
+                }
+
+                if (m.v[2].v[2] > m.v[i].v[i]) {
+                    i = 2;
+                }
+
+                const j = (i + 1) % 3;
+                const k = (i + 2) % 3;
+
+                const root = std.math.sqrt(m.v[i].v[i] - m.v[j].v[j] - m.v[k].v[k] + 1.0);
+                dst.v.v[i] = 0.5 * root;
+
+                const rootInv = 0.5 / root;
+
+                dst.v.v[3] = (m.v[j].v[k] - m.v[k].v[j]) * rootInv;
+                dst.v.v[j] = (m.v[j].v[i] - m.v[i].v[j]) * rootInv;
+                dst.v.v[k] = (m.v[k].v[i] - m.v[i].v[k]) * rootInv;
+            }
+
+            return dst;
+        }
+
+        /// Creates a quaternion from the given Euler angles.
+        pub inline fn fromEuler(x: T, y: T, z: T) Quat(T) {
+            const xHalf = x * 0.5;
+            const yHalf = y * 0.5;
+            const zHalf = z * 0.5;
+
+            const sx = std.math.sin(xHalf);
+            const cx = std.math.cos(xHalf);
+            const sy = std.math.sin(yHalf);
+            const cy = std.math.cos(yHalf);
+            const sz = std.math.sin(zHalf);
+            const cz = std.math.cos(zHalf);
+
+            return init(sx * cy * cz + cx * sy * sz, cx * sy * cz - sx * cy * sz, cx * cy * sz + sx * sy * cz, cx * cy * cz - sx * sy * sz);
         }
     };
 }
@@ -44,6 +226,17 @@ test "init" {
     });
 }
 
+test "inverse" {
+    const q = math.Quat.init(1.0, 2.0, 3.0, 4.0);
+    const expected = math.Quat.init(-0.0333333, -0.0666667, -0.1, 0.133333);
+    const actual = q.inverse();
+
+    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
+    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
+    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
+    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+}
+
 test "fromAxisAngle" {
     const expected = math.Quat.init(0.383, 0.0, 0.0, 0.924); // Expected values for a 45-degree rotation around the x-axis
     const actual = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), 0.785398); // 45 degrees in radians (π/4) around the x-axis
@@ -52,4 +245,98 @@ test "fromAxisAngle" {
     try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
     try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
     try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+}
+
+test "angleBetween" {
+    const a = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), 1.0);
+    const b = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), -1.0);
+
+    try testing.expect(f32, math.Quat.angleBetween(&a, &b)).eqlApprox(2.0, 0.001);
+}
+
+test "mul" {
+    const a = math.Quat.init(1.0, 2.0, 3.0, 4.0);
+    const b = a.inverse();
+    const expected = math.Quat.identity();
+    const actual = math.Quat.mul(&a, &b);
+
+    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
+    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
+    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
+    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+}
+
+test "rotateX" {
+    const q = math.Quat.identity();
+    const expected = math.Quat.init(0.383, 0.0, 0.0, 0.924); // Expected values for a 45-degree rotation around the x-axis
+    const actual = math.Quat.rotateX(&q, 0.785398);
+
+    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
+    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
+    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
+    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+}
+
+test "rotateY" {
+    const q = math.Quat.identity();
+    const expected = math.Quat.init(0.0, 0.383, 0.0, 0.924); // Expected values for a 45-degree rotation around the y-axis
+    const actual = math.Quat.rotateY(&q, 0.785398);
+
+    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
+    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
+    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
+    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+}
+
+test "rotateZ" {
+    const q = math.Quat.identity();
+    const expected = math.Quat.init(0.0, 0.0, 0.383, 0.924); // Expected values for a 45-degree rotation around the z-axis
+    const actual = math.Quat.rotateZ(&q, 0.785398);
+
+    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
+    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
+    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
+    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+}
+
+test "slerp" {
+    const a = math.Quat.init(1.0, 2.0, 3.0, 4.0);
+    const b = math.Quat.init(5.0, 6.0, 7.0, 8.0);
+    const expected = math.Quat.init(3.0, 4.0, 5.0, 6.0);
+    const actual = math.Quat.slerp(&a, &b, 0.5);
+
+    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
+    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
+    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
+    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+}
+
+test "conjugate" {
+    const q = math.Quat.init(1.0, 2.0, 3.0, 4.0);
+    const expected = math.Quat.init(-1.0, -2.0, -3.0, 4.0);
+    const actual = math.Quat.conjugate(&q);
+
+    try testing.expect(f32, actual.v.x()).eqlApprox(expected.v.x(), 0.001);
+    try testing.expect(f32, actual.v.y()).eqlApprox(expected.v.y(), 0.001);
+    try testing.expect(f32, actual.v.z()).eqlApprox(expected.v.z(), 0.001);
+    try testing.expect(f32, actual.v.w()).eqlApprox(expected.v.w(), 0.001);
+}
+
+test "fromMat4" {
+    const m = math.Mat4x4.rotateX(0.785398);
+    const q = math.Quat.fromMat(math.Mat4x4, &m);
+
+    try testing.expect(f32, q.v.x()).eqlApprox(0.383, 0.001);
+    try testing.expect(f32, q.v.y()).eqlApprox(0.0, 0.001);
+    try testing.expect(f32, q.v.z()).eqlApprox(0.0, 0.001);
+    try testing.expect(f32, q.v.w()).eqlApprox(0.924, 0.001);
+}
+
+test "fromEuler" {
+    const q = math.Quat.fromEuler(0.785398, 0.0, 0.0);
+
+    try testing.expect(f32, q.v.x()).eqlApprox(0.383, 0.001);
+    try testing.expect(f32, q.v.y()).eqlApprox(0.0, 0.001);
+    try testing.expect(f32, q.v.z()).eqlApprox(0.0, 0.001);
+    try testing.expect(f32, q.v.w()).eqlApprox(0.924, 0.001);
 }

--- a/src/math/quat.zig
+++ b/src/math/quat.zig
@@ -293,25 +293,17 @@ test "init" {
 
 test "inverse" {
     const q = math.Quat.init(1.0, 2.0, 3.0, 4.0);
-    const expected = math.Quat.init(-0.0333333, -0.0666667, -0.1, 0.1333333);
+    const expected = math.Quat.init(-0.1 / 3.0, -0.1 / 3.0 * 2.0, -0.1, 1.0 / 7.5);
     const actual = q.inverse();
-    std.log.debug("actual: {any}", .{actual});
-    std.log.debug("expected: {any}", .{expected});
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "fromAxisAngle" {
     const expected = math.Quat.identity().rotateX(math.pi / 4.0);
     const actual = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), math.pi / 4.0); // 45 degrees in radians (π/4) around the x-axis
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "angleBetween" {
@@ -327,10 +319,7 @@ test "mul" {
     const expected = math.Quat.identity();
     const actual = math.Quat.mul(&a, &b);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "add" {
@@ -339,10 +328,7 @@ test "add" {
     const expected = math.Quat.init(6.0, 8.0, 10.0, 12.0);
     const actual = math.Quat.add(&a, &b);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "sub" {
@@ -351,10 +337,7 @@ test "sub" {
     const expected = math.Quat.init(-4.0, -4.0, -4.0, -4.0);
     const actual = math.Quat.sub(&a, &b);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "mulScalar" {
@@ -362,10 +345,7 @@ test "mulScalar" {
     const expected = math.Quat.init(2.0, 4.0, 6.0, 8.0);
     const actual = math.Quat.mulScalar(&q, 2.0);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "divScalar" {
@@ -373,40 +353,28 @@ test "divScalar" {
     const expected = math.Quat.init(0.5, 1.0, 1.5, 2.0);
     const actual = math.Quat.divScalar(&q, 2.0);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "rotateX" {
     const expected = math.Quat.fromAxisAngle(math.vec3(1, 0, 0), math.pi / 4.0);
     const actual = math.Quat.identity().rotateX(math.pi / 4.0);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "rotateY" {
     const expected = math.Quat.fromAxisAngle(math.vec3(0, 1, 0), math.pi / 4.0);
     const actual = math.Quat.identity().rotateY(math.pi / 4.0);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "rotateZ" {
     const expected = math.Quat.fromAxisAngle(math.vec3(0, 0, 1), math.pi / 4.0);
     const actual = math.Quat.identity().rotateZ(math.pi / 4.0);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "slerp" {
@@ -415,10 +383,7 @@ test "slerp" {
     const expected = math.Quat.init(3.0, 4.0, 5.0, 6.0);
     const actual = math.Quat.slerp(&a, &b, 0.5);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "conjugate" {
@@ -426,29 +391,22 @@ test "conjugate" {
     const expected = math.Quat.init(-1.0, -2.0, -3.0, 4.0);
     const actual = math.Quat.conjugate(&q);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "fromMat4" {
     const m = math.Mat4x4.rotateX(math.pi / 4.0);
     const q = math.Quat.fromMat(math.Mat4x4, &m);
+    const expected = math.Quat.identity().rotateX(math.pi / 4.0);
 
-    try testing.expect(f32, q.v.x()).eqlApprox(0.383, 0.001);
-    try testing.expect(f32, q.v.y()).eqlApprox(0.0, 0.001);
-    try testing.expect(f32, q.v.z()).eqlApprox(0.0, 0.001);
-    try testing.expect(f32, q.v.w()).eqlApprox(0.924, 0.001);
+    try testing.expect(math.Vec4, expected.v).eql(q.v);
 }
 
 test "fromEuler" {
     const q = math.Quat.fromEuler(math.pi / 4.0, 0.0, 0.0);
+    const expected = math.Quat.identity().rotateX(math.pi / 4.0);
 
-    try testing.expect(f32, q.v.x()).eqlApprox(0.383, 0.001);
-    try testing.expect(f32, q.v.y()).eqlApprox(0.0, 0.001);
-    try testing.expect(f32, q.v.z()).eqlApprox(0.0, 0.001);
-    try testing.expect(f32, q.v.w()).eqlApprox(0.924, 0.001);
+    try testing.expect(math.Vec4, expected.v).eql(q.v);
 }
 
 test "dot" {
@@ -457,7 +415,7 @@ test "dot" {
     const expected = 70.0;
     const actual = math.Quat.dot(&a, &b);
 
-    try testing.expect(f32, actual).eqlApprox(expected, 0.001);
+    try testing.expect(f32, actual).eql(expected);
 }
 
 test "lerp" {
@@ -466,10 +424,7 @@ test "lerp" {
     const expected = math.Quat.init(3.0, 4.0, 5.0, 6.0);
     const actual = math.Quat.lerp(&a, &b, 0.5);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }
 
 test "len2" {
@@ -477,7 +432,7 @@ test "len2" {
     const expected = 30.0;
     const actual = math.Quat.len2(&q);
 
-    try testing.expect(f32, actual).eqlApprox(expected, 0.001);
+    try testing.expect(f32, actual).eql(expected);
 }
 
 test "len" {
@@ -485,7 +440,7 @@ test "len" {
     const expected = 5.0;
     const actual = math.Quat.len(&q);
 
-    try testing.expect(f32, actual).eqlApprox(expected, 0.001);
+    try testing.expect(f32, actual).eql(expected);
 }
 
 test "normalize" {
@@ -493,8 +448,5 @@ test "normalize" {
     const expected = math.Quat.init(0.0, 0.0, 0.6, 0.8);
     const actual = math.Quat.normalize(&q);
 
-    try testing.expect(f32, actual.v.x()).eql(expected.v.x());
-    try testing.expect(f32, actual.v.y()).eql(expected.v.y());
-    try testing.expect(f32, actual.v.z()).eql(expected.v.z());
-    try testing.expect(f32, actual.v.w()).eql(expected.v.w());
+    try testing.expect(math.Vec4, expected.v).eql(actual.v);
 }

--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -217,7 +217,7 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
 
         /// Calculates the dot product between vector a and b and returns scalar.
         pub inline fn dot(a: *const VecN, b: *const VecN) Scalar {
-            return .{ .v = @reduce(.Add, a.v * b.v) };
+            return @reduce(.Add, a.v * b.v);
         }
     };
 }


### PR DESCRIPTION
Initial Quaternion implementation.


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.