### PR TITLE
math: Rewrite Vec tests and fix Vec cross calculation bug

### DIFF
--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -512,16 +512,167 @@ test "minScalar" {
     try testing.expect(f32, -182).eql(math.Vec4.minScalar(&b, &c));
 }
 
-// TODO(math): add basic tests for these:
-//
-// pub inline fn add(a: *const VecN, b: *const VecN) VecN {
-// pub inline fn sub(a: *const VecN, b: *const VecN) VecN {
-// pub inline fn div(a: *const VecN, b: *const VecN) VecN {
-// pub inline fn mul(a: *const VecN, b: *const VecN) VecN {
-// pub inline fn addScalar(a: *const VecN, s: Scalar) VecN {
-// pub inline fn subScalar(a: *const VecN, s: Scalar) VecN {
-// pub inline fn divScalar(a: *const VecN, s: Scalar) VecN {
-// pub inline fn mulScalar(a: *const VecN, s: Scalar) VecN {
+test "add_vec2" {
+    const a: math.Vec2 = math.vec2(4, 1);
+    const b: math.Vec2 = math.vec2(3, 4);
+    try testing.expect(math.Vec2, math.vec2(7, 5)).eql(a.add(&b));
+}
+
+test "add_vec3" {
+    const a: math.Vec3 = math.vec3(5, 12, 9.2);
+    const b: math.Vec3 = math.vec3(7.5, 920, 11);
+    try testing.expect(math.Vec3, math.vec3(12.5, 932, 20.2)).eql(a.add(&b));
+}
+
+test "add_vec4" {
+    const a: math.Vec4 = math.vec4(1280, 910, 926.25, 1000);
+    const b: math.Vec4 = math.vec4(20, 1090, 2.25, 2100);
+    try testing.expect(math.Vec4, math.vec4(1300, 2000, 928.5, 3100))
+        .eql(a.add(&b));
+}
+
+test "sub_vec2" {
+    const a: math.Vec2 = math.vec2(19, 1);
+    const b: math.Vec2 = math.vec2(3, 1);
+    try testing.expect(math.Vec2, math.vec2(16, 0)).eql(a.sub(&b));
+}
+
+test "sub_vec3" {
+    const a: math.Vec3 = math.vec3(7.5, 220, 13);
+    const b: math.Vec3 = math.vec3(2, 9, 6);
+    try testing.expect(math.Vec3, math.vec3(5.5, 211, 7)).eql(a.sub(&b));
+}
+
+test "sub_vec4" {
+    const a: math.Vec4 = math.vec4(2023, 7, 2, 7);
+    const b: math.Vec4 = math.vec4(-2, -2, -5, -3);
+    try testing.expect(math.Vec4, math.vec4(2025, 9, 7, 10))
+        .eql(a.sub(&b));
+}
+
+test "div_vec2" {
+    const a: math.Vec2 = math.vec2(1, 2.8);
+    const b: math.Vec2 = math.vec2(2, 4);
+    try testing.expect(math.Vec2, math.vec2(0.5, 0.7)).eql(a.div(&b));
+}
+
+test "div_vec3" {
+    const a: math.Vec3 = math.vec3(21, 144, 1);
+    const b: math.Vec3 = math.vec3(3, 12, 3);
+    try testing.expect(math.Vec3, math.vec3(7, 12, 0.3333333))
+        .eql(a.div(&b));
+}
+
+test "div_vec4" {
+    const a: math.Vec4 = math.vec4(1024, 512, 29, 3);
+    const b: math.Vec4 = math.vec4(2, 2, 2, 10);
+    try testing.expect(math.Vec4, math.vec4(512, 256, 14.5, 0.3))
+        .eql(a.div(&b));
+}
+
+test "mul_vec2" {
+    const a: math.Vec2 = math.vec2(29, 900);
+    const b: math.Vec2 = math.vec2(29, 2.2);
+    try testing.expect(math.Vec2, math.vec2(841, 1980)).eql(a.mul(&b));
+}
+
+test "mul_vec3" {
+    const a: math.Vec3 = math.vec3(3.72, 9.217, 9);
+    const b: math.Vec3 = math.vec3(2.1, 3.3, 9);
+    try testing.expect(math.Vec3, math.vec3(7.812, 30.4161, 81))
+        .eql(a.mul(&b));
+}
+
+test "mul_vec4" {
+    const a: math.Vec4 = math.vec4(3.72, 9.217, 9, 21);
+    const b: math.Vec4 = math.vec4(2.1, 3.3, 9, 15);
+    try testing.expect(math.Vec4, math.vec4(7.812, 30.4161, 81, 315))
+        .eql(a.mul(&b));
+}
+
+test "addScalar_vec2" {
+    const a: math.Vec2 = math.vec2(92, 78);
+    const s: f32 = 13;
+    try testing.expect(math.Vec2, math.vec2(105, 91))
+        .eql(a.addScalar(s));
+}
+
+test "addScalar_vec3" {
+    const a: math.Vec3 = math.vec3(92, 78, 120);
+    const s: f32 = 13;
+    try testing.expect(math.Vec3, math.vec3(105, 91, 133))
+        .eql(a.addScalar(s));
+}
+
+test "addScalar_vec4" {
+    const a: math.Vec4 = math.vec4(92, 78, 120, 111);
+    const s: f32 = 13;
+    try testing.expect(math.Vec4, math.vec4(105, 91, 133, 124))
+        .eql(a.addScalar(s));
+}
+
+test "subScalar_vec2" {
+    const a: math.Vec2 = math.vec2(1000.1, 3);
+    const s: f32 = 1;
+    try testing.expect(math.Vec2, math.vec2(999.1, 2))
+        .eql(a.subScalar(s));
+}
+
+test "subScalar_vec3" {
+    const a: math.Vec3 = math.vec3(1000.1, 3, 5);
+    const s: f32 = 1;
+    try testing.expect(math.Vec3, math.vec3(999.1, 2, 4))
+        .eql(a.subScalar(s));
+}
+
+test "subScalar_vec4" {
+    const a: math.Vec4 = math.vec4(1000.1, 3, 5, 38);
+    const s: f32 = 1;
+    try testing.expect(math.Vec4, math.vec4(999.1, 2, 4, 37))
+        .eql(a.subScalar(s));
+}
+
+test "divScalar_vec2" {
+    const a: math.Vec2 = math.vec2(13, 15);
+    const s: f32 = 2;
+    try testing.expect(math.Vec2, math.vec2(6.5, 7.5))
+        .eql(a.divScalar(s));
+}
+
+test "divScalar_vec3" {
+    const a: math.Vec3 = math.vec3(13, 15, 12);
+    const s: f32 = 2;
+    try testing.expect(math.Vec3, math.vec3(6.5, 7.5, 6))
+        .eql(a.divScalar(s));
+}
+
+test "divScalar_vec4" {
+    const a: math.Vec4 = math.vec4(13, 15, 12, 29);
+    const s: f32 = 2;
+    try testing.expect(math.Vec4, math.vec4(6.5, 7.5, 6, 14.5))
+        .eql(a.divScalar(s));
+}
+
+test "mulScalar_vec2" {
+    const a: math.Vec2 = math.vec2(10, 125);
+    const s: f32 = 5;
+    try testing.expect(math.Vec2, math.vec2(50, 625))
+        .eql(a.mulScalar(s));
+}
+
+test "mulScalar_vec3" {
+    const a: math.Vec3 = math.vec3(10, 125, 3);
+    const s: f32 = 5;
+    try testing.expect(math.Vec3, math.vec3(50, 625, 15))
+        .eql(a.mulScalar(s));
+}
+
+test "mulScalar_vec4" {
+    const a: math.Vec4 = math.vec4(10, 125, 3, 27);
+    const s: f32 = 5;
+    try testing.expect(math.Vec4, math.vec4(50, 625, 15, 135))
+        .eql(a.mulScalar(s));
+}
 
 // TODO(math): the tests below violate our styleguide (https://machengine.org/about/style/) we
 // should write new tests loosely based on them:

--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -57,9 +57,9 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
                 /// and required inputs are Vec3.
                 pub inline fn cross(a: *const VecN, b: *const VecN) VecN {
                     // https://gamemath.com/book/vectors.html#cross_product
-                    const s1 = a.yzx().mul(b.zxy());
-                    const s2 = a.zxy().mul(b.yzx());
-                    return s1.sub(s2);
+                    const s1 = a.yzx().mul(&b.zxy());
+                    const s2 = a.zxy().mul(&b.yzx());
+                    return s1.sub(&s2);
                 }
             },
             inline 4 => struct {

--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -46,8 +46,8 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
                 }
 
                 // TODO(math): come up with a better strategy for swizzling?
-                pub inline fn yzw(v: *const VecN) VecN {
-                    return VecN.init(v.y(), v.z(), v.w());
+                pub inline fn yzx(v: *const VecN) VecN {
+                    return VecN.init(v.y(), v.z(), v.x());
                 }
                 pub inline fn zxy(v: *const VecN) VecN {
                     return VecN.init(v.z(), v.x(), v.y());

--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -674,202 +674,173 @@ test "mulScalar_vec4" {
         .eql(a.mulScalar(s));
 }
 
-// TODO(math): the tests below violate our styleguide (https://machengine.org/about/style/) we
-// should write new tests loosely based on them:
+test "dir_zero_vec2" {
+    const near_zero_value = 1e-8;
+    const a: math.Vec2 = math.vec2(0, 0);
+    const b: math.Vec2 = math.vec2(0, 0);
+    try testing.expect(math.Vec2, math.vec2(0, 0))
+        .eql(a.dir(&b, near_zero_value));
+}
 
-// test "vec.dir" {
-//     const near_zero_value = 1e-8;
+test "dir_zero_vec3" {
+    const near_zero_value = 1e-8;
+    const a: math.Vec3 = math.vec3(0, 0, 0);
+    const b: math.Vec3 = math.vec3(0, 0, 0);
+    try testing.expect(math.Vec3, math.vec3(0, 0, 0))
+        .eql(a.dir(&b, near_zero_value));
+}
 
-//     {
-//         const a = Vec2{ 0, 0 };
-//         const b = Vec2{ 0, 0 };
-//         const d = vec.dir(a, b, near_zero_value);
-//         try expect(d[0] == 0 and d[1] == 0);
-//     }
+test "dir_zero_vec4" {
+    const near_zero_value = 1e-8;
+    const a: math.Vec4 = math.vec4(0, 0, 0, 0);
+    const b: math.Vec4 = math.vec4(0, 0, 0, 0);
+    try testing.expect(math.Vec4, math.vec4(0, 0, 0, 0))
+        .eql(a.dir(&b, near_zero_value));
+}
 
-//     {
-//         const a = Vec2{ 1, 2 };
-//         const b = Vec2{ 1, 2 };
-//         const d = vec.dir(a, b, near_zero_value);
-//         try expect(d[0] == 0 and d[1] == 0);
-//     }
+test "dir_vec2" {
+    const a: math.Vec2 = math.vec2(1, 2);
+    const b: math.Vec2 = math.vec2(3, 4);
+    try testing.expect(math.Vec2, math.vec2(std.math.sqrt1_2, std.math.sqrt1_2))
+        .eql(a.dir(&b, 0));
+}
 
-//     {
-//         const a = Vec2{ 1, 2 };
-//         const b = Vec2{ 3, 4 };
-//         const d = vec.dir(a, b, 0);
-//         const result = std.math.sqrt1_2; // 1 / sqrt(2)
-//         try expect(d[0] == result and d[1] == result);
-//     }
+test "dir_vec3" {
+    const a: math.Vec3 = math.vec3(1, -1, 0);
+    const b: math.Vec3 = math.vec3(0, 1, 1);
 
-//     {
-//         const a = Vec2{ 1, 2 };
-//         const b = Vec2{ -1, -2 };
-//         const d = vec.dir(a, b, 0);
-//         const result = -0.44721359549995793928; // 1 / sqrt(5)
-//         try expectApproxEqAbs(d[0], result, near_zero_value);
-//         try expectApproxEqAbs(d[1], 2 * result, near_zero_value);
-//     }
+    const result_x = -0.40824829046386301637; // -1 / sqrt(6)
+    const result_y = 0.81649658092772603273; // sqrt(2/3)
+    const result_z = -result_x; // 1 / sqrt(6)
 
-//     {
-//         const a = Vec3{ 1, -1, 0 };
-//         const b = Vec3{ 0, 1, 1 };
-//         const d = vec.dir(a, b, 0);
+    try testing.expect(math.Vec3, math.vec3(result_x, result_y, result_z))
+        .eql(a.dir(&b, 0));
+}
 
-//         const result_3 = 0.40824829046386301637; // 1 / sqrt(6)
-//         const result_1 = -result_3; // -1 / sqrt(6)
-//         const result_2 = 0.81649658092772603273; // sqrt(2/3)
-//         try expectApproxEqAbs(d[0], result_1, 1e-7);
-//         try expectApproxEqAbs(d[1], result_2, 1e-7);
-//         try expectApproxEqAbs(d[2], result_3, 1e-7);
-//     }
-// }
+test "dist_zero_vec2" {
+    const a: math.Vec2 = math.vec2(0, 0);
+    const b: math.Vec2 = math.vec2(0, 0);
+    try testing.expect(f32, 0).eql(a.dist(&b));
+}
 
-// test "vec.dist2" {
-//     {
-//         const a = Vec4{ 0, 0, 0, 0 };
-//         const b = Vec4{ 0, 0, 0, 0 };
-//         try expect(vec.dist2(a, b) == 0);
-//     }
+test "dist_zero_vec3" {
+    const a: math.Vec3 = math.vec3(0, 0, 0);
+    const b: math.Vec3 = math.vec3(0, 0, 0);
+    try testing.expect(f32, 0).eql(a.dist(&b));
+}
 
-//     {
-//         const a = Vec2{ 1, 1 };
-//         try expect(vec.dist2(a, a) == 0);
-//     }
+test "dist_zero_vec4" {
+    const a: math.Vec4 = math.vec4(0, 0, 0, 0);
+    const b: math.Vec4 = math.vec4(0, 0, 0, 0);
+    try testing.expect(f32, 0).eql(a.dist(&b));
+}
 
-//     {
-//         const a = Vec2{ 1, 2 };
-//         const b = Vec2{ 3, 4 };
-//         try expect(vec.dist2(a, b) == 8);
-//     }
+test "dist_vec2" {
+    const a: math.Vec2 = math.vec2(1.5, 2.25);
+    const b: math.Vec2 = math.vec2(1.44, -9.33);
+    try testing.expect(f64, 11.5802)
+        .eqlApprox(a.dist(&b), 1e-4);
+}
 
-//     {
-//         const a = Vec3{ -1, -2, -3 };
-//         const b = Vec3{ 3, 2, 1 };
-//         try expect(vec.dist2(a, b) == 48);
-//     }
+test "dist_vec3" {
+    const a: math.Vec3 = math.vec3(1.5, 2.25, 3.33);
+    const b: math.Vec3 = math.vec3(1.44, -9.33, 7.25);
+    try testing.expect(f64, 12.2256)
+        .eqlApprox(a.dist(&b), 1e-4);
+}
 
-//     {
-//         const a = Vec4{ 1.5, 2.25, 3.33, 4.44 };
-//         const b = Vec4{ 1.44, -9.33, 7.25, -0.5 };
-//         try expectApproxEqAbs(vec.dist2(a, b), 173.87, 1e-8);
-//     }
-// }
+test "dist_vec4" {
+    const a: math.Vec4 = math.vec4(1.5, 2.25, 3.33, 4.44);
+    const b: math.Vec4 = math.vec4(1.44, -9.33, 7.25, -0.5);
+    try testing.expect(f64, 13.186)
+        .eqlApprox(a.dist(&b), 1e-4);
+}
 
-// test "vec.dist" {
-//     {
-//         const a = Vec4{ 0, 0, 0, 0 };
-//         const b = Vec4{ 0, 0, 0, 0 };
-//         try expect(vec.dist(a, b) == 0);
-//     }
+test "dist2_zero_vec2" {
+    const a: math.Vec2 = math.vec2(0, 0);
+    const b: math.Vec2 = math.vec2(0, 0);
+    try testing.expect(f32, 0).eql(a.dist2(&b));
+}
 
-//     {
-//         const a = Vec2{ 1, 1 };
-//         try expect(vec.dist(a, a) == 0);
-//     }
+test "dist2_zero_vec3" {
+    const a: math.Vec3 = math.vec3(0, 0, 0);
+    const b: math.Vec3 = math.vec3(0, 0, 0);
+    try testing.expect(f32, 0).eql(a.dist2(&b));
+}
 
-//     {
-//         const a = Vec2{ 1, 2 };
-//         const b = Vec2{ 4, 6 };
-//         try expectEqual(vec.dist(a, b), 5);
-//     }
+test "dist2_zero_vec4" {
+    const a: math.Vec4 = math.vec4(0, 0, 0, 0);
+    const b: math.Vec4 = math.vec4(0, 0, 0, 0);
+    try testing.expect(f32, 0).eql(a.dist2(&b));
+}
 
-//     {
-//         const a = Vec3{ -1, -2, -3 };
-//         const b = Vec3{ 3, 2, -1 };
-//         try expect(vec.dist(a, b) == 6);
-//     }
+test "dist2_vec2" {
+    const a: math.Vec2 = math.vec2(1.5, 2.25);
+    const b: math.Vec2 = math.vec2(1.44, -9.33);
+    try testing.expect(f64, 134.10103204).eqlApprox(a.dist2(&b), 1e-2);
+}
 
-//     {
-//         const a = Vec4{ 1.5, 2.25, 3.33, 4.44 };
-//         const b = Vec4{ 1.44, -9.33, 7.25, -0.5 };
-//         try expectApproxEqAbs(vec.dist(a, b), 13.18597740025364975978, 1e-8);
-//     }
-// }
+test "dist2_vec3" {
+    const a: math.Vec3 = math.vec3(1.5, 2.25, 3.33);
+    const b: math.Vec3 = math.vec3(1.44, -9.33, 7.25);
+    try testing.expect(f64, 149.46529536).eqlApprox(a.dist2(&b), 1e-2);
+}
 
-// test "vec.lerp" {
-//     {
-//         const a = Vec4{ 1, 1, 1, 1 };
-//         const b = Vec4{ 0, 0, 0, 0 };
-//         const lerp_to_a = vec.lerp(a, b, 0.0);
-//         try expectEqual(lerp_to_a[0], a[0]);
-//         try expectEqual(lerp_to_a[1], a[1]);
-//         try expectEqual(lerp_to_a[2], a[2]);
-//         try expectEqual(lerp_to_a[3], a[3]);
+test "dist2_vec4" {
+    const a: math.Vec4 = math.vec4(1.5, 2.25, 3.33, 4.44);
+    const b: math.Vec4 = math.vec4(1.44, -9.33, 7.25, -0.5);
+    try testing.expect(f64, 173.870596).eqlApprox(a.dist2(&b), 1e-3);
+}
 
-//         const lerp_to_b = vec.lerp(a, b, 1.0);
-//         try expectEqual(lerp_to_b[0], b[0]);
-//         try expectEqual(lerp_to_b[1], b[1]);
-//         try expectEqual(lerp_to_b[2], b[2]);
-//         try expectEqual(lerp_to_b[3], b[3]);
+test "lerp_zero_vec2" {
+    const a: math.Vec2 = math.vec2(1, 1);
+    const b: math.Vec2 = math.vec2(0, 0);
+    try testing.expect(math.Vec2, math.vec2(1, 1)).eql(a.lerp(&b, 0));
+}
 
-//         const lerp_to_mid = vec.lerp(a, b, 0.5);
-//         try expectEqual(lerp_to_mid[0], 0.5);
-//         try expectEqual(lerp_to_mid[1], 0.5);
-//         try expectEqual(lerp_to_mid[2], 0.5);
-//         try expectEqual(lerp_to_mid[3], 0.5);
-//     }
-// }
+test "lerp_zero_vec3" {
+    const a: math.Vec3 = math.vec3(1, 1, 1);
+    const b: math.Vec3 = math.vec3(0, 0, 0);
+    try testing.expect(math.Vec3, math.vec3(1, 1, 1)).eql(a.lerp(&b, 0));
+}
 
-// test "vec.cross" {
-//     {
-//         const a = Vec3{ 1, 3, 4 };
-//         const b = Vec3{ 2, -5, 8 };
-//         const cross = vec.cross(a, b);
-//         try expectEqual(cross[0], 44);
-//         try expectEqual(cross[1], 0);
-//         try expectEqual(cross[2], -11);
-//     }
-//     {
-//         const a = Vec3{ 1.0, 0.0, 0.0 };
-//         const b = Vec3{ 0.0, 1.0, 0.0 };
-//         const cross = vec.cross(a, b);
-//         try expectEqual(cross[0], 0.0);
-//         try expectEqual(cross[1], 0.0);
-//         try expectEqual(cross[2], 1.0);
-//     }
-//     {
-//         const a = Vec3{ 1.0, 0.0, 0.0 };
-//         const b = Vec3{ 0.0, -1.0, 0.0 };
-//         const cross = vec.cross(a, b);
-//         try expectEqual(cross[0], 0.0);
-//         try expectEqual(cross[1], 0.0);
-//         try expectEqual(cross[2], -1.0);
-//     }
-//     {
-//         const a = Vec3{ -3.0, 0.0, -2.0 };
-//         const b = Vec3{ 5.0, -1.0, 2.0 };
-//         const cross = vec.cross(a, b);
-//         try expectEqual(cross[0], -2.0);
-//         try expectEqual(cross[1], -4.0);
-//         try expectEqual(cross[2], 3.0);
-//     }
-// }
+test "lerp_zero_vec4" {
+    const a: math.Vec4 = math.vec4(1, 1, 1, 1);
+    const b: math.Vec4 = math.vec4(0, 0, 0, 0);
+    try testing.expect(math.Vec4, math.vec4(1, 1, 1, 1)).eql(a.lerp(&b, 0));
+}
 
-// test "vec.dot" {
-//     {
-//         const a = Vec2{ -1, 2 };
-//         const b = Vec2{ 4, 5 };
-//         const dot = vec.dot(a, b);
-//         try expectEqual(dot, 6);
-//     }
-//     {
-//         const a = Vec3{ -1.0, 2.0, 3.0 };
-//         const b = Vec3{ 4.0, 5.0, 6.0 };
-//         const dot = vec.dot(a, b);
-//         try expectEqual(dot, 24.0);
-//     }
-//     {
-//         const a = Vec4{ -1.0, 2.0, 3.0, -2.0 };
-//         const b = Vec4{ 4.0, 5.0, 6.0, 2.0 };
-//         const dot = vec.dot(a, b);
-//         try expectEqual(dot, 20.0);
-//     }
+test "cross" {
+    const a: math.Vec3 = math.vec3(1, 3, 4);
+    const b: math.Vec3 = math.vec3(2, -5, 8);
+    try testing.expect(math.Vec3, math.vec3(44, 0, -11))
+        .eql(a.cross(&b));
 
-//     {
-//         const a = Vec4{ 0, 0, 0, 0 };
-//         const b = Vec4{ 0, 0, 0, 0 };
-//         const dot = vec.dot(a, b);
-//         try expectEqual(dot, 0.0);
-//     }
-// }
+    const c: math.Vec3 = math.vec3(1.0, 0.0, 0.0);
+    const d: math.Vec3 = math.vec3(0.0, 1.0, 0.0);
+    try testing.expect(math.Vec3, math.vec3(0.0, 0.0, 1.0))
+        .eql(c.cross(&d));
+
+    const e: math.Vec3 = math.vec3(-3.0, 0.0, -2.0);
+    const f: math.Vec3 = math.vec3(5.0, -1.0, 2.0);
+    try testing.expect(math.Vec3, math.vec3(-2.0, -4.0, 3.0))
+        .eql(e.cross(&f));
+}
+
+test "dot_vec2" {
+    const a: math.Vec2 = math.vec2(-1, 2);
+    const b: math.Vec2 = math.vec2(4, 5);
+    try testing.expect(f32, 6).eql(a.dot(&b));
+}
+
+test "dot_vec3" {
+    const a: math.Vec3 = math.vec3(-1, 2, 3);
+    const b: math.Vec3 = math.vec3(4, 5, 6);
+    try testing.expect(f32, 24).eql(a.dot(&b));
+}
+
+test "dot_vec4" {
+    const a: math.Vec4 = math.vec4(-1, 2, 3, -2);
+    const b: math.Vec4 = math.vec4(4, 5, 6, 2);
+    try testing.expect(f32, 20).eql(a.dot(&b));
+}


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

---

Rewrote the old commented out tests in accordance to the Mach style guide and added the listed missing basic tests.
While doing so I also caught two bugs in the cross and swizzling methods:
- the naming of the Vec3 swizzling method was wrong, using `yzw` instead of `yzx`, and `.w()` instead of `.x()`, while cross was calling `yzx`
- the cross method used e.g. `.mul(b.xzy())` instead of `.mul(&b.xzy())`