### PR TITLE
math: Implement new Vec swizzle method

### DIFF
--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -4,6 +4,7 @@ const mach = @import("../main.zig");
 const testing = mach.testing;
 const math = mach.math;
 
+pub const VecComponent = enum { x, y, z, w };
 pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
     return extern struct {
         v: Vector,


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
---
Motivated by the previously associated TODO note.
This strategy allows for generalized arbitrary swizzling instead by using an enum and the builtin [\@shuffle](https://ziglang.org/documentation/master/#shuffle) function.
- old: `a.yzx()`
- new: `a.swizzle(.y, .z, .x)`