### PR TITLE
Added mulVec function for matrices

### DIFF
--- a/src/math/mat.zig
+++ b/src/math/mat.zig
@@ -360,7 +360,7 @@ pub fn Mat(
             return result;
         }
 
-        /// Matrix - Vector multiplicatino: Mat * Vec
+        /// Matrix * Vector multiplication
         pub inline fn mulVec(a: *const Matrix, b: *const ColVec) ColVec {
             var result = [_]ColVec.T{0}**ColVec.n;
             inline for (0..Matrix.rows) |row| {

--- a/src/math/mat.zig
+++ b/src/math/mat.zig
@@ -675,7 +675,7 @@ test "Mat3x3_mulVec_vec3" {
     try testing.expect(math.Vec3, expected).eql(m);
 }
 
-test "Mat4x4_mulVec_ve4" {
+test "Mat4x4_mulVec_vec4" {
     const v = math.vec4(2, 5, 1, 8);
     const mat = math.Mat4x4.init(
         &math.vec4(1, 0, 2, 0),


### PR DESCRIPTION
Added function to multiply a matrix with a vector (Matrix* Vec).



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.