### PR TITLE
math: More precise triangleIntersect tests and Ray type improvements/bugfixes

### DIFF
--- a/src/math/ray.zig
+++ b/src/math/ray.zig
@@ -59,7 +59,9 @@ pub fn Ray(comptime Vec3P: type) type {
                 /// Check for collision of a ray and a triangle in 3D space.
                 /// Triangle winding, which determines front- and backface of
                 /// the given triangle, matters if backface culling is to be
-                /// enabled. Without backface culling it does not matter.
+                /// enabled. Without backface culling it does not matter for
+                /// hit detection, however the barycentric coordinates will
+                /// be negative in case of a backface hit.
                 /// On hit, will return a RayHit which contains distance t
                 /// and barycentric coordinates.
                 pub inline fn triangleIntersect(

--- a/src/math/ray.zig
+++ b/src/math/ray.zig
@@ -5,21 +5,6 @@ const testing = mach.testing;
 const math = mach.math;
 const vec = @import("vec.zig");
 
-// Determine the 3D vector dimension with the largest scalar value
-fn maxDim(v: math.Vec3) u8 {
-    if (v.v[0] > v.v[1]) {
-        if (v.v[0] > v.v[2]) {
-            return 0;
-        } else {
-            return 2;
-        }
-    } else if (v.v[1] > v.v[2]) {
-        return 1;
-    } else {
-        return 0;
-    }
-}
-
 // A Ray in three-dimensional space
 pub fn Ray(comptime Vec3P: type) type {
     // Floating point precision, will be either f16, f32, or f64
@@ -45,6 +30,22 @@ pub fn Ray(comptime Vec3P: type) type {
 
         pub usingnamespace switch (Vec3P) {
             math.Vec3, math.Vec3h, math.Vec3d => struct {
+                // Determine the 3D vector dimension with the largest scalar
+                // value
+                fn maxDim(v: [3]P) u8 {
+                    if (v[0] > v[1]) {
+                        if (v[0] > v[2]) {
+                            return 0;
+                        } else {
+                            return 2;
+                        }
+                    } else if (v[1] > v[2]) {
+                        return 1;
+                    } else {
+                        return 0;
+                    }
+                }
+
                 // Algorithm based on:
                 // https://www.jcgt.org/published/0002/01/05/
                 /// Check for collision of a ray and a triangle in 3D space.

--- a/src/math/ray.zig
+++ b/src/math/ray.zig
@@ -259,3 +259,95 @@ test "triangleIntersect_basic_backface_bc_miss" {
 
     try testing.expect(?math.Ray.Hit, null).eql(result);
 }
+
+test "triangleIntersect_precise_frontface_bc_hit_f32" {
+    const a: math.Vec3 = math.vec3(
+        3164.91,
+        3559.55,
+        3044.54,
+    );
+    const b: math.Vec3 = math.vec3(
+        1011.92,
+        3113.34,
+        3674.56,
+    );
+    const c: math.Vec3 = math.vec3(
+        503.804,
+        2311.16,
+        2449.58,
+    );
+    const ray0: math.Ray = math.Ray{
+        .origin = math.vec3(
+            293.293,
+            264.527,
+            225.465,
+        ),
+        .direction = math.vec3(
+            0.439063,
+            0.652555,
+            0.617573,
+        ),
+    };
+
+    const result: math.Ray.Hit = ray0.triangleIntersect(
+        &a,
+        &b,
+        &c,
+        true,
+    ).?;
+
+    const expected_t: f32 = 4606.98;
+    const expected_u: f32 = 0.643925;
+    const expected_v: f32 = 0.194228;
+    const expected_w: f32 = 0.161846;
+    try testing.expect(f32, expected_u).eqlApprox(result.v[0], 1e-5);
+    try testing.expect(f32, expected_v).eqlApprox(result.v[1], 1e-5);
+    try testing.expect(f32, expected_w).eqlApprox(result.v[2], 1e-5);
+    try testing.expect(f32, expected_t).eqlApprox(result.v[3], 1e-2);
+}
+
+test "triangleIntersect_precise_frontface_bc_hit_f64" {
+    const a: math.Vec3d = math.vec3d(
+        2371.01,
+        3208.12,
+        1570.04,
+    );
+    const b: math.Vec3d = math.vec3d(
+        1412.2,
+        2978.36,
+        1501.33,
+    );
+    const c: math.Vec3d = math.vec3d(
+        2520.99,
+        3323.93,
+        1567.18,
+    );
+    const ray0: math.Rayd = math.Rayd{
+        .origin = math.vec3d(
+            246.713,
+            279.646,
+            180.443,
+        ),
+        .direction = math.vec3d(
+            0.497991,
+            0.782698,
+            0.373349,
+        ),
+    };
+
+    const result: math.Rayd.Hit = ray0.triangleIntersect(
+        &a,
+        &b,
+        &c,
+        true,
+    ).?;
+
+    const expected_t: f64 = 3660.17;
+    const expected_u: f64 = 0.56102;
+    const expected_v: f64 = 0.33136;
+    const expected_w: f64 = 0.10761;
+    try testing.expect(f64, expected_u).eqlApprox(result.v[0], 1e-4);
+    try testing.expect(f64, expected_v).eqlApprox(result.v[1], 1e-4);
+    try testing.expect(f64, expected_w).eqlApprox(result.v[2], 1e-4);
+    try testing.expect(f64, expected_t).eqlApprox(result.v[3], 1e-2);
+}


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
-------
Added some more precise test cases for the ray-triangle intersection function.
I created these test cases the following way:
- Generate a random 3D triangle
- Sample a random point on/inside the triangle
- Calculate the barycentric coordinates of the sampled point
- Create a random ray origin point
- Calculate the normalized direction vector
- Calculate distance

(Did the calculations in Mathematica)

------
This PR also fixes a bug with the Ray type so that the `Rayd` and `Rayh` types work properly now and cleaned up the code a bit in the process: e.g. removed the `floatFallbackPrecision` function and replaced it with a simple switch expression. `Ray.Hit` is also now properly generic based on the specific `Ray` type, and will be either a `math.Vec4`, `math.Vec4d` or `math.Vec4h` respectively. In other words: `Ray.Hit` will be `math.Vec4`, `Rayd.Hit` will be `math.Vec4d` etc.

