### PR TITLE
math: Add Matrix multiplication tests

### DIFF
--- a/src/math/mat.zig
+++ b/src/math/mat.zig
@@ -340,7 +340,6 @@ pub fn Mat(
         };
 
         /// Matrix multiplication a*b
-        // TODO: needs tests
         pub inline fn mul(a: *const Matrix, b: *const Matrix) Matrix {
             @setEvalBranchQuota(10000);
             var result: Matrix = undefined;
@@ -362,7 +361,7 @@ pub fn Mat(
 
         /// Matrix * Vector multiplication
         pub inline fn mulVec(matrix: *const Matrix, vector: *const ColVec) ColVec {
-            var result = [_]ColVec.T{0}**ColVec.n;
+            var result = [_]ColVec.T{0} ** ColVec.n;
             inline for (0..Matrix.rows) |row| {
                 inline for (0..ColVec.n) |i| {
                     result[i] += matrix.v[row].v[i] * vector.v[row];
@@ -370,7 +369,6 @@ pub fn Mat(
             }
             return vec.Vec(ColVec.n, ColVec.T){ .v = result };
         }
-
 
         // TODO: the below code was correct in our old implementation, it just needs to be updated
         // to work with this new Mat approach, swapping f32 for the generic T float type, moving 3x3
@@ -688,5 +686,47 @@ test "Mat4x4_mulVec_vec4" {
     try testing.expect(math.Vec4, expected).eql(m);
 }
 
+test "Mat3x3_mul" {
+    const a = math.Mat3x3.init(
+        &math.vec3(4, 2, -3),
+        &math.vec3(7, 9, -8),
+        &math.vec3(-1, 8, -8),
+    );
+    const b = math.Mat3x3.init(
+        &math.vec3(5, -7, -8),
+        &math.vec3(6, -3, 2),
+        &math.vec3(-3, -4, 4),
+    );
+    const c = math.Mat3x3.mul(&a, &b);
 
+    const expected = math.Mat3x3.init(
+        &math.vec3(41, -22, -40),
+        &math.vec3(113, -44, -70),
+        &math.vec3(67, 15, -8),
+    );
+    try testing.expect(math.Mat3x3, expected).eql(c);
+}
 
+test "Mat4x4_mul" {
+    const a = math.Mat4x4.init(
+        &math.vec4(10, -5, 6, -2),
+        &math.vec4(0, -1, 0, 9),
+        &math.vec4(-1, 6, -4, 8),
+        &math.vec4(9, -8, -6, -10),
+    );
+    const b = math.Mat4x4.init(
+        &math.vec4(7, -7, -3, -8),
+        &math.vec4(1, -1, -7, -2),
+        &math.vec4(-10, 2, 2, -2),
+        &math.vec4(10, -7, 7, 1),
+    );
+    const c = math.Mat4x4.mul(&a, &b);
+
+    const expected = math.Mat4x4.init(
+        &math.vec4(-15, -39, 3, -84),
+        &math.vec4(89, -62, 70, 11),
+        &math.vec4(119, -63, 9, 12),
+        &math.vec4(15, 3, -53, -54),
+    );
+    try testing.expect(math.Mat4x4, expected).eql(c);
+}


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
--------
Motivated by the associated `TODO` comment.
Tests for Matrix multiplication with `Mat4x4` and `Mat3x3`. Caught a bug which causes the `Mat3x3` test to fail. The reason being that `Mat3x3` uses `Vec4`s, I assume this is for padding and compatibility reasons.
The culprit can be found in this line of the `mul` implementation:
```zig
var result: Matrix = undefined;
```
This does not matter for `Mat4x4` since every row and column gets touched. But for when creating a `Mat3x3` we call `init` with a `Vec3` but the `init` method sets the last column of the internal `Vec4` to `1`, so if the values start `undefined` it makes testing against and comparison with an expected `Mat3x3` fail.

Example:

```
============ expected this output: =============  len: 3 (0x3)

[0]: math.vec.Vec(4,f32){ .v = { 4.1e+01, 1.13e+02, 6.7e+01, 1.0e+00 } }
[1]: math.vec.Vec(4,f32){ .v = { -2.2e+01, -4.4e+01, 1.5e+01, 1.0e+00 } }
[2]: math.vec.Vec(4,f32){ .v = { -4.0e+01, -7.0e+01, -8.0e+00, 1.0e+00 } }

============= instead found this: ==============  len: 3 (0x3)

[0]: math.vec.Vec(4,f32){ .v = { 4.1e+01, 1.13e+02, 6.7e+01, -3.03164882e-13 } }
[1]: math.vec.Vec(4,f32){ .v = { -2.2e+01, -4.4e+01, 1.5e+01, -3.03164882e-13 } }
[2]: math.vec.Vec(4,f32){ .v = { -4.0e+01, -7.0e+01, -8.0e+00, -3.03164882e-13 } }

================================================
``` 

Since there are multiple places in which this problem can be fixed, e.g. in the `mul` method itself or by making testing aware of `Mat3x3` and ignore the last column, I have not yet done so. But if you tell me how you want it handled I can update this PR, or send another one.