### PR TITLE
engine: release encoder properly

### DIFF
--- a/src/engine.zig
+++ b/src/engine.zig
@@ -78,6 +78,7 @@ pub const Engine = struct {
 
         var command = engine.state.encoder.finish(null);
         defer command.release();
+        engine.state.encoder.release();
         engine.state.queue.submit(&[_]*gpu.CommandBuffer{command});
 
         // Prepare for next pass


### PR DESCRIPTION
Noticed a memory leak with the basic triangle example. An encoder release was forgotten.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.