### PR TITLE
math: Make Mat3x3's underlying type Vec3

### DIFF
--- a/src/math/main.zig
+++ b/src/math/main.zig
@@ -51,7 +51,7 @@ pub const Vec2 = vec.Vec(2, f32);
 pub const Vec3 = vec.Vec(3, f32);
 pub const Vec4 = vec.Vec(4, f32);
 pub const Quat = q.Quat(f32);
-pub const Mat3x3 = mat.Mat(3, 3, Vec4);
+pub const Mat3x3 = mat.Mat(3, 3, Vec3);
 pub const Mat4x4 = mat.Mat(4, 4, Vec4);
 pub const Ray = ray.Ray(Vec3);
 
@@ -60,7 +60,7 @@ pub const Vec2h = vec.Vec(2, f16);
 pub const Vec3h = vec.Vec(3, f16);
 pub const Vec4h = vec.Vec(4, f16);
 pub const Quath = q.Quat(f16);
-pub const Mat3x3h = mat.Mat(3, 3, Vec4h);
+pub const Mat3x3h = mat.Mat(3, 3, Vec3h);
 pub const Mat4x4h = mat.Mat(4, 4, Vec4h);
 pub const Rayh = ray.Ray(Vec3h);
 
@@ -69,7 +69,7 @@ pub const Vec2d = vec.Vec(2, f64);
 pub const Vec3d = vec.Vec(3, f64);
 pub const Vec4d = vec.Vec(4, f64);
 pub const Quatd = q.Quat(f64);
-pub const Mat3x3d = mat.Mat(3, 3, Vec4d);
+pub const Mat3x3d = mat.Mat(3, 3, Vec3d);
 pub const Mat4x4d = mat.Mat(4, 4, Vec4d);
 pub const Rayd = ray.Ray(Vec3d);
 

--- a/src/math/mat.zig
+++ b/src/math/mat.zig
@@ -38,7 +38,7 @@ pub fn Mat(
         /// The scalar type of this matrix, e.g. Mat3x3.T == f32
         pub const T = Vector.T;
 
-        /// The underlying Vec type, e.g. Mat3x3.Vec == Vec4
+        /// The underlying Vec type, e.g. Mat3x3.Vec == Vec3
         pub const Vec = Vector;
 
         /// The Vec type corresponding to the number of rows, e.g. Mat3x3.RowVec == Vec3
@@ -80,18 +80,18 @@ pub fn Mat(
                 ///
                 /// ```
                 /// const m = Mat3x3.init(
-                ///     vec4(1, 0, tx),
-                ///     vec4(0, 1, ty),
-                ///     vec4(0, 0, tz),
+                ///     vec3(1, 0, tx),
+                ///     vec3(0, 1, ty),
+                ///     vec3(0, 0, tz),
                 /// );
                 /// ```
                 ///
                 /// Note that Mach matrices use [column-major storage and column-vectors](https://machengine.org/engine/math/matrix-storage/).
                 pub inline fn init(r0: *const RowVec, r1: *const RowVec, r2: *const RowVec) Matrix {
                     return .{ .v = [_]Vec{
-                        Vec.init(r0.x(), r1.x(), r2.x(), 1),
-                        Vec.init(r0.y(), r1.y(), r2.y(), 1),
-                        Vec.init(r0.z(), r1.z(), r2.z(), 1),
+                        Vec.init(r0.x(), r1.x(), r2.x()),
+                        Vec.init(r0.y(), r1.y(), r2.y()),
+                        Vec.init(r0.z(), r1.z(), r2.z()),
                     } };
                 }
 
@@ -112,9 +112,9 @@ pub fn Mat(
                 /// Transposes the matrix.
                 pub inline fn transpose(m: *const Matrix) Matrix {
                     return .{ .v = [_]Vec{
-                        Vec.init(m.v[0].v[0], m.v[1].v[0], m.v[2].v[0], 1),
-                        Vec.init(m.v[0].v[1], m.v[1].v[1], m.v[2].v[1], 1),
-                        Vec.init(m.v[0].v[2], m.v[1].v[2], m.v[2].v[2], 1),
+                        Vec.init(m.v[0].v[0], m.v[1].v[0], m.v[2].v[0]),
+                        Vec.init(m.v[0].v[1], m.v[1].v[1], m.v[2].v[1]),
+                        Vec.init(m.v[0].v[2], m.v[1].v[2], m.v[2].v[2]),
                     } };
                 }
 
@@ -436,8 +436,8 @@ test "zero_struct_overhead" {
 test "n" {
     try testing.expect(usize, 3).eql(math.Mat3x3.cols);
     try testing.expect(usize, 3).eql(math.Mat3x3.rows);
-    try testing.expect(type, math.Vec4).eql(math.Mat3x3.Vec);
-    try testing.expect(usize, 4).eql(math.Mat3x3.Vec.n);
+    try testing.expect(type, math.Vec3).eql(math.Mat3x3.Vec);
+    try testing.expect(usize, 3).eql(math.Mat3x3.Vec.n);
 }
 
 test "init" {
@@ -446,20 +446,20 @@ test "init" {
         &math.vec3(0, 1, 7331),
         &math.vec3(0, 0, 1),
     )).eql(math.Mat3x3{
-        .v = [_]math.Vec4{
-            math.Vec4.init(1, 0, 0, 1),
-            math.Vec4.init(0, 1, 0, 1),
-            math.Vec4.init(1337, 7331, 1, 1),
+        .v = [_]math.Vec3{
+            math.Vec3.init(1, 0, 0),
+            math.Vec3.init(0, 1, 0),
+            math.Vec3.init(1337, 7331, 1),
         },
     });
 }
 
 test "mat3x3_ident" {
     try testing.expect(math.Mat3x3, math.Mat3x3.ident).eql(math.Mat3x3{
-        .v = [_]math.Vec4{
-            math.Vec4.init(1, 0, 0, 1),
-            math.Vec4.init(0, 1, 0, 1),
-            math.Vec4.init(0, 0, 1, 1),
+        .v = [_]math.Vec3{
+            math.Vec3.init(1, 0, 0),
+            math.Vec3.init(0, 1, 0),
+            math.Vec3.init(0, 0, 1),
         },
     });
 }

--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -29,7 +29,7 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
                 }
                 pub inline fn fromInt(xs: anytype, ys: anytype) VecN {
                     return .{ .v = .{ @floatFromInt(xs), @floatFromInt(ys) } };
-                } 
+                }
                 pub inline fn x(v: *const VecN) Scalar {
                     return v.v[0];
                 }
@@ -43,7 +43,7 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
                 }
                 pub inline fn fromInt(xs: anytype, ys: anytype, zs: anytype) VecN {
                     return .{ .v = .{ @floatFromInt(xs), @floatFromInt(ys), @floatFromInt(zs) } };
-                } 
+                }
                 pub inline fn x(v: *const VecN) Scalar {
                     return v.v[0];
                 }
@@ -79,7 +79,7 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
                 }
 
                 /// Vector * Matrix multiplication
-                pub inline fn mulMat(vector: *const VecN, matrix: *const mat.Mat(3, 3, Vec(4, T))) VecN {
+                pub inline fn mulMat(vector: *const VecN, matrix: *const mat.Mat(3, 3, Vec(3, T))) VecN {
                     var result = [_]VecN.T{0} ** 3;
                     inline for (0..3) |i| {
                         inline for (0..3) |j| {
@@ -95,7 +95,7 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
                 }
                 pub inline fn fromInt(xs: anytype, ys: anytype, zs: anytype, ws: anytype) VecN {
                     return .{ .v = .{ @floatFromInt(xs), @floatFromInt(ys), @floatFromInt(zs), @floatFromInt(ws) } };
-                } 
+                }
                 pub inline fn x(v: *const VecN) Scalar {
                     return v.v[0];
                 }


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
-----

Turns out 3 element vectors already give us the alignment we want. This change fixes `Mat3x3` comparison while still allowing the `gpu_compatibility` tests to pass without modification.
