### PR TITLE
math: Add vector comparison functions

### DIFF
--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -374,6 +374,24 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
 
             return min_scalar;
         }
+
+        /// Checks for approximate (tolerence) equality between two vectors
+        /// of the same type and dimensions
+        pub inline fn equalsApprox(a: *const VecN, b: *const VecN, tolerance: T) bool {
+            var i: usize = 0;
+            while (i < VecN.n) : (i += 1) {
+                if (!math.eql(T, a.v[i], b.v[i], tolerance)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// Checks for approximate (absolute epsilon tolerence) equality
+        /// between two vectors of the same type and dimensions
+        pub inline fn equals(a: *const VecN, b: *const VecN) bool {
+            return a.equalsApprox(b, math.eps(T));
+        }
     };
 }
 

--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -377,6 +377,40 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
     };
 }
 
+test "equals_vec2" {
+    const a: math.Vec2 = math.vec2(92, 103);
+    const b: math.Vec2 = math.vec2(92, 103);
+    const c: math.Vec2 = math.vec2(92, 103.2);
+
+    try testing.expect(bool, true).eql(a.equals(&b));
+    try testing.expect(bool, false).eql(a.equals(&c));
+}
+
+test "equals_vec3" {
+    const a: math.Vec3 = math.vec3(92, 103, 576);
+    const b: math.Vec3 = math.vec3(92, 103, 576);
+    const c: math.Vec3 = math.vec3(92.009, 103.2, 578);
+
+    try testing.expect(bool, true).eql(a.equals(&b));
+    try testing.expect(bool, false).eql(a.equals(&c));
+}
+
+test "equalsApprox_vec2" {
+    const a: math.Vec2 = math.vec2(92.92837, 103.54682);
+    const b: math.Vec2 = math.vec2(92.92998, 103.54791);
+
+    try testing.expect(bool, true).eql(a.equalsApprox(&b, 1e-2));
+    try testing.expect(bool, false).eql(a.equalsApprox(&b, 1e-3));
+}
+
+test "equalsApprox_vec3" {
+    const a: math.Vec3 = math.vec3(92.92837, 103.54682, 256.9);
+    const b: math.Vec3 = math.vec3(92.92998, 103.54791, 256.9);
+
+    try testing.expect(bool, true).eql(a.equalsApprox(&b, 1e-2));
+    try testing.expect(bool, false).eql(a.equalsApprox(&b, 1e-3));
+}
+
 test "gpu_compatibility" {
     // https://www.w3.org/TR/WGSL/#alignment-and-size
     try testing.expect(usize, 8).eql(@sizeOf(math.Vec2)); // WGSL AlignOf 8, SizeOf 8

--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -375,7 +375,7 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
             return min_scalar;
         }
 
-        /// Checks for approximate (tolerence) equality between two vectors
+        /// Checks for approximate (absolute tolerance) equality between two vectors
         /// of the same type and dimensions
         pub inline fn eqlApprox(a: *const VecN, b: *const VecN, tolerance: T) bool {
             var i: usize = 0;
@@ -387,7 +387,7 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
             return true;
         }
 
-        /// Checks for approximate (absolute epsilon tolerence) equality
+        /// Checks for approximate (absolute epsilon tolerance) equality
         /// between two vectors of the same type and dimensions
         pub inline fn eql(a: *const VecN, b: *const VecN) bool {
             return a.eqlApprox(b, math.eps(T));

--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -377,7 +377,7 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
 
         /// Checks for approximate (tolerence) equality between two vectors
         /// of the same type and dimensions
-        pub inline fn equalsApprox(a: *const VecN, b: *const VecN, tolerance: T) bool {
+        pub inline fn eqlApprox(a: *const VecN, b: *const VecN, tolerance: T) bool {
             var i: usize = 0;
             while (i < VecN.n) : (i += 1) {
                 if (!math.eql(T, a.v[i], b.v[i], tolerance)) {
@@ -389,44 +389,44 @@ pub fn Vec(comptime n_value: usize, comptime Scalar: type) type {
 
         /// Checks for approximate (absolute epsilon tolerence) equality
         /// between two vectors of the same type and dimensions
-        pub inline fn equals(a: *const VecN, b: *const VecN) bool {
-            return a.equalsApprox(b, math.eps(T));
+        pub inline fn eql(a: *const VecN, b: *const VecN) bool {
+            return a.eqlApprox(b, math.eps(T));
         }
     };
 }
 
-test "equals_vec2" {
+test "eql_vec2" {
     const a: math.Vec2 = math.vec2(92, 103);
     const b: math.Vec2 = math.vec2(92, 103);
     const c: math.Vec2 = math.vec2(92, 103.2);
 
-    try testing.expect(bool, true).eql(a.equals(&b));
-    try testing.expect(bool, false).eql(a.equals(&c));
+    try testing.expect(bool, true).eql(a.eql(&b));
+    try testing.expect(bool, false).eql(a.eql(&c));
 }
 
-test "equals_vec3" {
+test "eql_vec3" {
     const a: math.Vec3 = math.vec3(92, 103, 576);
     const b: math.Vec3 = math.vec3(92, 103, 576);
     const c: math.Vec3 = math.vec3(92.009, 103.2, 578);
 
-    try testing.expect(bool, true).eql(a.equals(&b));
-    try testing.expect(bool, false).eql(a.equals(&c));
+    try testing.expect(bool, true).eql(a.eql(&b));
+    try testing.expect(bool, false).eql(a.eql(&c));
 }
 
-test "equalsApprox_vec2" {
+test "eqlApprox_vec2" {
     const a: math.Vec2 = math.vec2(92.92837, 103.54682);
     const b: math.Vec2 = math.vec2(92.92998, 103.54791);
 
-    try testing.expect(bool, true).eql(a.equalsApprox(&b, 1e-2));
-    try testing.expect(bool, false).eql(a.equalsApprox(&b, 1e-3));
+    try testing.expect(bool, true).eql(a.eqlApprox(&b, 1e-2));
+    try testing.expect(bool, false).eql(a.eqlApprox(&b, 1e-3));
 }
 
-test "equalsApprox_vec3" {
+test "eqlApprox_vec3" {
     const a: math.Vec3 = math.vec3(92.92837, 103.54682, 256.9);
     const b: math.Vec3 = math.vec3(92.92998, 103.54791, 256.9);
 
-    try testing.expect(bool, true).eql(a.equalsApprox(&b, 1e-2));
-    try testing.expect(bool, false).eql(a.equalsApprox(&b, 1e-3));
+    try testing.expect(bool, true).eql(a.eqlApprox(&b, 1e-2));
+    try testing.expect(bool, false).eql(a.eqlApprox(&b, 1e-3));
 }
 
 test "gpu_compatibility" {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -8,12 +8,12 @@ fn ExpectFloat(comptime T: type) type {
     return struct {
         expected: T,
 
-        /// Approximate (absolute epsilon tolerence) equality
+        /// Approximate (absolute epsilon tolerance) equality
         pub fn eql(e: *const @This(), actual: T) !void {
             try e.eqlApprox(actual, math.eps(T));
         }
 
-        /// Approximate (tolerence) equality
+        /// Approximate (absolute tolerance) equality
         pub fn eqlApprox(e: *const @This(), actual: T, tolerance: T) !void {
             try testing.expectApproxEqAbs(e.expected, actual, tolerance);
         }
@@ -31,12 +31,12 @@ fn ExpectVector(comptime T: type) type {
     return struct {
         expected: T,
 
-        /// Approximate (absolute epsilon tolerence) equality
+        /// Approximate (absolute epsilon tolerance) equality
         pub fn eql(e: *const @This(), actual: T) !void {
             try e.eqlApprox(actual, math.eps(Elem));
         }
 
-        /// Approximate (tolerence) equality
+        /// Approximate (absolute tolerance) equality
         pub fn eqlApprox(e: *const @This(), actual: T, tolerance: Elem) !void {
             var i: usize = 0;
             while (i < len) : (i += 1) {
@@ -58,12 +58,12 @@ fn ExpectVecMat(comptime T: type) type {
     return struct {
         expected: T,
 
-        /// Approximate (absolute epsilon tolerence) equality
+        /// Approximate (absolute epsilon tolerance) equality
         pub fn eql(e: *const @This(), actual: T) !void {
             try e.eqlApprox(actual, math.eps(T.T));
         }
 
-        /// Approximate (tolerence) equality
+        /// Approximate (absolute tolerance) equality
         pub fn eqlApprox(e: *const @This(), actual: T, tolerance: T.T) !void {
             var i: usize = 0;
             while (i < T.n) : (i += 1) {
@@ -155,7 +155,7 @@ fn Expect(comptime T: type) type {
 /// Floats, mach.math.Vec, and mach.math.Mat types support:
 ///
 /// * `.eql(v)` (epsilon equality)
-/// * `.eqlApprox(v, tolerence)` (specific tolerence equality)
+/// * `.eqlApprox(v, tolerance)` (specific tolerance equality)
 /// * `.eqlBinary(v)` binary equality
 ///
 /// All other types support only `.eql(v)` binary equality.


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

----

Once accepted (and finished), helps #1109

Based on the testing implementation, which I left untouched for now. Naming based on the old [Matrix equality functions](https://github.com/hexops/mach/blob/260802f7771c651246930455dfd7de7a75c9869a/src/math/mat.zig#L354).

Let me know if this follows the intended direction.