### PR TITLE
ECS: @memcpy Overlap Memory Bug Fix

### DIFF
--- a/src/ecs/Archetype.zig
+++ b/src/ecs/Archetype.zig
@@ -195,7 +195,7 @@ pub fn getDynamic(storage: *Archetype, row_index: u32, name: StringTable.Index, 
 
 /// Swap-removes the specified row with the last row in the table.
 pub fn remove(storage: *Archetype, row_index: u32) void {
-    if (storage.len > 1) {
+    if (storage.len > 1 and row_index != storage.len - 1) {
         for (storage.columns) |column| {
             const dstStart = column.size * row_index;
             const dst = column.values[dstStart .. dstStart + column.size];

--- a/src/ecs/entities.zig
+++ b/src/ecs/entities.zig
@@ -322,6 +322,9 @@ pub fn Entities(comptime all_components: anytype) type {
                         .component_names = entities.component_names,
                         .hash = archetype_entry.hash,
                     };
+
+                    // Potential pointer invalidation if additional memory was required, reassigning prev pointer
+                    prev_archetype = &entities.archetypes.items[prev_archetype_idx];
                 } else {
                     entities.allocator.free(columns);
                 }


### PR DESCRIPTION

When attempting to remove some items from the entities list, I was receiving some aliasing errors from @memcpy. This happened because there are attempts to copying overlapping regions of memory (same index as the last element in this case) which is not allowed with that builtin function. This fix should alleviate that.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.