### PR TITLE
ecs: add query any

### DIFF
--- a/src/ecs/Archetype.zig
+++ b/src/ecs/Archetype.zig
@@ -195,7 +195,7 @@ pub fn getDynamic(storage: *Archetype, row_index: u32, name: StringTable.Index, 
 
 /// Swap-removes the specified row with the last row in the table.
 pub fn remove(storage: *Archetype, row_index: u32) void {
-    if (storage.len > 1) {
+    if (storage.len > 1 and row_index != storage.len - 1) {
         for (storage.columns) |column| {
             const dstStart = column.size * row_index;
             const dst = column.values[dstStart .. dstStart + column.size];


### PR DESCRIPTION
A basic change-up of the query `all` to be used for the `any` query. Added a test that seems to be on par with the `all` test as is. If a separate test should be created for `any`, let me know. Also if this is not the intended design of `any` with what y'all have in mind, I am also down to adhering to any feedback.

What I really wanted was a query that would allow me to query all entities given a namespace, but figured an any call with all provided component names will do for now and saw it was panic-ing due to no implementation.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.