### PR TITLE
added swap chain usage flags to core.init() options

### DIFF
--- a/src/core/main.zig
+++ b/src/core/main.zig
@@ -130,6 +130,7 @@ pub const Options = struct {
     power_preference: gpu.PowerPreference = .undefined,
     required_features: ?[]const gpu.FeatureName = null,
     required_limits: ?gpu.Limits = null,
+    swap_chain_usage: gpu.Texture.UsageFlags = .{ .render_attachment = true, },
 };
 
 pub fn init(options_in: Options) !void {

--- a/src/core/platform/glfw/Core.zig
+++ b/src/core/platform/glfw/Core.zig
@@ -256,7 +256,7 @@ pub fn init(
     const framebuffer_size = window.getFramebufferSize();
     const swap_chain_desc = gpu.SwapChain.Descriptor{
         .label = "main swap chain",
-        .usage = .{ .render_attachment = true },
+        .usage = options.swap_chain_usage,
         .format = .bgra8_unorm,
         .width = framebuffer_size.width,
         .height = framebuffer_size.height,

--- a/src/core/platform/wayland/Core.zig
+++ b/src/core/platform/wayland/Core.zig
@@ -977,7 +977,7 @@ pub fn init(
 
     const swap_chain_desc = gpu.SwapChain.Descriptor{
         .label = "main swap chain",
-        .usage = .{ .render_attachment = true },
+        .usage = options.swap_chain_usage,
         .format = .bgra8_unorm,
         .width = options.size.width,
         .height = options.size.height,

--- a/src/core/platform/x11/Core.zig
+++ b/src/core/platform/x11/Core.zig
@@ -488,7 +488,7 @@ pub fn init(
 
     const swap_chain_desc = gpu.SwapChain.Descriptor{
         .label = "main swap chain",
-        .usage = .{ .render_attachment = true },
+        .usage = options.swap_chain_usage,
         .format = .bgra8_unorm,
         .width = @intCast(window_attrs.width),
         .height = @intCast(window_attrs.height),


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

Added field swap_chain_usage to core.Options, as well as replacing the default usage flags with this in glfw, x11, and wayland platform