### PR TITLE
sysgpu: fix overflow trying to report an error

### DIFF
--- a/src/sysgpu/shader/ErrorList.zig
+++ b/src/sysgpu/shader/ErrorList.zig
@@ -116,13 +116,17 @@ fn printCode(writer: anytype, term: std.io.tty.Config, source: []const u8, loc: 
 
     // location pointer
     const line_number_len = (std.math.log10(loc_extra.line) + 1) + 3;
-    try writer.writeByteNTimes(
-        ' ',
-        line_number_len + (loc_extra.col - 1),
-    );
+    if (line_number_len > loc_extra.col) {
+        try writer.writeByteNTimes(
+            ' ',
+            line_number_len + (loc_extra.col - 1),
+        );
+    }
     try term.setColor(writer, .bold);
     try term.setColor(writer, .green);
     try writer.writeByte('^');
-    try writer.writeByteNTimes('~', loc.end - loc.start - 1);
+    if (loc.end > loc.start) {
+        try writer.writeByteNTimes('~', loc.end - loc.start - 1);
+    }
     try writer.writeByte('\n');
 }


### PR DESCRIPTION
It was erroring due to an unnecessary trailing semicolon that dawn was fine with, and the error location was 0 bytes long so it overflowed

```
null:45:1 error: expected global declaration, found 'EOF'
45 │ 
     ^
```

```wgsl
struct VertexInput{
    …
}; // <- extra semicolon at the end of the file caused an error. earlier extra semicolons were fine.
```

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.