### PR TITLE
math: simplify algorithm finding greatest dimension vector

### DIFF
--- a/src/math/ray.zig
+++ b/src/math/ray.zig
@@ -47,10 +47,9 @@ pub fn Ray(comptime Vec3P: type) type {
                         }
                     } else if (v[1] > v[2]) {
                         return 1;
-                    } else if (v[2] > v[0]) {
+                    } else {
                         return 2;
                     }
-                    return 0;
                 }
 
                 // Algorithm based on:


### PR DESCRIPTION
The `maxDim` function could be further optimized to remove an unnecessary check. The removed check used to observe whether `v[2]` was already greater than `v[0]`, but this is already known because in order for the function to reach that point `v[1]` has to be greater than or equal to `v[0]` and `v[1]` has to not be greater than `v[2]`, so the greatest dimension must be `v[2]` at that point. The removal of this check also removes the need for the final `return 0;` because the else case covers the case in which all three are the same length. This should result in a small performance gain.

The function is still a bit hard to read, which is probably how the unnecessary check snuck in.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.