### PR TITLE
module: remove global events, rename events -> systems, hinder/remove 'event arguments'

### DIFF
--- a/examples/core-custom-entrypoint/App.zig
+++ b/examples/core-custom-entrypoint/App.zig
@@ -5,7 +5,7 @@ const gpu = mach.gpu;
 pub const name = .app;
 pub const Mod = mach.Mod(@This());
 
-pub const events = .{
+pub const systems = .{
     .init = .{ .handler = init },
     .deinit = .{ .handler = deinit },
     .tick = .{ .handler = tick },
@@ -16,7 +16,7 @@ pipeline: *gpu.RenderPipeline,
 
 pub fn deinit(core: *mach.Core.Mod, game: *Mod) void {
     game.state().pipeline.release();
-    core.send(.deinit, .{});
+    core.schedule(.deinit);
 }
 
 fn init(game: *Mod, core: *mach.Core.Mod) !void {
@@ -59,7 +59,7 @@ fn init(game: *Mod, core: *mach.Core.Mod) !void {
     });
     try updateWindowTitle(core);
 
-    core.send(.start, .{});
+    core.schedule(.start);
 }
 
 // TODO(important): remove need for returning an error here
@@ -69,7 +69,7 @@ fn tick(core: *mach.Core.Mod, game: *Mod) !void {
     var iter = mach.core.pollEvents();
     while (iter.next()) |event| {
         switch (event) {
-            .close => core.send(.exit, .{}), // Tell mach.Core to exit the app
+            .close => core.schedule(.exit), // Tell mach.Core to exit the app
             else => {},
         }
     }
@@ -111,7 +111,7 @@ fn tick(core: *mach.Core.Mod, game: *Mod) !void {
     core.state().queue.submit(&[_]*gpu.CommandBuffer{command});
 
     // Present the frame
-    core.send(.present_frame, .{});
+    core.schedule(.present_frame);
 
     // update the window title every second
     if (game.state().title_timer.read() >= 1.0) {
@@ -131,5 +131,5 @@ fn updateWindowTitle(core: *mach.Core.Mod) !void {
             mach.core.inputRate(),
         },
     );
-    core.send(.update, .{});
+    core.schedule(.update);
 }

--- a/examples/custom-renderer/App.zig
+++ b/examples/custom-renderer/App.zig
@@ -22,7 +22,7 @@ pub const components = .{
     .follower = .{ .type = void },
 };
 
-pub const events = .{
+pub const systems = .{
     .init = .{ .handler = init },
     .deinit = .{ .handler = deinit },
     .tick = .{ .handler = tick },
@@ -39,8 +39,8 @@ pub const name = .app;
 pub const Mod = mach.Mod(@This());
 
 pub fn deinit(core: *mach.Core.Mod, renderer: *Renderer.Mod) void {
-    renderer.send(.deinit, .{});
-    core.send(.deinit, .{});
+    renderer.schedule(.deinit);
+    core.schedule(.deinit);
 }
 
 // TODO(important): remove need for returning an error here
@@ -53,7 +53,7 @@ fn init(
     renderer: *Renderer.Mod,
     game: *Mod,
 ) !void {
-    renderer.send(.init, .{});
+    renderer.schedule(.init);
 
     // Create our player entity.
     const player = try entities.new();
@@ -77,7 +77,7 @@ fn init(
         .player = player,
     });
 
-    core.send(.start, .{});
+    core.schedule(.start);
 }
 
 // TODO(important): remove need for returning an error here
@@ -114,7 +114,7 @@ fn tick(
                     else => {},
                 }
             },
-            .close => core.send(.exit, .{}), // Send an event telling mach to exit the app
+            .close => core.schedule(.exit), // Send an event telling mach to exit the app
             else => {},
         }
     }
@@ -208,5 +208,5 @@ fn tick(
         }
     }
 
-    renderer.send(.render_frame, .{});
+    renderer.schedule(.render_frame);
 }

--- a/examples/custom-renderer/Renderer.zig
+++ b/examples/custom-renderer/Renderer.zig
@@ -26,7 +26,7 @@ pub const components = .{
     .scale = .{ .type = f32 },
 };
 
-pub const events = .{
+pub const systems = .{
     .init = .{ .handler = init },
     .deinit = .{ .handler = deinit },
     .render_frame = .{ .handler = renderFrame },
@@ -185,5 +185,5 @@ fn renderFrame(
     core.state().queue.submit(&[_]*gpu.CommandBuffer{command});
 
     // Present the frame
-    core.send(.present_frame, .{});
+    core.schedule(.present_frame);
 }

--- a/examples/glyphs/Glyphs.zig
+++ b/examples/glyphs/Glyphs.zig
@@ -8,7 +8,7 @@ const assets = @import("assets");
 pub const name = .glyphs;
 pub const Mod = mach.Mod(@This());
 
-pub const events = .{
+pub const systems = .{
     .init = .{ .handler = init },
     .deinit = .{ .handler = deinit },
     .prepare = .{ .handler = prepare },

--- a/examples/play-opus/App.zig
+++ b/examples/play-opus/App.zig
@@ -18,7 +18,7 @@ var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 pub const name = .app;
 pub const Mod = mach.Mod(@This());
 
-pub const events = .{
+pub const systems = .{
     .init = .{ .handler = init },
     .after_init = .{ .handler = afterInit },
     .deinit = .{ .handler = deinit },
@@ -38,8 +38,8 @@ fn init(
     audio: *mach.Audio.Mod,
     app: *Mod,
 ) !void {
-    audio.send(.init, .{});
-    app.send(.after_init, .{});
+    audio.schedule(.init);
+    app.schedule(.after_init);
 
     const bgm_fbs = std.io.fixedBufferStream(assets.bgm.bit_bit_loop);
     const sfx_fbs = std.io.fixedBufferStream(assets.sfx.sword1);
@@ -65,18 +65,18 @@ fn init(
     std.debug.print("[arrow up]   increase volume 10%\n", .{});
     std.debug.print("[arrow down] decrease volume 10%\n", .{});
 
-    core.send(.start, .{});
+    core.schedule(.start);
 }
 
 fn afterInit(audio: *mach.Audio.Mod, app: *Mod) void {
     // Configure the audio module to send our app's .audio_state_change event when an entity's sound
     // finishes playing.
-    audio.state().on_state_change = app.event(.audio_state_change);
+    audio.state().on_state_change = app.system(.audio_state_change);
 }
 
 fn deinit(core: *mach.Core.Mod, audio: *mach.Audio.Mod) void {
-    audio.send(.deinit, .{});
-    core.send(.deinit, .{});
+    audio.schedule(.deinit);
+    core.schedule(.deinit);
 }
 
 fn audioStateChange(
@@ -135,7 +135,7 @@ fn tick(
                     try audio.set(e, .playing, true);
                 },
             },
-            .close => core.send(.exit, .{}),
+            .close => core.schedule(.exit),
             else => {},
         }
     }
@@ -175,5 +175,5 @@ fn tick(
     core.state().queue.submit(&[_]*gpu.CommandBuffer{command});
 
     // Present the frame
-    core.send(.present_frame, .{});
+    core.schedule(.present_frame);
 }

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -10,7 +10,7 @@ pub const name = .mach_core;
 
 pub const Mod = mach.Mod(@This());
 
-pub const events = .{
+pub const systems = .{
     .start = .{ .handler = start, .description = 
     \\ Send this once your app is initialized and ready for .app.tick events.
     },
@@ -128,7 +128,7 @@ fn init(entities: *mach.Entities.Mod, core: *Mod) !void {
         .main_window = main_window,
     });
 
-    mach.core.mods.send(.app, .init, .{});
+    mach.core.mods.schedule(.app, .init);
 }
 
 fn update(entities: *mach.Entities.Mod) !void {
@@ -153,12 +153,12 @@ fn presentFrame(core: *Mod) !void {
             mach.core.swap_chain.present();
 
             // Signal that mainThreadTick is done
-            core.send(.main_thread_tick_done, .{});
+            core.schedule(.main_thread_tick_done);
         },
         .exiting => {
             // Exit opportunity is here, deinitialize now
             core.state().run_state = .deinitializing;
-            mach.core.mods.send(.app, .deinit, .{});
+            mach.core.mods.schedule(.app, .deinit);
         },
         else => return,
     }
@@ -181,13 +181,13 @@ fn deinit(entities: *mach.Entities.Mod, core: *Mod) !void {
     core.state().run_state = .exited;
 
     // Signal that mainThreadTick is done
-    core.send(.main_thread_tick_done, .{});
+    core.schedule(.main_thread_tick_done);
 }
 
 fn mainThreadTick(core: *Mod) !void {
     if (core.state().run_state != .running) return;
     _ = try mach.core.update(null);
-    mach.core.mods.send(.app, .tick, .{});
+    mach.core.mods.schedule(.app, .tick);
 }
 
 fn exit(core: *Mod) void {

--- a/src/core/main.zig
+++ b/src/core/main.zig
@@ -16,19 +16,19 @@ pub fn initModule() !void {
     // Initialize the global set of Mach modules used in the program.
     try mods.init(std.heap.c_allocator);
 
-    mods.send(.mach_core, .init, .{});
+    mods.schedule(.mach_core, .init);
 }
 
 /// Tick runs a single step of the main loop on the main OS thread.
 ///
 /// Returns true if tick() should be called again, false if the application should exit.
 pub fn tick() !bool {
-    mods.send(.mach_core, .main_thread_tick, .{});
+    mods.schedule(.mach_core, .main_thread_tick);
 
     // Dispatch events until this .mach_core.main_thread_tick_done is sent
     try mods.dispatch(&stack_space, .{ .until = .{
         .module_name = mods.moduleNameToID(.mach_core),
-        .local_event = mods.localEventToID(.mach_core, .main_thread_tick_done),
+        .system = mods.systemToID(.mach_core, .main_thread_tick_done),
     } });
 
     return mods.mod.mach_core.state().run_state != .exited;

--- a/src/gfx/Sprite.zig
+++ b/src/gfx/Sprite.zig
@@ -38,7 +38,7 @@ pub const components = .{
     },
 };
 
-pub const events = .{
+pub const systems = .{
     .update = .{ .handler = update },
 };
 

--- a/src/gfx/SpritePipeline.zig
+++ b/src/gfx/SpritePipeline.zig
@@ -59,7 +59,7 @@ pub const components = .{
     .built = .{ .type = BuiltPipeline, .description = "internal" },
 };
 
-pub const events = .{
+pub const systems = .{
     .init = .{ .handler = init },
     .deinit = .{ .handler = deinit },
     .update = .{ .handler = update },

--- a/src/gfx/Text.zig
+++ b/src/gfx/Text.zig
@@ -50,7 +50,7 @@ pub const components = .{
     .built = .{ .type = BuiltText, .description = "internal" },
 };
 
-pub const events = .{
+pub const systems = .{
     .update = .{ .handler = update },
 };
 

--- a/src/gfx/TextPipeline.zig
+++ b/src/gfx/TextPipeline.zig
@@ -60,7 +60,7 @@ pub const components = .{
     .built = .{ .type = BuiltPipeline, .description = "internal" },
 };
 
-pub const events = .{
+pub const systems = .{
     .init = .{ .handler = fn () void },
     .deinit = .{ .handler = deinit },
     .update = .{ .handler = update },

--- a/src/main.zig
+++ b/src/main.zig
@@ -61,7 +61,11 @@ test {
     _ = gfx;
     _ = math;
     _ = testing;
+    std.testing.refAllDeclsRecursive(@import("module/Archetype.zig"));
+    std.testing.refAllDeclsRecursive(@import("module/entities.zig"));
     // std.testing.refAllDeclsRecursive(@import("module/main.zig"));
+    std.testing.refAllDeclsRecursive(@import("module/module.zig"));
+    std.testing.refAllDeclsRecursive(@import("module/StringTable.zig"));
     std.testing.refAllDeclsRecursive(gamemode);
     std.testing.refAllDeclsRecursive(math);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -36,8 +36,8 @@ pub const EntityID = @import("module/main.zig").EntityID; // TODO: rename to jus
 pub const Archetype = @import("module/main.zig").Archetype;
 
 pub const ModuleID = @import("module/main.zig").ModuleID;
-pub const EventID = @import("module/main.zig").EventID;
-pub const AnyEvent = @import("module/main.zig").AnyEvent;
+pub const SystemID = @import("module/main.zig").SystemID;
+pub const AnySystem = @import("module/main.zig").AnySystem;
 pub const merge = @import("module/main.zig").merge;
 pub const builtin_modules = @import("module/main.zig").builtin_modules;
 pub const Entities = @import("module/main.zig").Entities;

--- a/src/module/entities.zig
+++ b/src/module/entities.zig
@@ -1099,7 +1099,7 @@ test "example" {
     // Resolve archetype by entity ID and print column names
     const columns = world.archetypeByID(player2).columns;
     try testing.expectEqual(@as(usize, 2), columns.len);
-    try testing.expectEqualStrings("entity.id", world.component_names.string(columns[0].name));
+    try testing.expectEqualStrings("entities.id", world.component_names.string(columns[0].name));
     try testing.expectEqualStrings("game.rotation", world.component_names.string(columns[1].name));
 
     //-------------------------------------------------------------------------
@@ -1128,7 +1128,7 @@ test "example" {
         try testing.expectEqual(@as(usize, 1), archtype.len);
         try testing.expectEqual(@as(usize, 2), archtype.columns.len);
 
-        try testing.expectEqualStrings("entity.id", world.component_names.string(archtype.columns[0].name));
+        try testing.expectEqualStrings("entities.id", world.component_names.string(archtype.columns[0].name));
         try testing.expectEqualStrings("game.rotation", world.component_names.string(archtype.columns[1].name));
     }
 
@@ -1186,16 +1186,16 @@ test "many entities" {
     // Confirm archetypes
     var columns = archetypes[0].columns;
     try testing.expectEqual(@as(usize, 1), columns.len);
-    try testing.expectEqualStrings("entity.id", world.component_names.string(columns[0].name));
+    try testing.expectEqualStrings("entities.id", world.component_names.string(columns[0].name));
 
     columns = archetypes[1].columns;
     try testing.expectEqual(@as(usize, 2), columns.len);
-    try testing.expectEqualStrings("entity.id", world.component_names.string(columns[0].name));
+    try testing.expectEqualStrings("entities.id", world.component_names.string(columns[0].name));
     try testing.expectEqualStrings("game.name", world.component_names.string(columns[1].name));
 
     columns = archetypes[2].columns;
     try testing.expectEqual(@as(usize, 3), columns.len);
-    try testing.expectEqualStrings("entity.id", world.component_names.string(columns[0].name));
+    try testing.expectEqualStrings("entities.id", world.component_names.string(columns[0].name));
     try testing.expectEqualStrings("game.name", world.component_names.string(columns[1].name));
     try testing.expectEqualStrings("game.location", world.component_names.string(columns[2].name));
 }

--- a/src/module/main.zig
+++ b/src/module/main.zig
@@ -8,8 +8,8 @@ pub const Archetype = @import("Archetype.zig");
 pub const ModSet = @import("module.zig").ModSet;
 pub const Modules = @import("module.zig").Modules;
 pub const ModuleID = @import("module.zig").ModuleID;
-pub const EventID = @import("module.zig").EventID;
-pub const AnyEvent = @import("module.zig").AnyEvent;
+pub const SystemID = @import("module.zig").SystemID;
+pub const AnySystem = @import("module.zig").AnySystem;
 pub const Merge = @import("module.zig").Merge;
 pub const merge = @import("module.zig").merge;
 
@@ -46,7 +46,7 @@ test "entities DB" {
             pub const components = .{
                 .id = .{ .type = u32 },
             };
-            pub const events = .{
+            pub const systems = .{
                 .tick = .{ .handler = tick },
             };
 
@@ -60,7 +60,7 @@ test "entities DB" {
             pub const components = .{
                 .id = .{ .type = u16 },
             };
-            pub const events = .{
+            pub const systems = .{
                 .tick = .{ .handler = tick },
             };
 
@@ -97,8 +97,10 @@ test "entities DB" {
     try physics.set(player3, .id, 1003);
 
     //-------------------------------------------------------------------------
-    // Send events to modules
-    world.mod.renderer.send(.tick, .{});
+    // Schedule systems to run
+    world.mod.renderer.schedule(.tick);
+
+    // Dispatch systems
     var stack_space: [8 * 1024 * 1024]u8 = undefined;
     try world.dispatch(&stack_space, .{});
 }

--- a/src/module/main.zig
+++ b/src/module/main.zig
@@ -46,7 +46,7 @@ test "entities DB" {
             pub const components = .{
                 .id = .{ .type = u32 },
             };
-            pub const global_events = .{
+            pub const events = .{
                 .tick = .{ .handler = tick },
             };
 
@@ -60,7 +60,7 @@ test "entities DB" {
             pub const components = .{
                 .id = .{ .type = u16 },
             };
-            pub const global_events = .{
+            pub const events = .{
                 .tick = .{ .handler = tick },
             };
 
@@ -87,9 +87,9 @@ test "entities DB" {
     physics.init(.{ .pointer = 123 });
     _ = physics.state().pointer; // == 123
 
-    const player1 = try try entities.new();
-    const player2 = try try entities.new();
-    const player3 = try try entities.new();
+    const player1 = try entities.new();
+    const player2 = try entities.new();
+    const player3 = try entities.new();
     try physics.set(player1, .id, 1001);
     try renderer.set(player1, .id, 1001);
 
@@ -98,7 +98,7 @@ test "entities DB" {
 
     //-------------------------------------------------------------------------
     // Send events to modules
-    world.mod.renderer.sendGlobal(.tick, .{});
+    world.mod.renderer.send(.tick, .{});
     var stack_space: [8 * 1024 * 1024]u8 = undefined;
     try world.dispatch(&stack_space, .{});
 }


### PR DESCRIPTION
## Remove global events

Previously our module system / ECS had two concepts of executable code ('systems' in other ECS), 'local events' and 'global events':

* Local events were where one module would schedule a function to run on another specific module.
* Global events were where one module would say 'an event has occurred' and any other module (potentially multiple) could react to it by having their function get scheduled for execution.

Global events were intended to be _unordered execution_, a point of parallelism opportunity to run multiple functions at once across different threads.

However, in practice, we don't have this multi-threaded capability yet - and it was easy to accidentally end up observing execution order of global events' handler functions. There is also some suspicion that it is not the right API for parallelism here. So for now, we remove this concept.

## Hinder/remove 'event arguments'

Event arguments I think are still a good idea, specifically in the cases they were intended for:

* A GUI editor external process wanting to communicate some data to your game process, without needing to shuffle it through a component value.
* One process communicating to another (potentially over a network) some data.
* One language communicating some data to another language (e.g. Zig and Go ECS modules in the same program)
* Debug tooling being able to observe notable information about things that have occurred.

However, these use cases are different from 'one zig function passes data to another' - and it has been tempting to misuse this feature for that purpose, which is almost always better served by storing data as components on entities.

To help correct this, we make it very clear in docs that you shouldn't be using 'event arguments' except in situations above, and that the types of arguments may be restriction in the future. Additionally, we make the default 'send event' function _not_ take arguments and have a second (longer-name to discourage its use) variant which does.

## Renamed Events to Systems

What we call events are typically called systems in other ECS implementations. Although we do differ in some substantial ways (e.g. how we schedule the execution of a function is more 'fire an event and the function runs once' style than it is 'a system generally always runs' style, found in other ECS.)

Still, even with our unique take on system scheduling - and even with 'event arguments' being a thing, I've come to believe we should keep the `system` name instead for a few reasons:

1. For others coming from different languages/etc looking for 'how does mach do ECS systems' from a documentation POV.
2. To avoid conflict with other 'events' in Mach, e.g. (keyboard/mouse) input events are different from a 'system function event' - so it makes sense to just call one events and the other systems to avoid confusion.
3. 'Sending' something which causes a function to _run later_ is not as clear as 'Scheduling' a function to run later.

## API renamings

```
foo_mod.send(.bar, .{}) -> foo_mod.schedule(.bar)
foo_mod.send(.bar, .{baz}) -> foo_mod.scheduleWithArgs(.bar, .{baz}) // discouraged for use
foo_mod.sendAnyEvent(event) -> foo_mod.scheduleAny(system)
```

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.