### PR TITLE
sysaudio: fix wasapi format selection + fix crash without capture device

### DIFF
--- a/src/sysaudio/wasapi.zig
+++ b/src/sysaudio/wasapi.zig
@@ -162,7 +162,9 @@ pub const Context = struct {
         const default_playback_id = try ctx.getDefaultAudioEndpoint(.playback);
         defer ctx.allocator.free(default_playback_id.?);
         const default_capture_id = try ctx.getDefaultAudioEndpoint(.capture);
-        defer ctx.allocator.free(default_capture_id.?);
+        if (default_capture_id) |default_id| {
+            defer ctx.allocator.free(default_id);
+        }
 
         // enumerate
         var collection: ?*win32.IMMDeviceCollection = null;


### PR DESCRIPTION
This fixes a crash in the `play-opus` example on my Windows 11 machine, wherein no audio format is selected and crashes when trying to read from `device.formats[0]`.
(Stacktrace for reference: https://gist.github.com/Andoryuuta/defa7bef64bfd5d14e913e5dd9b04284)

Additionally, while debugging this, I found that the example would also crash on startup when my microphone was not plugged in. Small drive-by fix for that is included in this MR as well.

This "works on my machine", but I'm not confident I understand the intentions of the previous code enough to say that this is completely correct.


- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.