### PR TITLE
Examples: Add "screenshot" functionality to the triangle example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -568,7 +568,7 @@ fn buildExamples(
     }{
         // Mach core examples
         .{ .core = true, .name = "custom-entrypoint", .deps = &.{} },
-        .{ .core = true, .name = "triangle", .deps = &.{} },
+        .{ .core = true, .name = "triangle", .deps = &.{.zigimg} },
 
         // Mach engine examples
         .{ .name = "hardware-check", .deps = &.{ .assets, .zigimg } },

--- a/examples/core/triangle/App.zig
+++ b/examples/core/triangle/App.zig
@@ -147,10 +147,13 @@ fn tick(core: *mach.Core.Mod, game: *Mod, offscreen: *Offscreen.Mod) !void {
 
         encoder.copyTextureToBuffer(
             &.{ .texture = offscreen.state().texture },
-            &.{ .buffer = offscreen.state().buffer, .layout = .{
-                .bytes_per_row = offscreen.state().buffer_padded_bytes_per_row,
-                .rows_per_image = offscreen.state().buffer_height,
-            } },
+            &.{
+                .buffer = offscreen.state().buffer,
+                .layout = .{
+                    .bytes_per_row = offscreen.state().buffer_padded_bytes_per_row,
+                    .rows_per_image = offscreen.state().buffer_height,
+                },
+            },
             &.{
                 .width = offscreen.state().buffer_width,
                 .height = offscreen.state().buffer_height,

--- a/examples/core/triangle/App.zig
+++ b/examples/core/triangle/App.zig
@@ -206,6 +206,8 @@ fn tick(core: *mach.Core.Mod, game: *Mod, offscreen: *Offscreen.Mod) !void {
             try image.writeToFilePath("output.png", .{ .png = .{} });
         }
 
+        state.buffer.unmap();
+
         game.state().save_screenshot = false;
         game.state().screenshot_saved = true;
     }

--- a/examples/core/triangle/App.zig
+++ b/examples/core/triangle/App.zig
@@ -203,6 +203,7 @@ fn tick(core: *mach.Core.Mod, game: *Mod, offscreen: *Offscreen.Mod) !void {
             callback,
         );
 
+        state.buffer.unmap();
         game.state().save_screenshot = false;
     }
 

--- a/examples/core/triangle/App.zig
+++ b/examples/core/triangle/App.zig
@@ -156,7 +156,7 @@ fn tick(core: *mach.Core.Mod, game: *Mod, offscreen: *Offscreen.Mod) !void {
                 .label = label,
                 .color_attachments = &offscreen_color_attachments,
             }));
-            defer render_pass.release();
+            defer offscreen_render_pass.release();
 
             // Draw
             offscreen_render_pass.setPipeline(game.state().pipeline);

--- a/examples/core/triangle/App.zig
+++ b/examples/core/triangle/App.zig
@@ -5,6 +5,8 @@ const gpu = mach.gpu;
 pub const name = .app;
 pub const Mod = mach.Mod(@This());
 
+const Offscreen = @import("Offscreen.zig");
+
 pub const systems = .{
     .init = .{ .handler = init },
     .after_init = .{ .handler = afterInit },
@@ -14,18 +16,23 @@ pub const systems = .{
 
 title_timer: mach.Timer,
 pipeline: *gpu.RenderPipeline,
+screenshot_requested: bool = false,
+save_screenshot: bool = false,
 
-pub fn deinit(core: *mach.Core.Mod, game: *Mod) void {
+pub fn deinit(core: *mach.Core.Mod, game: *Mod, offscreen: *Offscreen.Mod) void {
     game.state().pipeline.release();
+    offscreen.schedule(.deinit);
     core.schedule(.deinit);
 }
 
-fn init(game: *Mod, core: *mach.Core.Mod) !void {
+fn init(game: *Mod, core: *mach.Core.Mod, offscreen: *Offscreen.Mod) !void {
     core.schedule(.init);
+    offscreen.schedule(.init);
     game.schedule(.after_init);
 }
 
-fn afterInit(game: *Mod, core: *mach.Core.Mod) !void {
+fn afterInit(game: *Mod, core: *mach.Core.Mod, offscreen: *Offscreen.Mod) !void {
+
     // Create our shader module
     const shader_module = core.state().device.createShaderModuleWGSL("shader.wgsl", @embedFile("shader.wgsl"));
     defer shader_module.release();
@@ -39,11 +46,22 @@ fn afterInit(game: *Mod, core: *mach.Core.Mod) !void {
         .blend = &blend,
     };
 
+    const offscreen_color_target = gpu.ColorTargetState{
+        .format = .rgba8_unorm,
+        .blend = &blend,
+    };
+
     // Fragment state describes which shader and entrypoint to use for rendering fragments.
     const fragment = gpu.FragmentState.init(.{
         .module = shader_module,
         .entry_point = "frag_main",
         .targets = &.{color_target},
+    });
+
+    const offscreen_fragment = gpu.FragmentState.init(.{
+        .module = shader_module,
+        .entry_point = "frag_main",
+        .targets = &.{offscreen_color_target},
     });
 
     // Create our render pipeline that will ultimately get pixels onto the screen.
@@ -58,6 +76,17 @@ fn afterInit(game: *Mod, core: *mach.Core.Mod) !void {
     };
     const pipeline = core.state().device.createRenderPipeline(&pipeline_descriptor);
 
+    const offscreen_pipeline_descriptor = gpu.RenderPipeline.Descriptor{
+        .label = label,
+        .fragment = &offscreen_fragment,
+        .vertex = gpu.VertexState{
+            .module = shader_module,
+            .entry_point = "vertex_main",
+        },
+    };
+
+    offscreen.state().pipeline = core.state().device.createRenderPipeline(&offscreen_pipeline_descriptor);
+
     // Store our render pipeline in our module's state, so we can access it later on.
     game.init(.{
         .title_timer = try mach.Timer.start(),
@@ -68,7 +97,7 @@ fn afterInit(game: *Mod, core: *mach.Core.Mod) !void {
     core.schedule(.start);
 }
 
-fn tick(core: *mach.Core.Mod, game: *Mod) !void {
+fn tick(core: *mach.Core.Mod, game: *Mod, offscreen: *Offscreen.Mod) !void {
     // TODO(important): event polling should occur in mach.Core module and get fired as ECS event.
     // TODO(Core)
     var iter = mach.core.pollEvents();
@@ -79,44 +108,103 @@ fn tick(core: *mach.Core.Mod, game: *Mod) !void {
         }
     }
 
-    // Grab the back buffer of the swapchain
-    // TODO(Core)
-    const back_buffer_view = mach.core.swap_chain.getCurrentTextureView().?;
-    defer back_buffer_view.release();
+    if (mach.core.keyPressed(mach.core.Key.space)) {
+        game.state().screenshot_requested = true;
+    }
 
-    // Create a command encoder
-    const label = @tagName(name) ++ ".tick";
-    const encoder = core.state().device.createCommandEncoder(&.{ .label = label });
-    defer encoder.release();
+    {
+        // Grab the back buffer of the swapchain
+        // TODO(Core)
+        const back_buffer_view = mach.core.swap_chain.getCurrentTextureView().?;
+        defer back_buffer_view.release();
 
-    // Begin render pass
-    const sky_blue_background = gpu.Color{ .r = 0.776, .g = 0.988, .b = 1, .a = 1 };
-    const color_attachments = [_]gpu.RenderPassColorAttachment{.{
-        .view = back_buffer_view,
-        .clear_value = sky_blue_background,
-        .load_op = .clear,
-        .store_op = .store,
-    }};
-    const render_pass = encoder.beginRenderPass(&gpu.RenderPassDescriptor.init(.{
-        .label = label,
-        .color_attachments = &color_attachments,
-    }));
-    defer render_pass.release();
+        // Create a command encoder
+        const label = @tagName(name) ++ ".tick";
+        const encoder: *mach.gpu.CommandEncoder = core.state().device.createCommandEncoder(&.{ .label = label });
+        defer encoder.release();
 
-    // Draw
-    render_pass.setPipeline(game.state().pipeline);
-    render_pass.draw(3, 1, 0, 0);
+        // Begin render pass
+        const sky_blue_background = gpu.Color{ .r = 0.776, .g = 0.988, .b = 1, .a = 1 };
+        const color_attachments = [_]gpu.RenderPassColorAttachment{.{
+            .view = back_buffer_view,
+            .clear_value = sky_blue_background,
+            .load_op = .clear,
+            .store_op = .store,
+        }};
+        const render_pass = encoder.beginRenderPass(&gpu.RenderPassDescriptor.init(.{
+            .label = label,
+            .color_attachments = &color_attachments,
+        }));
+        defer render_pass.release();
 
-    // Finish render pass
-    render_pass.end();
+        // Draw
+        render_pass.setPipeline(game.state().pipeline);
+        render_pass.draw(3, 1, 0, 0);
 
-    // Submit our commands to the queue
-    var command = encoder.finish(&.{ .label = label });
-    defer command.release();
-    core.state().queue.submit(&[_]*gpu.CommandBuffer{command});
+        // Finish render pass
+        render_pass.end();
 
-    // Present the frame
-    core.schedule(.present_frame);
+        if (game.state().screenshot_requested) {
+            const offscreen_color_attachments = [_]gpu.RenderPassColorAttachment{.{
+                .view = offscreen.state().view,
+                .clear_value = sky_blue_background,
+                .load_op = .clear,
+                .store_op = .store,
+            }};
+
+            const offscreen_render_pass = encoder.beginRenderPass(&gpu.RenderPassDescriptor.init(.{
+                .label = label,
+                .color_attachments = &offscreen_color_attachments,
+            }));
+            defer render_pass.release();
+
+            // Draw
+            offscreen_render_pass.setPipeline(game.state().pipeline);
+            offscreen_render_pass.draw(3, 1, 0, 0);
+
+            // Finish render pass
+            offscreen_render_pass.end();
+
+            encoder.copyTextureToBuffer(
+                &.{ .texture = offscreen.state().texture },
+                &.{ .buffer = offscreen.state().buffer, .layout = .{
+                    .bytes_per_row = offscreen.state().buffer_padded_bytes_per_row,
+                    .rows_per_image = offscreen.state().buffer_height,
+                } },
+                &.{
+                    .width = offscreen.state().buffer_width,
+                    .height = offscreen.state().buffer_height,
+                    .depth_or_array_layers = 1,
+                },
+            );
+            game.state().save_screenshot = true;
+            game.state().screenshot_requested = false;
+        }
+
+        // Submit our commands to the queue
+        var command = encoder.finish(&.{ .label = label });
+        defer command.release();
+        core.state().queue.submit(&[_]*gpu.CommandBuffer{command});
+
+        // Present the frame
+        core.schedule(.present_frame);
+    }
+
+    if (game.state().save_screenshot) {
+        const state: *Offscreen = offscreen.state();
+
+        var ctx: CallbackCtx = .{};
+
+        state.buffer.mapAsync(
+            .{ .read = true },
+            0,
+            state.buffer_height * state.buffer_padded_bytes_per_row,
+            &ctx,
+            callback,
+        );
+
+        game.state().save_screenshot = false;
+    }
 
     // update the window title every second
     if (game.state().title_timer.read() >= 1.0) {
@@ -138,3 +226,11 @@ fn updateWindowTitle(core: *mach.Core.Mod) !void {
     );
     core.schedule(.update);
 }
+
+pub const CallbackCtx = struct {};
+
+pub inline fn callback(_: *CallbackCtx, status: mach.gpu.Buffer.MapAsyncStatus) void {
+    _ = status; // autofix
+}
+
+//comptime callback: fn(ctx:@TypeOf(context), status:MapAsyncStatus)callconv(.Inline)void

--- a/examples/core/triangle/Offscreen.zig
+++ b/examples/core/triangle/Offscreen.zig
@@ -24,7 +24,6 @@ buffer_width: u32 = 0,
 buffer_height: u32 = 0,
 buffer_unpadded_bytes_per_row: u32 = 0,
 buffer_padded_bytes_per_row: u32 = 0,
-output_image: zigimg.Image,
 allocator: std.mem.Allocator,
 
 fn deinit(offscreen: *Mod) !void {
@@ -43,8 +42,6 @@ fn init(
     const allocator = gpa.allocator();
 
     const img_size = gpu.Extent3D{ .width = mach.core.size().width, .height = mach.core.size().height };
-
-    const output_image = zigimg.Image.create(allocator, @intCast(img_size.width), @intCast(img_size.height), .rgba32) catch unreachable;
 
     // Create a GPU texture
     const label = @tagName(name) ++ ".init";
@@ -77,7 +74,6 @@ fn init(
         .buffer_width = img_size.width,
         .buffer_height = img_size.height,
         .buffer_padded_bytes_per_row = @sizeOf([4]u8) * img_size.width,
-        .output_image = output_image,
         .allocator = allocator,
     });
 }

--- a/examples/core/triangle/Offscreen.zig
+++ b/examples/core/triangle/Offscreen.zig
@@ -70,6 +70,9 @@ fn init(
         .texture = texture,
         .view = view,
         .buffer = buffer,
+        .buffer_width = img_size.width,
+        .buffer_height = img_size.height,
+        .buffer_padded_bytes_per_row = @sizeOf([4]u8) * img_size.width,
         .allocator = allocator,
         .pipeline = undefined,
     });

--- a/examples/core/triangle/Offscreen.zig
+++ b/examples/core/triangle/Offscreen.zig
@@ -52,6 +52,7 @@ fn init(
         .usage = .{
             .texture_binding = true,
             .copy_dst = true,
+            .copy_src = true,
             .render_attachment = true,
         },
     });

--- a/examples/core/triangle/Offscreen.zig
+++ b/examples/core/triangle/Offscreen.zig
@@ -12,12 +12,10 @@ pub const Mod = mach.Mod(@This());
 pub const systems = .{
     .init = .{ .handler = init },
     .deinit = .{ .handler = deinit },
-    .prepare = .{ .handler = prepare },
 };
 
 var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 
-pipeline: *gpu.RenderPipeline,
 texture: *gpu.Texture,
 view: *gpu.TextureView,
 buffer: *gpu.Buffer,
@@ -81,13 +79,5 @@ fn init(
         .buffer_padded_bytes_per_row = @sizeOf([4]u8) * img_size.width,
         .output_image = output_image,
         .allocator = allocator,
-        .pipeline = undefined,
     });
-}
-
-fn prepare(core: *mach.Core.Mod, offscreen: *Mod) !void {
-    _ = core;
-
-    const state: *@This() = offscreen.state();
-    _ = state; // autofix
 }

--- a/examples/core/triangle/Offscreen.zig
+++ b/examples/core/triangle/Offscreen.zig
@@ -4,6 +4,8 @@ const gpu = mach.gpu;
 const std = @import("std");
 const assets = @import("assets");
 
+const zigimg = @import("zigimg");
+
 pub const name = .offscreen;
 pub const Mod = mach.Mod(@This());
 
@@ -24,6 +26,7 @@ buffer_width: u32 = 0,
 buffer_height: u32 = 0,
 buffer_unpadded_bytes_per_row: u32 = 0,
 buffer_padded_bytes_per_row: u32 = 0,
+output_image: zigimg.Image,
 allocator: std.mem.Allocator,
 
 fn deinit(offscreen: *Mod) !void {
@@ -42,6 +45,8 @@ fn init(
     const allocator = gpa.allocator();
 
     const img_size = gpu.Extent3D{ .width = mach.core.size().width, .height = mach.core.size().height };
+
+    const output_image = zigimg.Image.create(allocator, @intCast(img_size.width), @intCast(img_size.height), .rgba32) catch unreachable;
 
     // Create a GPU texture
     const label = @tagName(name) ++ ".init";
@@ -74,6 +79,7 @@ fn init(
         .buffer_width = img_size.width,
         .buffer_height = img_size.height,
         .buffer_padded_bytes_per_row = @sizeOf([4]u8) * img_size.width,
+        .output_image = output_image,
         .allocator = allocator,
         .pipeline = undefined,
     });

--- a/examples/core/triangle/Offscreen.zig
+++ b/examples/core/triangle/Offscreen.zig
@@ -1,0 +1,83 @@
+// TODO(important): review all code in this file in-depth
+const mach = @import("mach");
+const gpu = mach.gpu;
+const std = @import("std");
+const assets = @import("assets");
+
+pub const name = .offscreen;
+pub const Mod = mach.Mod(@This());
+
+pub const systems = .{
+    .init = .{ .handler = init },
+    .deinit = .{ .handler = deinit },
+    .prepare = .{ .handler = prepare },
+};
+
+var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+
+pipeline: *gpu.RenderPipeline,
+texture: *gpu.Texture,
+view: *gpu.TextureView,
+buffer: *gpu.Buffer,
+buffer_mapped: bool = false,
+buffer_width: u32 = 0,
+buffer_height: u32 = 0,
+buffer_unpadded_bytes_per_row: u32 = 0,
+buffer_padded_bytes_per_row: u32 = 0,
+allocator: std.mem.Allocator,
+
+fn deinit(offscreen: *Mod) !void {
+    const state = offscreen.state();
+
+    state.texture.release();
+    state.view.release();
+    state.buffer.release();
+}
+
+fn init(
+    core: *mach.Core.Mod,
+    offscreen: *Mod,
+) !void {
+    const device: *mach.gpu.Device = core.state().device;
+    const allocator = gpa.allocator();
+
+    const img_size = gpu.Extent3D{ .width = mach.core.size().width, .height = mach.core.size().height };
+
+    // Create a GPU texture
+    const label = @tagName(name) ++ ".init";
+    const texture = device.createTexture(&.{
+        .label = label,
+        .size = img_size,
+        .format = .bgra8_unorm,
+        .usage = .{
+            .texture_binding = true,
+            .copy_dst = true,
+            .render_attachment = true,
+        },
+    });
+
+    const view = texture.createView(&.{
+        .format = .bgra8_unorm,
+        .dimension = .dimension_2d,
+    });
+
+    const buffer = device.createBuffer(&.{
+        .usage = .{ .map_read = true, .copy_dst = true },
+        .size = @sizeOf([4]u8) * img_size.width * img_size.height,
+    });
+
+    offscreen.init(.{
+        .texture = texture,
+        .view = view,
+        .buffer = buffer,
+        .allocator = allocator,
+        .pipeline = undefined,
+    });
+}
+
+fn prepare(core: *mach.Core.Mod, offscreen: *Mod) !void {
+    _ = core;
+
+    const state: *@This() = offscreen.state();
+    _ = state; // autofix
+}

--- a/examples/core/triangle/main.zig
+++ b/examples/core/triangle/main.zig
@@ -4,6 +4,7 @@ const mach = @import("mach");
 pub const modules = .{
     mach.Core,
     @import("App.zig"),
+    @import("Offscreen.zig"),
 };
 
 pub fn main() !void {


### PR DESCRIPTION
This PR adds the ability to press spacebar on the triangle example to save an offscreen render texture from GPU to CPU then save to an image on disk. This should work fine when using Dawn but will highlight an unimplemented method `encoder.CopyTextureToBuffer` in sysgpu.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.