### PR TITLE
CI: use mlugg/setup-zig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Zig
-        run: |
-          sudo apt install xz-utils
-          sudo sh -c 'wget -c https://pkg.machengine.org/zig/zig-linux-x86_64-0.13.0-dev.351+64ef45eb0.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 2024.5.0-mach
+          mirror: 'https://pkg.machengine.org/zig'
       # - name: x86_64-linux -> x86_64-linux-musl
       #   run: zig build -Dtarget=x86_64-linux-musl
       - name: x86_64-linux -> x86_64-macos
@@ -70,12 +71,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Zig
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri 'https://pkg.machengine.org/zig/zig-windows-x86_64-0.13.0-dev.351+64ef45eb0.zip' -OutFile 'C:\zig.zip'
-          cd C:\
-          7z x zig.zip
-          Add-Content $env:GITHUB_PATH 'C:\zig-windows-x86_64-0.13.0-dev.351+64ef45eb0\'
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 2024.5.0-mach
+          mirror: 'https://pkg.machengine.org/zig'
       - name: test
         run: zig build test
   x86_64-macos:
@@ -87,9 +86,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Zig
-        run: |
-          brew uninstall --ignore-dependencies libx11 # https://github.com/ziglang/zig/issues/11066
-          brew install xz
-          sudo sh -c 'wget -c https://pkg.machengine.org/zig/zig-macos-x86_64-0.13.0-dev.351+64ef45eb0.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 2024.5.0-mach
+          mirror: 'https://pkg.machengine.org/zig'
+      - name: Workaround Zig Bug
+        run: brew uninstall --ignore-dependencies libx11 # https://github.com/ziglang/zig/issues/11066
       - name: test
         run: zig build test


### PR DESCRIPTION
This doesn't need to be merged if you'd prefer to stick with the current logic; I largely just wanted to see if it works properly. Nonetheless, I think this represents an improvement to the CI scripts.

This PR begins using the https://github.com/mlugg/setup-zig action to install Zig in the CI workflow. This has the following advantages:
* No more target-specific scripts; setting up Zig is 4 simple lines.
* The tarball's minisig is verified, so this will flag up issues if the Mach mirror ever starts doing anything weird.
* The Zig version is specified in Mach lingo, i.e. `2024.5.0-mach` rather than `zig-0.13.0-dev.351+64ef45eb0`.
  * This could alternatively say `mach-latest`, but I figured this makes more sense for handling the upgrade process when new versions are nominated.
* The global Zig cache is automatically preserved across runs, avoiding redundant work. In particular, this will avoid doing redundant work rebuilding C dependencies on every commit.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.