### PR TITLE
Few fixes for sysgpu on d3d12

### DIFF
--- a/src/core/examples/sysgpu/sprite2d/main.zig
+++ b/src/core/examples/sysgpu/sprite2d/main.zig
@@ -75,7 +75,7 @@ pub fn init(app: *App) !void {
 
     const allocator = gpa.allocator();
 
-    const sprites_file = try std.fs.cwd().openFile("../../examples/sprite2d/sprites.json", .{ .mode = .read_only });
+    const sprites_file = try std.fs.cwd().openFile("../../src/core/examples/sysgpu/sprite2d/sprites.json", .{ .mode = .read_only });
     defer sprites_file.close();
     const file_size = (try sprites_file.stat()).size;
     const buffer = try allocator.alloc(u8, file_size);
@@ -272,7 +272,7 @@ pub fn update(app: *App) !bool {
     // update the window title every second
     if (app.title_timer.read() >= 1.0) {
         app.title_timer.reset();
-        try core.printTitle("Sprite2D [ {d}fps ] [ Input {d}hz ]", .{
+        try core.printTitle("Sprite2D [ {d}fps ] [ Input {d}hz]", .{
             core.frameRate(),
             core.inputRate(),
         });

--- a/src/core/examples/sysgpu/sprite2d/sprite-shader.wgsl
+++ b/src/core/examples/sysgpu/sprite2d/sprite-shader.wgsl
@@ -6,7 +6,7 @@ struct Uniforms {
 struct VertexOutput {
   @builtin(position) Position : vec4<f32>,
   @location(0) fragUV : vec2<f32>,
-  @location(1) spriteIndex : f32,
+  @location(1) spriteIndex : vec3<f32>,
 };
 
 struct Sprite {
@@ -56,7 +56,7 @@ fn vertex_main(
   var output : VertexOutput;
   output.Position = vec4<f32>(pos.x, 0.0, pos.y, 1.0) * uniforms.modelViewProjectionMatrix;
   output.fragUV = uv;
-  output.spriteIndex = f32(VertexIndex / 6);
+  output.spriteIndex = vec3<f32>(f32(VertexIndex / 6));
   return output;
 }
 
@@ -66,10 +66,10 @@ fn vertex_main(
 @fragment
 fn frag_main(
   @location(0) fragUV: vec2<f32>,
-  @location(1) spriteIndex: f32
+  @location(1) spriteIndex: vec3<f32>
 ) -> @location(0) vec4<f32> {
     var color = textureSample(spriteTexture, spriteSampler, fragUV);
-    if (spriteIndex == 0.0) {
+    if (spriteIndex[0] == 0.0) {
       if (color[3] > 0.0) {
         color[0] = 0.3;
         color[1] = 0.2;

--- a/src/gfx/Sprite.zig
+++ b/src/gfx/Sprite.zig
@@ -5,6 +5,9 @@ const gfx = mach.gfx;
 
 const math = mach.math;
 const vec2 = math.vec2;
+const vec3 = math.vec3;
+const vec4 = math.vec4;
+const mat4x4 = math.mat4x4;
 const Vec2 = math.Vec2;
 const Vec3 = math.Vec3;
 const Mat3x3 = math.Mat3x3;
@@ -87,8 +90,12 @@ fn updatePipeline(
             // that all entities with the same pipeline value are stored in contiguous memory, and
             // skip this copy.
             if (sprite_pipeline_id == pipeline_id) {
+                const uv = uv_transform;
                 gfx.SpritePipeline.cp_transforms[i] = transform;
-                gfx.SpritePipeline.cp_uv_transforms[i] = uv_transform;
+                gfx.SpritePipeline.cp_uv_transforms[i].v[0] = vec4(uv.v[0].x(), uv.v[0].y(), uv.v[0].z(), 0.0);
+                gfx.SpritePipeline.cp_uv_transforms[i].v[1] = vec4(uv.v[1].x(), uv.v[1].y(), uv.v[1].z(), 0.0);
+                gfx.SpritePipeline.cp_uv_transforms[i].v[2] = vec4(uv.v[2].x(), uv.v[2].y(), uv.v[2].z(), 0.0);
+                gfx.SpritePipeline.cp_uv_transforms[i].v[3] = vec4(0.0, 0.0, 0.0, 0.0);
                 gfx.SpritePipeline.cp_sizes[i] = size;
                 i += 1;
                 num_sprites += 1;
@@ -99,7 +106,7 @@ fn updatePipeline(
     // Sort sprites back-to-front for draw order, alpha blending
     const Context = struct {
         transforms: []Mat4x4,
-        uv_transforms: []Mat3x3,
+        uv_transforms: []Mat4x4, 
         sizes: []Vec2,
 
         pub fn lessThan(ctx: @This(), a: usize, b: usize) bool {
@@ -111,7 +118,7 @@ fn updatePipeline(
 
         pub fn swap(ctx: @This(), a: usize, b: usize) void {
             std.mem.swap(Mat4x4, &ctx.transforms[a], &ctx.transforms[b]);
-            std.mem.swap(Mat3x3, &ctx.uv_transforms[a], &ctx.uv_transforms[b]);
+            std.mem.swap(Mat4x4, &ctx.uv_transforms[a], &ctx.uv_transforms[b]);
             std.mem.swap(Vec2, &ctx.sizes[a], &ctx.sizes[b]);
         }
     };

--- a/src/gfx/SpritePipeline.zig
+++ b/src/gfx/SpritePipeline.zig
@@ -110,7 +110,7 @@ const sprite_buffer_cap = 1024 * 512; // TODO(sprite): allow user to specify pre
 // TODO(sprite): eliminate these, see Sprite.updatePipeline for details on why these exist
 // currently.
 pub var cp_transforms: [sprite_buffer_cap]math.Mat4x4 = undefined;
-pub var cp_uv_transforms: [sprite_buffer_cap]math.Mat3x3 = undefined;
+pub var cp_uv_transforms: [sprite_buffer_cap]math.Mat4x4 = undefined;
 pub var cp_sizes: [sprite_buffer_cap]math.Vec2 = undefined;
 
 /// Which render pass should be used during .render
@@ -209,7 +209,7 @@ fn buildPipeline(
     const uv_transforms = device.createBuffer(&.{
         .label = label ++ " uv_transforms",
         .usage = .{ .storage = true, .copy_dst = true },
-        .size = @sizeOf(math.Mat3x3) * sprite_buffer_cap,
+        .size = @sizeOf(math.Mat4x4) * sprite_buffer_cap,
         .mapped_at_creation = .false,
     });
     const sizes = device.createBuffer(&.{
@@ -269,9 +269,9 @@ fn buildPipeline(
                 else
                     gpu.BindGroup.Entry.buffer(1, transforms, 0, @sizeOf(math.Mat4x4) * sprite_buffer_cap),
                 if (mach.use_sysgpu)
-                    gpu.BindGroup.Entry.buffer(2, uv_transforms, 0, @sizeOf(math.Mat3x3) * sprite_buffer_cap, @sizeOf(math.Mat3x3))
+                    gpu.BindGroup.Entry.buffer(2, uv_transforms, 0, @sizeOf(math.Mat4x4) * sprite_buffer_cap, @sizeOf(math.Mat4x4))
                 else
-                    gpu.BindGroup.Entry.buffer(2, uv_transforms, 0, @sizeOf(math.Mat3x3) * sprite_buffer_cap),
+                    gpu.BindGroup.Entry.buffer(2, uv_transforms, 0, @sizeOf(math.Mat4x4) * sprite_buffer_cap),
                 if (mach.use_sysgpu)
                     gpu.BindGroup.Entry.buffer(3, sizes, 0, @sizeOf(math.Vec2) * sprite_buffer_cap, @sizeOf(math.Vec2))
                 else

--- a/src/gfx/Text.zig
+++ b/src/gfx/Text.zig
@@ -273,6 +273,7 @@ fn updatePipeline(
                         ).divScalar(px_density),
                         .size = size.divScalar(px_density),
                         .text_index = num_texts,
+                        .text_padding = 0,
                         .uv_pos = vec2(@floatFromInt(r.x), @floatFromInt(r.y)),
                         .color = font_color,
                     });

--- a/src/gfx/TextPipeline.zig
+++ b/src/gfx/TextPipeline.zig
@@ -134,6 +134,7 @@ pub const Glyph = extern struct {
 
     /// Which text this glyph belongs to; this is the index for transforms[i], colors[i].
     text_index: u32,
+    text_padding: u32,
 
     /// Color of the glyph
     color: math.Vec4,

--- a/src/gfx/sprite.wgsl
+++ b/src/gfx/sprite.wgsl
@@ -25,7 +25,7 @@ struct Uniforms {
 
 // Sprite UV coordinate transformation matrices. Sprite UV coordinates are (0, 0) at the top-left
 // corner, and in pixels.
-@group(0) @binding(2) var<storage, read> sprite_uv_transforms: array<mat3x3<f32>>;
+@group(0) @binding(2) var<storage, read> sprite_uv_transforms: array<mat4x4<f32>>;
 
 // Sprite sizes, in pixels.
 @group(0) @binding(3) var<storage, read> sprite_sizes: array<vec2<f32>>;
@@ -70,12 +70,12 @@ fn vertMain(
   // Currently, our pos_2d and uv coordinates describe a card that covers 1px by 1px; and the UV
   // coordinates describe using the entire texture. We alter the coordinates to describe the
   // desired sprite location, size, and apply a subset of the texture instead of the entire texture.
-  var pos = vec4<f32>(pos_2d * sprite_size, 0, 1); // normalized -> pixels
+  var pos = vec4<f32>(pos_2d * sprite_size, 0, 1); // normalized -> pixels 
   pos = sprite_transform * pos; // apply sprite transform (pixels)
   pos = uniforms.view_projection * pos; // pixels -> normalized
 
   uv *= sprite_size; // normalized -> pixels
-  uv = (sprite_uv_transform * vec3<f32>(uv, 1)).xy; // apply sprite UV transform (pixels)
+  uv = (sprite_uv_transform * vec4<f32>(uv, 1, 0)).xy; // apply sprite UV transform (pixels)
   uv /= uniforms.texture_size; // pixels -> normalized
 
   var output : VertexOutput;

--- a/src/gfx/text.wgsl
+++ b/src/gfx/text.wgsl
@@ -33,6 +33,7 @@ struct Glyph {
 
   // Which text this glyph belongs to; this is the index for transforms[i], colors[i]
   text_index: u32,
+  text_index2: u32,   // Padding for struct alignment
 
   // Color of the glyph
   color: vec4<f32>,

--- a/src/sysgpu/d3d12.zig
+++ b/src/sysgpu/d3d12.zig
@@ -1498,6 +1498,8 @@ pub const Resource = struct {
     pub fn deinit(resource: *Resource) void {
         if (resource.mem_allocator) |mem_allocator| {
             mem_allocator.destroyResource(resource.*) catch {};
+        } else {
+            _ = resource.d3d_resource.lpVtbl.*.Release.?(resource.d3d_resource);
         }
     }
 };

--- a/src/sysgpu/main.zig
+++ b/src/sysgpu/main.zig
@@ -1317,7 +1317,7 @@ pub const Impl = sysgpu.Interface(struct {
 
     pub inline fn textureGetWidth(texture_raw: *sysgpu.Texture) u32 {
         const texture: *impl.Texture = @ptrCast(@alignCast(texture_raw));
-        return texture.getHeight();
+        return texture.getWidth();
     }
 
     pub inline fn textureSetLabel(texture: *sysgpu.Texture, label: [*:0]const u8) void {

--- a/src/sysgpu/shader/codegen/hlsl.zig
+++ b/src/sysgpu/shader/codegen/hlsl.zig
@@ -32,8 +32,6 @@ pub fn gen(allocator: std.mem.Allocator, air: *const Air, debug_info: DebugInfo)
         hlsl.arena.deinit();
     }
 
-    try hlsl.output.appendSlice(allocator, "#pragma pack_matrix( row_major )\n");
-
     for (air.refToList(air.globals_index)) |inst_idx| {
         switch (air.getInst(inst_idx)) {
             .@"var" => try hlsl.emitGlobalVar(inst_idx),
@@ -938,12 +936,12 @@ fn emitBinary(hlsl: *Hlsl, inst: Inst.Binary) !void {
             const rhs_type = hlsl.air.getInst(inst.rhs_type);
 
             if (lhs_type == .matrix or rhs_type == .matrix) {
-                // matrices are transposed
+                // matrices are in column major storage
                 try hlsl.writeAll("mul");
                 try hlsl.writeAll("(");
-                try hlsl.emitExpr(inst.rhs);
-                try hlsl.writeAll(", ");
                 try hlsl.emitExpr(inst.lhs);
+                try hlsl.writeAll(", ");
+                try hlsl.emitExpr(inst.rhs);
                 try hlsl.writeAll(")");
             } else {
                 try hlsl.emitBinaryOp(inst);


### PR DESCRIPTION
Contains few fixes required for d3d12. These are mainly alignment issues that came up with HLSL. The matrix ordering for StoredBuffers and constant buffers in HLSL is not always the same. 

Mat3x3 matrices are packed tightly in StoredBuffers.

https://github.com/hexops/mach/issues/1217

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.