### PR TITLE
Win32 events and borderless fullscreen

### DIFF
--- a/src/Core.zig
+++ b/src/Core.zig
@@ -377,7 +377,8 @@ pub const Key = enum {
     kp_7,
     kp_8,
     kp_9,
-    kp_decimal,
+    kp_decimal,  
+    kp_comma,
     kp_equal,
     kp_enter,
 
@@ -421,6 +422,9 @@ pub const Key = enum {
     period,
     slash,
     grave,
+
+    iso_backslash,
+    international1,
 
     unknown,
 

--- a/src/core/win32/win32.zig
+++ b/src/core/win32/win32.zig
@@ -21,6 +21,8 @@ pub const HICON = w.HICON;
 pub const HCURSOR = w.HCURSOR;
 pub const HBRUSH = w.HBRUSH;
 pub const HMENU = w.HMENU;
+pub const HMONITOR = *opaque{};
+pub const HDC = w.HDC;
 pub const WINAPI = w.WINAPI;
 pub const TRUE = w.TRUE;
 pub const FALSE = w.FALSE;
@@ -2298,3 +2300,106 @@ pub const VK_ZOOM = VIRTUAL_KEY.ZOOM;
 pub const VK_NONAME = VIRTUAL_KEY.NONAME;
 pub const VK_PA1 = VIRTUAL_KEY.PA1;
 pub const VK_OEM_CLEAR = VIRTUAL_KEY.OEM_CLEAR;
+
+// ---------------------------
+// Keyboard and mouse
+// ---------------------------
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn GetFocus(
+) callconv(@import("std").os.windows.WINAPI) ?HWND;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn GetKBCodePage(
+) callconv(@import("std").os.windows.WINAPI) u32;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn GetKeyState(
+    nVirtKey: i32,
+) callconv(@import("std").os.windows.WINAPI) i16;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn GetAsyncKeyState(
+    vKey: i32,
+) callconv(@import("std").os.windows.WINAPI) i16;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn GetKeyboardState(
+    lpKeyState: *[256]u8,
+) callconv(@import("std").os.windows.WINAPI) BOOL;
+
+pub extern "user32" fn GetCapture(
+) callconv(@import("std").os.windows.WINAPI) ?HWND;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn SetCapture(
+    hWnd: ?HWND,
+) callconv(@import("std").os.windows.WINAPI) ?HWND;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn ReleaseCapture(
+) callconv(@import("std").os.windows.WINAPI) BOOL;
+
+
+// --------------------------
+//  GDI
+// --------------------------
+pub const MONITORENUMPROC = *const fn(
+        param0: ?HMONITOR,
+        param1: ?HDC,
+        param2: ?*RECT,
+        param3: LPARAM,
+    ) callconv(@import("std").os.windows.WINAPI) BOOL;
+
+pub const MONITORINFO = extern struct {
+    cbSize: u32,
+    rcMonitor: RECT,
+    rcWork: RECT,
+    dwFlags: u32,
+};
+
+pub const MONITOR_FROM_FLAGS = enum(u32) {
+    NEAREST = 2,
+    NULL = 0,
+    PRIMARY = 1,
+};
+pub const MONITOR_DEFAULTTONEAREST = MONITOR_FROM_FLAGS.NEAREST;
+pub const MONITOR_DEFAULTTONULL = MONITOR_FROM_FLAGS.NULL;
+pub const MONITOR_DEFAULTTOPRIMARY = MONITOR_FROM_FLAGS.PRIMARY;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn MonitorFromPoint(
+    pt: POINT,
+    dwFlags: MONITOR_FROM_FLAGS,
+) callconv(@import("std").os.windows.WINAPI) ?HMONITOR;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn MonitorFromRect(
+    lprc: ?*RECT,
+    dwFlags: MONITOR_FROM_FLAGS,
+) callconv(@import("std").os.windows.WINAPI) ?HMONITOR;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn MonitorFromWindow(
+    hwnd: ?HWND,
+    dwFlags: MONITOR_FROM_FLAGS,
+) callconv(@import("std").os.windows.WINAPI) ?HMONITOR;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn GetMonitorInfoA(
+    hMonitor: ?HMONITOR,
+    lpmi: ?*MONITORINFO,
+) callconv(@import("std").os.windows.WINAPI) BOOL;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn GetMonitorInfoW(
+    hMonitor: ?HMONITOR,
+    lpmi: ?*MONITORINFO,
+) callconv(@import("std").os.windows.WINAPI) BOOL;
+
+// TODO: this type is limited to platform 'windows5.0'
+pub extern "user32" fn EnumDisplayMonitors(
+    hdc: ?HDC,
+    lprcClip: ?*RECT,
+    lpfnEnum: ?MONITORENUMPROC,
+    dwData: LPARAM,
+) callconv(@import("std").os.windows.WINAPI) BOOL;

--- a/src/sysgpu/d3d12.zig
+++ b/src/sysgpu/d3d12.zig
@@ -1401,6 +1401,8 @@ pub const SwapChain = struct {
     buffer_index: u32 = 0,
 
     pub fn init(device: *Device, surface: *Surface, desc: *const sysgpu.SwapChain.Descriptor) !*SwapChain {
+        std.debug.print("Init swap chain\n", .{});
+
         const instance = device.adapter.instance;
         const dxgi_factory = instance.dxgi_factory;
         var hr: c.HRESULT = undefined;
@@ -1417,7 +1419,7 @@ pub const SwapChain = struct {
             .SampleDesc = .{ .Count = 1, .Quality = 0 },
             .BufferUsage = conv.dxgiUsage(desc.usage),
             .BufferCount = back_buffer_count,
-            .Scaling = c.DXGI_MODE_SCALING_UNSPECIFIED,
+            .Scaling = c.DXGI_SCALING_STRETCH,
             .SwapEffect = c.DXGI_SWAP_EFFECT_FLIP_DISCARD,
             .AlphaMode = c.DXGI_ALPHA_MODE_UNSPECIFIED,
             .Flags = if (instance.allow_tearing) c.DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING else 0,


### PR DESCRIPTION
More features added to the win32 platform. Note, the fullscreen mode is currently implemented as borderless full screen. It is not exclusive fullscreen mode which would also change the display mode. 

* Added borderless fullscreen mode.
* Added borderless mode.
* Implemented keyPressed, keyRelease, ... functions
* Added mouse wheel event.
* Added modifiers to keyboard and mouse events.
* Default scaling is stretch in d3d12 backend.
* Display mode borderless and fullscreen behave the same for now.
* The fullscreen implementation will be reviewed later to include
display mode change.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
