### PR TITLE
initial macOS backend

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -277,10 +277,12 @@ pub const Platform = enum {
     wayland,
     web,
     win32,
+    darwin,
     null,
 
     pub fn fromTarget(target: std.Target) Platform {
         if (target.cpu.arch == .wasm32) return .web;
+        if (target.os.tag.isDarwin()) return .darwin;
         if (target.os.tag == .windows) return .win32;
         return .x11;
     }

--- a/build.zig
+++ b/build.zig
@@ -77,17 +77,6 @@ pub fn build(b: *std.Build) !void {
     });
     module.addImport("build-options", build_options.createModule());
 
-    if (target.result.isDarwin()) {
-        if (b.lazyDependency("mach_objc", .{
-            .target = target,
-            .optimize = optimize,
-        })) |dep| {
-            if (want_core or want_sysaudio or want_sysgpu) {
-                module.addImport("objc", dep.module("mach-objc"));
-            }
-        }
-    }
-
     if (want_mach) {
         // Linux gamemode requires libc.
         if (target.result.os.tag == .linux) module.link_libc = true;
@@ -147,6 +136,12 @@ pub fn build(b: *std.Build) !void {
                 module.linkLibrary(dep.artifact("wayland-headers"));
                 lib.linkLibrary(dep.artifact("wayland-headers"));
             }
+            if (target.result.isDarwin()) {
+                if (b.lazyDependency("mach_objc", .{
+                    .target = target,
+                    .optimize = optimize,
+                })) |dep| module.addImport("objc", dep.module("mach-objc"));
+            }
         }
     }
     if (want_sysaudio) {
@@ -177,6 +172,12 @@ pub fn build(b: *std.Build) !void {
                     const example_run_step = b.step("run-sysaudio-" ++ example, "Run '" ++ example ++ "' example");
                     example_run_step.dependOn(&example_run_cmd.step);
                 }
+            }
+            if (target.result.isDarwin()) {
+                if (b.lazyDependency("mach_objc", .{
+                    .target = target,
+                    .optimize = optimize,
+                })) |dep| module.addImport("objc", dep.module("mach-objc"));
             }
         }
 
@@ -229,6 +230,12 @@ pub fn build(b: *std.Build) !void {
     }
     if (want_sysgpu) {
         if (b.lazyDependency("vulkan_zig_generated", .{})) |dep| module.addImport("vulkan", dep.module("vulkan-zig-generated"));
+        if (target.result.isDarwin()) {
+            if (b.lazyDependency("mach_objc", .{
+                .target = target,
+                .optimize = optimize,
+            })) |dep| module.addImport("objc", dep.module("mach-objc"));
+        }
 
         linkSysgpu(b, module);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,10 +22,9 @@
             .lazy = true,
         },
         .mach_objc = .{
-            // .url = "https://pkg.machengine.org/mach-objc/055619a732ae50ba24eb04399613be87f8432f0f.tar.gz",
-            // .hash = "1220211475420584a552b461dd569f891d29cb8e9e485b97053be604680c8d6e2a3e",
-            // .lazy = true,
-            .path = "../mach-objc",
+            .url = "https://pkg.machengine.org/mach-objc/dac41fb87d34f222ebc72238e98871eba6cad982.tar.gz",
+            .hash = "12204f209a397362846c091d99483d7f2ed4cc8374c5518affc1b8fc87157e12b64a",
+            .lazy = true,
         },
         .xcode_frameworks = .{
             .url = "https://pkg.machengine.org/xcode-frameworks/122b43323db27b2082a2d44ed2121de21c9ccf75.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,8 +22,8 @@
             .lazy = true,
         },
         .mach_objc = .{
-            .url = "https://pkg.machengine.org/mach-objc/dac41fb87d34f222ebc72238e98871eba6cad982.tar.gz",
-            .hash = "12204f209a397362846c091d99483d7f2ed4cc8374c5518affc1b8fc87157e12b64a",
+            .url = "https://pkg.machengine.org/mach-objc/9f4635396dc8805247bab86c1decb7531b5f0309.tar.gz",
+            .hash = "1220b2997b164f3a6c0be62264c79c7feae2ca005d7f5c405315def5a9af887be5ba",
             .lazy = true,
         },
         .xcode_frameworks = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,9 +22,10 @@
             .lazy = true,
         },
         .mach_objc = .{
-            .url = "https://pkg.machengine.org/mach-objc/055619a732ae50ba24eb04399613be87f8432f0f.tar.gz",
-            .hash = "1220211475420584a552b461dd569f891d29cb8e9e485b97053be604680c8d6e2a3e",
-            .lazy = true,
+            // .url = "https://pkg.machengine.org/mach-objc/055619a732ae50ba24eb04399613be87f8432f0f.tar.gz",
+            // .hash = "1220211475420584a552b461dd569f891d29cb8e9e485b97053be604680c8d6e2a3e",
+            // .lazy = true,
+            .path = "../mach-objc",
         },
         .xcode_frameworks = .{
             .url = "https://pkg.machengine.org/xcode-frameworks/122b43323db27b2082a2d44ed2121de21c9ccf75.tar.gz",

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -17,6 +17,7 @@ const Platform = switch (build_options.core_platform) {
     .wayland => @import("core/Wayland.zig"),
     .web => @panic("TODO: revive wasm backend"),
     .win32 => @import("core/win32.zig"),
+    .darwin => @import("core/Darwin.zig"),
     .null => @import("core/Null.zig"),
 };
 

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -12,7 +12,7 @@ pub const sysjs = @import("mach-sysjs");
 pub const Timer = @import("core/Timer.zig");
 const Frequency = @import("core/Frequency.zig");
 
-const Platform = switch (build_options.core_platform) {
+pub const Platform = switch (build_options.core_platform) {
     .x11 => @import("core/X11.zig"),
     .wayland => @import("core/Wayland.zig"),
     .web => @panic("TODO: revive wasm backend"),

--- a/src/core/darwin.zig
+++ b/src/core/darwin.zig
@@ -20,6 +20,7 @@ const Position = Core.Position;
 const Key = Core.Key;
 const KeyMods = Core.KeyMods;
 const Joystick = Core.Joystick;
+const objc = @import("objc");
 
 const log = std.log.scoped(.mach);
 
@@ -54,6 +55,8 @@ surface_descriptor: gpu.Surface.Descriptor,
 
 // Called on the main thread
 pub fn init(_: *Darwin, _: InitOptions) !void {
+    const app = objc.appkit.ns.Application.sharedApplication();
+    _ = app; // autofix
     return;
 }
 

--- a/src/core/darwin.zig
+++ b/src/core/darwin.zig
@@ -1,0 +1,162 @@
+const std = @import("std");
+const mach = @import("../main.zig");
+const Core = @import("../Core.zig");
+const InputState = @import("InputState.zig");
+const Frequency = @import("Frequency.zig");
+const unicode = @import("unicode.zig");
+const detectBackendType = @import("common.zig").detectBackendType;
+const gpu = mach.gpu;
+const InitOptions = Core.InitOptions;
+const Event = Core.Event;
+const KeyEvent = Core.KeyEvent;
+const MouseButtonEvent = Core.MouseButtonEvent;
+const MouseButton = Core.MouseButton;
+const Size = Core.Size;
+const DisplayMode = Core.DisplayMode;
+const CursorShape = Core.CursorShape;
+const VSyncMode = Core.VSyncMode;
+const CursorMode = Core.CursorMode;
+const Position = Core.Position;
+const Key = Core.Key;
+const KeyMods = Core.KeyMods;
+const Joystick = Core.Joystick;
+
+const log = std.log.scoped(.mach);
+
+const EventQueue = std.fifo.LinearFifo(Event, .Dynamic);
+pub const EventIterator = struct {
+    queue: *EventQueue,
+
+    pub inline fn next(self: *EventIterator) ?Event {
+        return self.queue.readItem();
+    }
+};
+
+pub const Darwin = @This();
+
+allocator: std.mem.Allocator,
+core: *Core,
+
+events: EventQueue,
+input_state: InputState,
+modifiers: KeyMods,
+
+title: [:0]u8,
+display_mode: DisplayMode,
+vsync_mode: VSyncMode,
+cursor_mode: CursorMode,
+cursor_shape: CursorShape,
+border: bool,
+headless: bool,
+refresh_rate: u32,
+size: Size,
+surface_descriptor: gpu.Surface.Descriptor,
+
+// Called on the main thread
+pub fn init(_: *Darwin, _: InitOptions) !void {
+    return;
+}
+
+pub fn deinit(_: *Darwin) void {
+    return;
+}
+
+// Called on the main thread
+pub fn update(_: *Darwin) !void {
+    return;
+}
+
+// May be called from any thread.
+pub inline fn pollEvents(n: *Darwin) EventIterator {
+    return EventIterator{ .queue = &n.events };
+}
+
+// May be called from any thread.
+pub fn setTitle(_: *Darwin, _: [:0]const u8) void {
+    return;
+}
+
+// May be called from any thread.
+pub fn setDisplayMode(_: *Darwin, _: DisplayMode) void {
+    return;
+}
+
+// May be called from any thread.
+pub fn setBorder(_: *Darwin, _: bool) void {
+    return;
+}
+
+// May be called from any thread.
+pub fn setHeadless(_: *Darwin, _: bool) void {
+    return;
+}
+
+// May be called from any thread.
+pub fn setVSync(_: *Darwin, _: VSyncMode) void {
+    return;
+}
+
+// May be called from any thread.
+pub fn setSize(_: *Darwin, _: Size) void {
+    return;
+}
+
+// May be called from any thread.
+pub fn size(_: *Darwin) Size {
+    return Size{ .width = 100, .height = 100 };
+}
+
+// May be called from any thread.
+pub fn setCursorMode(_: *Darwin, _: CursorMode) void {
+    return;
+}
+
+// May be called from any thread.
+pub fn setCursorShape(_: *Darwin, _: CursorShape) void {
+    return;
+}
+
+// May be called from any thread.
+pub fn joystickPresent(_: *Darwin, _: Joystick) bool {
+    return false;
+}
+
+// May be called from any thread.
+pub fn joystickName(_: *Darwin, _: Joystick) ?[:0]const u8 {
+    return null;
+}
+
+// May be called from any thread.
+pub fn joystickButtons(_: *Darwin, _: Joystick) ?[]const bool {
+    return null;
+}
+
+// May be called from any thread.
+pub fn joystickAxes(_: *Darwin, _: Joystick) ?[]const f32 {
+    return null;
+}
+
+// May be called from any thread.
+pub fn keyPressed(_: *Darwin, _: Key) bool {
+    return false;
+}
+
+// May be called from any thread.
+pub fn keyReleased(_: *Darwin, _: Key) bool {
+    return true;
+}
+
+// May be called from any thread.
+pub fn mousePressed(_: *Darwin, _: MouseButton) bool {
+    return false;
+}
+
+// May be called from any thread.
+pub fn mouseReleased(_: *Darwin, _: MouseButton) bool {
+    return true;
+}
+
+// May be called from any thread.
+pub fn mousePosition(_: *Darwin) Position {
+    return Position{ .x = 0, .y = 0 };
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -91,7 +91,7 @@ pub const App = struct {
 
         // Dispatch events until queue is empty
         try app.mods.dispatch(stack_space, .{});
-        // Run `update` when `init` and all other systems are exectued
+        // Run `update` when `init` and all other systems are executed
         app.mods.schedule(app.main_mod, .update);
         return true;
     }

--- a/src/sysgpu/metal.zig
+++ b/src/sysgpu/metal.zig
@@ -2214,13 +2214,14 @@ pub const Queue = struct {
             .queue = queue,
             .fence_value = queue.fence_value,
         };
-        mtl_command_buffer.addCompletedHandler(ctx, completedHandler);
+        var handler = ns.stackBlockLiteral(completedHandler, ctx, null, null);
+        mtl_command_buffer.addCompletedHandler(handler.asBlock());
         mtl_command_buffer.commit();
     }
 
-    fn completedHandler(ctx: CompletedContext, mtl_command_buffer: *mtl.CommandBuffer) void {
+    fn completedHandler(block: *ns.BlockLiteral(CompletedContext), mtl_command_buffer: *mtl.CommandBuffer) callconv(.C) void {
         _ = mtl_command_buffer;
-        ctx.queue.completed_value.store(ctx.fence_value, .release);
+        block.context.queue.completed_value.store(block.context.fence_value, .release);
     }
 };
 


### PR DESCRIPTION
Initial macOS backend to replace GLFW. Still heavily experimental, no input, etc. but it renders a triangle at least. Special thanks to mjbshaw for contributing a bulk of this through various PRs.

Next up will be to alter/refactor the `mach.Core` API in some pretty substantial ways.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.