### PR TITLE
Fixing core to work with win32 #1257

### DIFF
--- a/examples/core/custom-entrypoint/main.zig
+++ b/examples/core/custom-entrypoint/main.zig
@@ -25,7 +25,7 @@ pub fn main() !void {
     // possible on all platforms.
     if (mach.Core.supports_non_blocking) {
         mach.Core.non_blocking = true;
-        while (mach.mods.mod.mach_core.state != .exited) {
+        while (mach.mods.mod.mach_core.state().state != .exited) {
             // Execute systems until a frame has been finished.
             try mach.mods.dispatchUntil(stack_space, .mach_core, .frame_finished);
         }

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -331,8 +331,8 @@ pub fn start(core: *Mod) !void {
     const stack_space = try core.state().allocator.alloc(u8, 8 * 1024 * 1024);
 
     if (supports_non_blocking) {
-        while (mach.mods.mod.mach_core.state != .exited) {
-            try mach.mods.dispatchUntil(stack_space, .mach_core, .frame_finished);
+        while (core.state().state != .exited) {
+            dispatch(stack_space);
         }
         // Don't return, because Platform.run wouldn't either (marked noreturn due to underlying
         // platform APIs never returning.)
@@ -346,6 +346,10 @@ pub fn start(core: *Mod) !void {
         // good measure.
         std.process.exit(1);
     }
+}
+
+fn dispatch(stack_space: []u8) void {
+    mach.mods.dispatchUntil(stack_space, .mach_core, .frame_finished) catch { @panic("Dispatch in Core failed"); };
 }
 
 fn platform_update_callback(core: *Mod, stack_space: []u8) !bool {

--- a/src/core/win32.zig
+++ b/src/core/win32.zig
@@ -130,6 +130,7 @@ pub fn init(
     self.border = options.border;
     self.headless = options.headless;
     self.refresh_rate = 60; // TODO (win32)  get monitor refresh rate
+    self.vsync_mode = .triple;
 
     _ = w.SetWindowLongPtrW(window, w.GWLP_USERDATA, @bitCast(@intFromPtr(self)));
     if (!options.headless) {


### PR DESCRIPTION
Use core.state()
Moved dispatch call from a system to its own function.
Set a default vsync mode in win32. There are some stability issues when free running.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.