### PR TITLE
Fix sysgpu_backend build option 

### DIFF
--- a/src/sysgpu/main.zig
+++ b/src/sysgpu/main.zig
@@ -5,7 +5,20 @@ pub const sysgpu = @import("sysgpu/main.zig");
 pub const shader = @import("shader.zig");
 const utils = @import("utils.zig");
 
-const backend_type: sysgpu.BackendType = backendFromBuildOption(build_options.sysgpu_backend);
+const backend_type: sysgpu.BackendType = switch (build_options.sysgpu_backend) {
+    .webgpu => .webgpu,
+    .d3d12 => .d3d12,
+    .metal => .metal,
+    .vulkan => .vulkan,
+    .opengl => .opengl,
+    .default => switch (builtin.target.os.tag) {
+        .linux => .vulkan,
+        .macos, .ios => .metal,
+        .windows => .d3d12,
+        else => @compileError("unsupported platform"),
+    },
+};
+
 const impl = switch (backend_type) {
     .d3d12 => @import("d3d12.zig"),
     .metal => @import("metal.zig"),
@@ -16,24 +29,6 @@ const impl = switch (backend_type) {
 
 var inited = false;
 var allocator: std.mem.Allocator = undefined;
-
-fn backendFromBuildOption(comptime opt: build_options.@"build.SysgpuBackend") sysgpu.BackendType {
-    switch (opt) {
-        .default => {
-            switch (builtin.target.os.tag) {
-                .linux => return .vulkan,
-                .macos, .ios => return .metal,
-                .windows => return .d3d12,
-                else => @compileError("unsupported platform"),
-            }
-        },
-        .webgpu => return .webgpu,
-        .d3d12 => return .d3d12,
-        .metal => return .metal,
-        .vulkan => return .vulkan,
-        .opengl => return .opengl,
-    }
-}
 
 pub const Impl = sysgpu.Interface(struct {
     pub fn init(alloc: std.mem.Allocator, options: impl.InitOptions) !void {


### PR DESCRIPTION
The sysgpu backend build option was treating the build option as the wrong enum type. This type is defined in `build.zig` and is exposed through the generated `build_options` struct. This is really nasty, but I think this is the correct way to do this. 


The generated code for `@import("build_options")` for reference:
```
pub const want_mach: bool = true;
pub const want_core: bool = true;
pub const want_sysaudio: bool = true;
pub const want_sysgpu: bool = true;
pub const @"build.SysgpuBackend" = enum (u3) {
    default = 0,
    webgpu = 1,
    d3d12 = 2,
    metal = 3,
    vulkan = 4,
    opengl = 5,
};
pub const sysgpu_backend: @"build.SysgpuBackend" = .opengl;
pub const @"build.Platform" = enum (u3) {
    wasm = 0,
    linux = 1,
    windows = 2,
    darwin = 3,
    null = 4,
};
pub const core_platform: @"build.Platform" = .linux;
```


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.