### PR TITLE
core: enable x11, employ `MACH_BACKEND` env var, minor fixes/tweaks

### DIFF
--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -69,7 +69,7 @@ pub fn init(
             "MACH_CORE_BACKEND",
         ) catch |err| switch (err) {
             error.EnvironmentVariableNotFound => {
-                break :blk .x11;
+                break :blk .wayland;
             },
             else => return err,
         };

--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -66,7 +66,7 @@ pub fn init(
     const desired_backend: BackendEnum = blk: {
         const backend = std.process.getEnvVarOwned(
             linux.allocator,
-            "MACH_CORE_BACKEND",
+            "MACH_BACKEND",
         ) catch |err| switch (err) {
             error.EnvironmentVariableNotFound => {
                 break :blk .wayland;
@@ -77,7 +77,7 @@ pub fn init(
 
         if (std.ascii.eqlIgnoreCase(backend, "x11")) break :blk .x11;
         if (std.ascii.eqlIgnoreCase(backend, "wayland")) break :blk .wayland;
-        std.debug.panic("mach: unknown MACH_CORE_BACKEND: {s}", .{backend});
+        std.debug.panic("mach: unknown MACH_BACKEND: {s}", .{backend});
     };
 
     // Try to initialize the desired backend, falling back to the other if that one is not supported

--- a/src/core/linux/Wayland.zig
+++ b/src/core/linux/Wayland.zig
@@ -130,8 +130,8 @@ pub fn init(
             region,
             0,
             0,
-            @intCast(options.size.width),
-            @intCast(options.size.height),
+            @intCast(wl.size.width),
+            @intCast(wl.size.height),
         );
         c.wl_surface_set_opaque_region(wl.surface, region);
         c.wl_region_destroy(region);

--- a/src/core/linux/Wayland.zig
+++ b/src/core/linux/Wayland.zig
@@ -83,7 +83,7 @@ pub fn init(
         .libxkbcommon = try LibXkbCommon.load(),
         .libwaylandclient = libwaylandclient_global,
         .interfaces = Interfaces{},
-        .display = libwaylandclient_global.wl_display_connect(null) orelse return error.FailedToConnectToWaylandDisplay,
+        .display = libwaylandclient_global.wl_display_connect(null) orelse return error.FailedToConnectToDisplay,
         .title = try options.allocator.dupeZ(u8, options.title),
         .size = &linux.size,
         .modifiers = .{

--- a/src/core/linux/X11.zig
+++ b/src/core/linux/X11.zig
@@ -99,8 +99,7 @@ pub fn init(
         else => return err,
     };
     const display = libx11.XOpenDisplay(null) orelse {
-        std.log.err("X11: Cannot open display", .{});
-        return error.CannotOpenDisplay;
+        return error.FailedToConnectToDisplay;
     };
     const screen = c.DefaultScreen(display);
     const visual = c.DefaultVisual(display, screen);

--- a/src/core/linux/X11.zig
+++ b/src/core/linux/X11.zig
@@ -74,7 +74,7 @@ display_mode: DisplayMode = .windowed,
 vsync_mode: VSyncMode = .triple,
 border: bool,
 headless: bool,
-size: Core.Size,
+size: *Core.Size,
 cursor_mode: CursorMode = .normal,
 cursor_shape: CursorShape = .arrow,
 surface_descriptor: *gpu.Surface.DescriptorFromXlibWindow,
@@ -119,8 +119,8 @@ pub fn init(
         root_window,
         @divFloor(libx11.XDisplayWidth(display, screen), 2), // TODO: add window width?
         @divFloor(libx11.XDisplayHeight(display, screen), 2), // TODO: add window height?
-        options.size.width,
-        options.size.height,
+        linux.size.width,
+        linux.size.height,
         0,
         c.DefaultDepth(display, screen),
         c.InputOutput,
@@ -130,7 +130,7 @@ pub fn init(
     );
     var window_attrs: c.XWindowAttributes = undefined;
     _ = libx11.XGetWindowAttributes(display, window, &window_attrs);
-    const window_size = Core.Size{
+    linux.size = Core.Size{
         .width = @intCast(window_attrs.width),
         .height = @intCast(window_attrs.height),
     };
@@ -180,7 +180,7 @@ pub fn init(
         .display_mode = .windowed,
         .border = options.border,
         .headless = options.headless,
-        .size = window_size,
+        .size = &linux.size,
         .cursors = std.mem.zeroes([@typeInfo(CursorShape).@"enum".fields.len]?c.Cursor),
         .surface_descriptor = surface_descriptor,
         .libxkbcommon = try LibXkbCommon.load(),


### PR DESCRIPTION
This PR makes the following changes:
- enable x11
- use `MACH_BACKEND` env var instead of `MACH_CORE_BACKEND` for selecting linux display server
- fix minor window size discrepancy bug in wayland
- add logging for both x11 and wayland that explain that not all features are supported yet

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.