### PR TITLE
sysgpu: replace deprecated @fence builtin

### DIFF
--- a/src/sysgpu/utils.zig
+++ b/src/sysgpu/utils.zig
@@ -12,8 +12,7 @@ pub fn Manager(comptime T: type) type {
         }
 
         pub fn release(manager: *@This()) void {
-            if (@atomicRmw(u32, &manager.count, .Sub, 1, .release) == 1) {
-                @fence(.acquire);
+            if (@atomicRmw(u32, &manager.count, .Sub, 1, .acq_rel) == 1) {
                 const parent: *T = @alignCast(@fieldParentPtr("manager", manager));
                 parent.deinit();
             }


### PR DESCRIPTION
Wrench is trying to update Zig, but Zig had an update that introduced a breaking change:
https://github.com/ziglang/zig/pull/21585

Due to this change, I have removed `@fence()`. I am new to atomics, but I believe the removal of `@fence()` means that we need to ensure that everything after the atomic write, which happens in `@atomicRmw()`, actually happens after the write, not before - namely the deinitialization of `parent`. This can be done by changing the ordering of `@atomicRmw()` from `.release` to `.acq_rel`, which is what I have done.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.