### PR TITLE
Call sysgpu device tick

### DIFF
--- a/src/Core.zig
+++ b/src/Core.zig
@@ -611,6 +611,7 @@ fn presentFrame(core: *Mod, entities: *mach.Entities.Mod) !void {
     if (num_windows > 1) @panic("mach: Core currently only supports a single window");
 
     _ = try state.platform.update();
+    mach.sysgpu.Impl.deviceTick(state.device);
     state.swap_chain.present();
 
     // Update swapchain for the next frame

--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -91,7 +91,7 @@ pub fn init(
             const x11 = X11.init(linux, core, options) catch |err| {
                 const err_msg = switch (err) {
                     error.LibraryNotFound => "Missing X11 library",
-                    error.FailedToConnectToDisplay => "Failed to connect to display",
+                    error.FailedToConnectToDisplay => "Failed to connect to X11 display",
                     else => "An unknown error occured while trying to connect to X11",
                 };
                 log.err("{s}\nFalling back to Wayland\n", .{err_msg});
@@ -104,7 +104,7 @@ pub fn init(
             const wayland = Wayland.init(linux, core, options) catch |err| {
                 const err_msg = switch (err) {
                     error.LibraryNotFound => "Missing Wayland library",
-                    error.FailedToConnectToDisplay => "Failed to connect to display",
+                    error.FailedToConnectToDisplay => "Failed to connect to Wayland display",
                     else => "An unknown error occured while trying to connect to Wayland",
                 };
                 log.err("{s}\nFalling back to X11\n", .{err_msg});

--- a/src/core/linux/X11.zig
+++ b/src/core/linux/X11.zig
@@ -243,7 +243,6 @@ pub fn deinit(
     x11: *X11,
     linux: *Linux,
 ) void {
-    x11.allocator.destroy(x11.surface_descriptor);
     linux.allocator.destroy(x11.surface_descriptor);
     for (x11.cursors) |cur| {
         if (cur) |_| {


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

Fixes: https://github.com/hexops/mach/issues/1288

Related to:
https://github.com/hexops/mach/issues/1232
https://github.com/hexops/mach/issues/1252 
https://github.com/hexops/mach/issues/1253
https://github.com/hexops/mach/issues/1259
https://github.com/hexops/mach/issues/1270
https://github.com/hexops/mach/issues/1271
https://github.com/hexops/mach/issues/1275

## Changes
1. add: deviceTick call after platform update.
2. add: display name to `error.FailedToConnectToDisplay` message.
3. fix: double free during X11 deinit.