### PR TITLE
Call XInitThreads first; XCloseDisplay cleanup

### DIFF
--- a/src/Core.zig
+++ b/src/Core.zig
@@ -355,11 +355,8 @@ pub fn deinit(entities: *mach.Entities.Mod, core: *Mod) !void {
         }
     }
 
-    // GPU backend (ie. d3d12, metal, opengl, vulkan)
-    //
-    // Must be released BEFORE platform deinit.
-    //   Otherwise, we enter a race condition where GPU might try to present
-    //   to the window server.
+    // GPU backend must be released BEFORE platform deinit, otherwise we may enter a race
+    // where the GPU might try to present to the window server.
     state.swap_chain.release();
     state.queue.release();
     state.device.release();
@@ -367,7 +364,7 @@ pub fn deinit(entities: *mach.Entities.Mod, core: *Mod) !void {
     state.adapter.release();
     state.instance.release();
 
-    // Platform (ie. Windows, MacOS, Linux X11, or Wayland)
+    // Deinit the platform
     state.platform.deinit();
 
     state.events.deinit();

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -355,13 +355,21 @@ pub fn deinit(entities: *mach.Entities.Mod, core: *Mod) !void {
         }
     }
 
-    state.platform.deinit();
+    // GPU backend (ie. d3d12, metal, opengl, vulkan)
+    //
+    // Must be done BEFORE platform deinit.
+    //   Otherwise, we enter a race condition where GPU might try to present
+    //   to the window server.
     state.swap_chain.release();
     state.queue.release();
     state.device.release();
     state.surface.release();
     state.adapter.release();
     state.instance.release();
+
+    // Platform (ie. Windows, MacOS, Linux X11 or Wayland)
+    state.platform.deinit();
+
     state.events.deinit();
 }
 

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -357,7 +357,7 @@ pub fn deinit(entities: *mach.Entities.Mod, core: *Mod) !void {
 
     // GPU backend (ie. d3d12, metal, opengl, vulkan)
     //
-    // Must be done BEFORE platform deinit.
+    // Must be released BEFORE platform deinit.
     //   Otherwise, we enter a race condition where GPU might try to present
     //   to the window server.
     state.swap_chain.release();
@@ -367,7 +367,7 @@ pub fn deinit(entities: *mach.Entities.Mod, core: *Mod) !void {
     state.adapter.release();
     state.instance.release();
 
-    // Platform (ie. Windows, MacOS, Linux X11 or Wayland)
+    // Platform (ie. Windows, MacOS, Linux X11, or Wayland)
     state.platform.deinit();
 
     state.events.deinit();

--- a/src/core/linux/X11.zig
+++ b/src/core/linux/X11.zig
@@ -86,6 +86,7 @@ pub fn init(
 ) !X11 {
     // TODO(core): return errors.NotSupported if not supported
     const libx11 = try LibX11.load();
+    _ = libx11.XInitThreads();
     const libgl: ?LibGL = LibGL.load() catch |err| switch (err) {
         error.LibraryNotFound => null,
         else => return err,
@@ -185,7 +186,6 @@ pub fn init(
         .libxkbcommon = try LibXkbCommon.load(),
     };
     _ = libx11.XSetErrorHandler(errorHandler);
-    _ = libx11.XInitThreads();
     _ = libx11.XrmInitialize();
     defer _ = libx11.XFreeColormap(display, colormap);
     for (0..2) |i| {

--- a/src/core/linux/X11.zig
+++ b/src/core/linux/X11.zig
@@ -185,7 +185,6 @@ pub fn init(
         .surface_descriptor = surface_descriptor,
         .libxkbcommon = try LibXkbCommon.load(),
     };
-    _ = libx11.XSetErrorHandler(errorHandler);
     _ = libx11.XrmInitialize();
     defer _ = libx11.XFreeColormap(display, colormap);
     for (0..2) |i| {
@@ -441,12 +440,6 @@ const LibXkbCommon = struct {
         return lib;
     }
 };
-
-fn errorHandler(display: ?*c.Display, event: [*c]c.XErrorEvent) callconv(.C) c_int {
-    _ = display;
-    log.err("X11: error code {d}\n", .{event.*.error_code});
-    return 0;
-}
 
 fn createStandardCursor(x11: *X11, shape: CursorShape) !c.Cursor {
     if (x11.libxcursor) |libxcursor| {

--- a/src/core/linux/X11.zig
+++ b/src/core/linux/X11.zig
@@ -86,6 +86,10 @@ pub fn init(
 ) !X11 {
     // TODO(core): return errors.NotSupported if not supported
     const libx11 = try LibX11.load();
+
+    // Xlibx11.XInitThreads must be called first
+    //
+    // if not, 'Unknown sequence number while processing queue' errors occur.
     _ = libx11.XInitThreads();
     const libgl: ?LibGL = LibGL.load() catch |err| switch (err) {
         error.LibraryNotFound => null,


### PR DESCRIPTION

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

Closes https://github.com/hexops/mach/issues/1290

## Context
yppy provided some excellent advise on discord:
> XInitThreads should be the first xlib function called (though im not sure i would believe in xlib multithreading...)

And after I mentioned an error code on exit, they also advised:
> error 3 is badwindow
> probably something is using it after XDestroyWindow

The discussion after lead to the realization that `platform.deinit` is called *before* the GPU backend is released. This caused a race condition where the GPU backend might interact with the window before it is released.

## Changes

* change: `libx11.XInitThreads` is now called first when initializing X11.
* remove: X11's custom `errorHandler` in favor of the default handler's more verbose description.
* change: `platform.deinit` is now called *after* the GPU backend has been released.


## Some additional detail

To show why I removed the custom X11 error handler.

### Custom Error Message
```
err(mach): X11: error code 3
```

### Default Error Message
```
X Error of failed request:  BadWindow (invalid Window parameter)
  Major opcode of failed request:  148 ()
  Minor opcode of failed request:  1
  Resource id in failed request:  0x5400002
  Serial number of failed request:  2035
  Current serial number in output stream:  2036
```