### PR TITLE
Wayland should error when no server side decoration

### DIFF
--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -103,6 +103,7 @@ pub fn init(
         .wayland => blk: {
             const wayland = Wayland.init(linux, core, options) catch |err| {
                 const err_msg = switch (err) {
+                    error.NoServerSideDecorationSupport => "Server Side Decorations aren't supported",
                     error.LibraryNotFound => "Missing Wayland library",
                     error.FailedToConnectToDisplay => "Failed to connect to Wayland display",
                     else => "An unknown error occured while trying to connect to Wayland",

--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -94,7 +94,7 @@ pub fn init(
                     error.FailedToConnectToDisplay => "Failed to connect to X11 display",
                     else => "An unknown error occured while trying to connect to X11",
                 };
-                log.err("{s}\nFalling back to Wayland\n", .{err_msg});
+                log.err("{s}\n\nFalling back to Wayland\n", .{err_msg});
                 linux.backend = .{ .wayland = try Wayland.init(linux, core, options) };
                 break :blk;
             };
@@ -107,7 +107,7 @@ pub fn init(
                     error.FailedToConnectToDisplay => "Failed to connect to Wayland display",
                     else => "An unknown error occured while trying to connect to Wayland",
                 };
-                log.err("{s}\nFalling back to X11\n", .{err_msg});
+                log.err("{s}\n\nFalling back to X11\n", .{err_msg});
                 linux.backend = .{ .x11 = try X11.init(linux, core, options) };
                 break :blk;
             };
@@ -210,7 +210,7 @@ pub fn deinitLinuxGamemode() void {
 /// Used to inform users that some features are not present. Remove when features are complete.
 fn warnAboutIncompleteFeatures(backend: BackendEnum, missing_features_x11: []const []const u8, missing_features_wayland: []const []const u8, alloc: std.mem.Allocator) !void {
     const features_incomplete_message =
-        \\WARNING: You are using the {s} backend, which is currently experimental as we continue to rewrite Mach in Zig instead of using C libraries like GLFW/etc. The following features are expected to not work:
+        \\You are using the {s} backend, which is currently experimental as we continue to rewrite Mach in Zig instead of using C libraries like GLFW/etc. The following features are expected to not work:
         \\
         \\{s}
         \\
@@ -222,7 +222,7 @@ fn warnAboutIncompleteFeatures(backend: BackendEnum, missing_features_x11: []con
         .wayland => try generateFeatureBulletPoints(missing_features_wayland, alloc),
     };
     defer bullet_points.deinit();
-    log.info(features_incomplete_message, .{ @tagName(backend), bullet_points.items });
+    log.warn(features_incomplete_message, .{ @tagName(backend), bullet_points.items });
 }
 
 /// Turn an array of strings into a single, bullet-pointed string, like this:

--- a/src/core/linux/Wayland.zig
+++ b/src/core/linux/Wayland.zig
@@ -118,6 +118,10 @@ pub fn init(
     //Round trip to get all initial output events
     _ = wl.libwaylandclient.wl_display_roundtrip(wl.display);
 
+    if (wl.interfaces.zxdg_decoration_manager_v1 == null) {
+        return error.NoServerSideDecorationSupport;
+    }
+
     //Setup surface
     wl.surface = c.wl_compositor_create_surface(wl.interfaces.wl_compositor) orelse return error.UnableToCreateSurface;
     wl.surface_descriptor = try options.allocator.create(gpu.Surface.DescriptorFromWaylandSurface);


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

As discussed in https://github.com/hexops/mach/issues/1275, this PR is a stopgap until we implement Client Side Decoration in Mach.

If the decoration interface is not found, an error is returned so that the system can attempt a fallback to x11.