### PR TITLE
fix incorrect zig version error message

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -449,6 +449,6 @@ const SysAudioTest = struct {
 comptime {
     const supported_zig = std.SemanticVersion.parse("0.14.0-dev.1911+3bf89f55c") catch unreachable;
     if (builtin.zig_version.order(supported_zig) != .eq) {
-        @compileError(std.fmt.comptimePrint("unsupported Zig version ({}). Required Zig version 2024.5.0-mach: https://machengine.org/about/nominated-zig/#202450-mach", .{builtin.zig_version}));
+        @compileError(std.fmt.comptimePrint("unsupported Zig version ({}). Required Zig version 2024.10.0-mach: https://machengine.org/docs/nominated-zig/#2024100-mach", .{builtin.zig_version}));
     }
 }


### PR DESCRIPTION
Commit 2d13c5efc58d3649a2b58947a2e1786279445ac4 did not edit the error message, and I was a bit confused when it wasn't building properly on 2024.5.0-mach. This also updates the URL to the new one.
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.