### PR TITLE
wayland: Remove references to `wl.state`

### DIFF
--- a/src/core/linux/Wayland.zig
+++ b/src/core/linux/Wayland.zig
@@ -650,8 +650,8 @@ const pointer_listener = struct {
 
         const mouse_button: Core.MouseButton = @enumFromInt(button - c.BTN_LEFT);
         const pressed = state == c.WL_POINTER_BUTTON_STATE_PRESSED;
-        const x = wl.state.input_state.mouse_position.x;
-        const y = wl.state.input_state.mouse_position.y;
+        const x = wl.core.input_state.mouse_position.x;
+        const y = wl.core.input_state.mouse_position.y;
 
         if (pressed) {
             wl.core.pushEvent(Core.Event{ .mouse_press = .{


### PR DESCRIPTION
This should get CI back green.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.