### PR TITLE
obj: Make field tracking use a single bitset

### DIFF
--- a/src/module.zig
+++ b/src/module.zig
@@ -68,7 +68,7 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
             /// Global pointer to object relations graph
             graph: *Graph,
 
-            /// A bitset per-field used to track field changes. Only used if options.track_fields == true.
+            /// A bitset used to track per-field changes. Only used if options.track_fields == true.
             updated: ?std.bit_set.DynamicBitSetUnmanaged = if (options.track_fields) .{} else null,
         },
 


### PR DESCRIPTION
As you mentioned in the previously merged PR

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.