### PR TITLE
obj: Move `Platform` and `InitOptions` fields into `core.windows`

### DIFF
--- a/src/Core.zig
+++ b/src/Core.zig
@@ -679,32 +679,48 @@ pub const Event = union(enum) {
     key_repeat: KeyEvent,
     key_release: KeyEvent,
     char_input: struct {
+        window_id: mach.ObjectID,
         codepoint: u21,
     },
     mouse_motion: struct {
+        window_id: mach.ObjectID,
         pos: Position,
     },
     mouse_press: MouseButtonEvent,
     mouse_release: MouseButtonEvent,
     mouse_scroll: struct {
+        window_id: mach.ObjectID,
         xoffset: f32,
         yoffset: f32,
     },
-    framebuffer_resize: Size,
-    focus_gained,
-    focus_lost,
-    close,
+    window_resize: ResizeEvent,
+    focus_gained: struct {
+        window_id: mach.ObjectID,
+    },
+    focus_lost: struct {
+        window_id: mach.ObjectID,
+    },
+    close: struct {
+        window_id: mach.ObjectID,
+    },
 };
 
 pub const KeyEvent = struct {
+    window_id: mach.ObjectID,
     key: Key,
     mods: KeyMods,
 };
 
 pub const MouseButtonEvent = struct {
+    window_id: mach.ObjectID,
     button: MouseButton,
     pos: Position,
     mods: KeyMods,
+};
+
+pub const ResizeEvent = struct {
+    window_id: mach.ObjectID,
+    size: Size,
 };
 
 pub const MouseButton = enum {

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -46,9 +46,11 @@ windows: mach.Objects(
         framebuffer_format: gpu.Texture.Format = .bgra8_unorm,
 
         /// Width of the framebuffer in texels (read-only)
+        /// Will be updated to reflect the actual framebuffer dimensions after window creation.
         framebuffer_width: u32 = 1920 / 2,
 
         /// Height of the framebuffer in texels (read-only)
+        /// Will be updated to reflect the actual framebuffer dimensions after window creation.
         framebuffer_height: u32 = 1080 / 2,
 
         /// Vertical sync mode, prevents screen tearing.

--- a/src/core/Darwin.zig
+++ b/src/core/Darwin.zig
@@ -21,26 +21,9 @@ const log = std.log.scoped(.mach);
 
 pub const Darwin = @This();
 
-// --------------------------
-// Module state
-// --------------------------
-allocator: std.mem.Allocator,
-core: *Core,
-
-// Core platform interface
-surface_descriptor: gpu.Surface.Descriptor,
-title: [:0]const u8,
-display_mode: DisplayMode,
-vsync_mode: VSyncMode,
-cursor_mode: CursorMode,
-cursor_shape: CursorShape,
-border: bool,
-headless: bool,
-refresh_rate: u32,
-size: Size,
-
-// Internals
-window: ?*objc.app_kit.Window,
+pub const Native = struct {
+    window: ?*objc.app_kit.Window = null,
+};
 
 pub fn run(comptime on_each_update_fn: anytype, args_tuple: std.meta.ArgsTuple(@TypeOf(on_each_update_fn))) noreturn {
     const Args = @TypeOf(args_tuple);
@@ -76,193 +59,299 @@ pub fn run(comptime on_each_update_fn: anytype, args_tuple: std.meta.ArgsTuple(@
     // TODO: support UIKit.
 }
 
-pub fn init(
-    darwin: *Darwin,
-    core: *Core,
-    options: InitOptions,
-) !void {
-    var surface_descriptor = gpu.Surface.Descriptor{};
+pub fn tick(core: *Core) !void {
+    var windows = core.windows.slice();
+    while (windows.next()) |window_id| {
+        if (core.windows.getAll(window_id)) |cw| {
+            const core_window = cw;
+            const native: Native = core_window.native;
 
-    // TODO: support UIKit.
-    var window_opt: ?*objc.app_kit.Window = null;
-    if (!options.headless) {
+            if (core.windows.get(window_id, .device).? == null) {
+                // Window has not been set up yet, we need to init the window
+                //try initWindow(core, window_id);
+                //try core.initWindow(window_id);
+
+                try initWindow(core, window_id);
+                try core.initWindow(window_id);
+            }
+            if (native.window) |native_window| {
+                // Handle resizing the window when the user changes width or height
+                if (core.windows.updated(window_id, .width) or core.windows.updated(window_id, .height)) {
+                    var frame = native_window.frame();
+                    frame.size.height = @floatFromInt(core.windows.get(window_id, .width).?);
+                    frame.size.width = @floatFromInt(core.windows.get(window_id, .height).?);
+                    native_window.setFrame_display_animate(frame, true, true);
+                }
+            }
+        }
+    }
+}
+
+fn initWindow(
+    core: *Core,
+    window_id: mach.ObjectID,
+) !void {
+    if (core.windows.getAll(window_id)) |cw| {
+        var core_window = cw;
         // If the application is not headless, we need to make the application a genuine UI application
         // by setting the activation policy, this moves the process to foreground
+        // TODO: Only call this on the first window creation
         _ = objc.app_kit.Application.sharedApplication().setActivationPolicy(objc.app_kit.ApplicationActivationPolicyRegular);
 
-        const metal_descriptor = try options.allocator.create(gpu.Surface.DescriptorFromMetalLayer);
+        const metal_descriptor = try core.allocator.create(gpu.Surface.DescriptorFromMetalLayer);
         const layer = objc.quartz_core.MetalLayer.new();
         defer layer.release();
         layer.setDisplaySyncEnabled(true);
         metal_descriptor.* = .{
             .layer = layer,
         };
-        surface_descriptor.next_in_chain = .{ .from_metal_layer = metal_descriptor };
+        core_window.surface_descriptor = .{};
+        core_window.surface_descriptor.next_in_chain = .{ .from_metal_layer = metal_descriptor };
 
         const screen = objc.app_kit.Screen.mainScreen();
         const rect = objc.core_graphics.Rect{
             .origin = .{ .x = 0, .y = 0 },
-            .size = .{ .width = @floatFromInt(options.size.width), .height = @floatFromInt(options.size.height) },
+            .size = .{ .width = @floatFromInt(core_window.width), .height = @floatFromInt(core_window.height) },
         };
 
         const window_style =
-            (if (options.display_mode == .fullscreen) objc.app_kit.WindowStyleMaskFullScreen else 0) |
-            (if (options.display_mode == .windowed) objc.app_kit.WindowStyleMaskTitled else 0) |
-            (if (options.display_mode == .windowed) objc.app_kit.WindowStyleMaskClosable else 0) |
-            (if (options.display_mode == .windowed) objc.app_kit.WindowStyleMaskMiniaturizable else 0) |
-            (if (options.display_mode == .windowed) objc.app_kit.WindowStyleMaskResizable else 0);
+            (if (core_window.display_mode == .fullscreen) objc.app_kit.WindowStyleMaskFullScreen else 0) |
+            (if (core_window.display_mode == .windowed) objc.app_kit.WindowStyleMaskTitled else 0) |
+            (if (core_window.display_mode == .windowed) objc.app_kit.WindowStyleMaskClosable else 0) |
+            (if (core_window.display_mode == .windowed) objc.app_kit.WindowStyleMaskMiniaturizable else 0) |
+            (if (core_window.display_mode == .windowed) objc.app_kit.WindowStyleMaskResizable else 0);
 
-        window_opt = objc.app_kit.Window.alloc().initWithContentRect_styleMask_backing_defer_screen(
+        const native_window_opt: ?*objc.app_kit.Window = objc.app_kit.Window.alloc().initWithContentRect_styleMask_backing_defer_screen(
             rect,
             window_style,
             objc.app_kit.BackingStoreBuffered,
             false,
             screen,
         );
-        if (window_opt) |window| {
-            window.setReleasedWhenClosed(false);
+        if (native_window_opt) |native_window| {
+            core_window.native = .{ .window = native_window };
+
+            native_window.setReleasedWhenClosed(false);
 
             var view = objc.mach.View.allocInit();
             view.setLayer(@ptrCast(layer));
 
             {
-                var keyDown = objc.foundation.stackBlockLiteral(ViewCallbacks.keyDown, darwin, null, null);
+                var keyDown = objc.foundation.stackBlockLiteral(ViewCallbacks.keyDown, core, null, null);
                 view.setBlock_keyDown(keyDown.asBlock().copy());
 
-                var keyUp = objc.foundation.stackBlockLiteral(ViewCallbacks.keyUp, darwin, null, null);
+                var keyUp = objc.foundation.stackBlockLiteral(ViewCallbacks.keyUp, core, null, null);
                 view.setBlock_keyUp(keyUp.asBlock().copy());
             }
-            window.setContentView(@ptrCast(view));
-            window.center();
-            window.setIsVisible(true);
-            window.makeKeyAndOrderFront(null);
+            native_window.setContentView(@ptrCast(view));
+            native_window.center();
+            native_window.setIsVisible(true);
+            native_window.makeKeyAndOrderFront(null);
 
             const delegate = objc.mach.WindowDelegate.allocInit();
-            defer window.setDelegate(@ptrCast(delegate));
+            defer native_window.setDelegate(@ptrCast(delegate));
             { // Set WindowDelegate blocks
-                var windowWillResize_toSize = objc.foundation.stackBlockLiteral(WindowDelegateCallbacks.windowWillResize_toSize, darwin, null, null);
+                var windowWillResize_toSize = objc.foundation.stackBlockLiteral(WindowDelegateCallbacks.windowWillResize_toSize, core, null, null);
                 delegate.setBlock_windowWillResize_toSize(windowWillResize_toSize.asBlock().copy());
 
-                var windowShouldClose = objc.foundation.stackBlockLiteral(WindowDelegateCallbacks.windowShouldClose, darwin, null, null);
+                var windowShouldClose = objc.foundation.stackBlockLiteral(WindowDelegateCallbacks.windowShouldClose, core, null, null);
                 delegate.setBlock_windowShouldClose(windowShouldClose.asBlock().copy());
             }
+
+            core.windows.setAllRaw(window_id, core_window);
         } else std.debug.panic("mach: window failed to initialize", .{});
     }
-
-    darwin.* = .{
-        .allocator = options.allocator,
-        .core = core,
-        .title = options.title,
-        .display_mode = options.display_mode,
-        .vsync_mode = .none,
-        .cursor_mode = .normal,
-        .cursor_shape = .arrow,
-        .border = options.border,
-        .headless = options.headless,
-        .refresh_rate = 60, // TODO: set to something meaningful
-        .size = options.size,
-        .surface_descriptor = surface_descriptor,
-        .window = window_opt,
-    };
 }
 
-pub fn deinit(darwin: *Darwin) void {
-    if (darwin.window) |w| @as(*objc.foundation.ObjectProtocol, @ptrCast(w)).release();
-    return;
-}
+// pub fn init(
+//     darwin: *Darwin,
+//     core: *Core,
+//     //options: InitOptions,
+// ) !void {
+//     // var surface_descriptor = gpu.Surface.Descriptor{};
 
-pub fn update(darwin: *Darwin) !void {
-    if (darwin.window) |window| window.update();
-}
+//     // // TODO: support UIKit.
+//     // var window_opt: ?*objc.app_kit.Window = null;
+//     // if (!options.headless) {
+//     //     // If the application is not headless, we need to make the application a genuine UI application
+//     //     // by setting the activation policy, this moves the process to foreground
+//     //     _ = objc.app_kit.Application.sharedApplication().setActivationPolicy(objc.app_kit.ApplicationActivationPolicyRegular);
 
-pub fn setTitle(darwin: *Darwin, title: [:0]const u8) void {
-    if (darwin.window) |window| {
-        var string = objc.app_kit.String.allocInit();
-        defer string.release();
-        string = string.initWithUTF8String(title.ptr);
-        window.setTitle(string);
-    }
-}
+//     //     const metal_descriptor = try options.allocator.create(gpu.Surface.DescriptorFromMetalLayer);
+//     //     const layer = objc.quartz_core.MetalLayer.new();
+//     //     defer layer.release();
+//     //     layer.setDisplaySyncEnabled(true);
+//     //     metal_descriptor.* = .{
+//     //         .layer = layer,
+//     //     };
+//     //     surface_descriptor.next_in_chain = .{ .from_metal_layer = metal_descriptor };
 
-pub fn setDisplayMode(_: *Darwin, _: DisplayMode) void {
-    return;
-}
+//     //     const screen = objc.app_kit.Screen.mainScreen();
+//     //     const rect = objc.core_graphics.Rect{
+//     //         .origin = .{ .x = 0, .y = 0 },
+//     //         .size = .{ .width = @floatFromInt(options.size.width), .height = @floatFromInt(options.size.height) },
+//     //     };
 
-pub fn setBorder(_: *Darwin, _: bool) void {
-    return;
-}
+//     //     const window_style =
+//     //         (if (options.display_mode == .fullscreen) objc.app_kit.WindowStyleMaskFullScreen else 0) |
+//     //         (if (options.display_mode == .windowed) objc.app_kit.WindowStyleMaskTitled else 0) |
+//     //         (if (options.display_mode == .windowed) objc.app_kit.WindowStyleMaskClosable else 0) |
+//     //         (if (options.display_mode == .windowed) objc.app_kit.WindowStyleMaskMiniaturizable else 0) |
+//     //         (if (options.display_mode == .windowed) objc.app_kit.WindowStyleMaskResizable else 0);
 
-pub fn setHeadless(_: *Darwin, _: bool) void {
-    return;
-}
+//     //     window_opt = objc.app_kit.Window.alloc().initWithContentRect_styleMask_backing_defer_screen(
+//     //         rect,
+//     //         window_style,
+//     //         objc.app_kit.BackingStoreBuffered,
+//     //         false,
+//     //         screen,
+//     //     );
+//     //     if (window_opt) |window| {
+//     //         window.setReleasedWhenClosed(false);
 
-pub fn setVSync(_: *Darwin, _: VSyncMode) void {
-    return;
-}
+//     //         var view = objc.mach.View.allocInit();
+//     //         view.setLayer(@ptrCast(layer));
 
-pub fn setSize(darwin: *Darwin, size: Size) void {
-    if (darwin.window) |window| {
-        var frame = window.frame();
-        frame.size.height = @floatFromInt(size.height);
-        frame.size.width = @floatFromInt(size.width);
-        window.setFrame_display_animate(frame, true, true);
-    }
-}
+//     //         {
+//     //             var keyDown = objc.foundation.stackBlockLiteral(ViewCallbacks.keyDown, darwin, null, null);
+//     //             view.setBlock_keyDown(keyDown.asBlock().copy());
 
-pub fn setCursorMode(_: *Darwin, _: CursorMode) void {
-    return;
-}
+//     //             var keyUp = objc.foundation.stackBlockLiteral(ViewCallbacks.keyUp, darwin, null, null);
+//     //             view.setBlock_keyUp(keyUp.asBlock().copy());
+//     //         }
+//     //         window.setContentView(@ptrCast(view));
+//     //         window.center();
+//     //         window.setIsVisible(true);
+//     //         window.makeKeyAndOrderFront(null);
 
-pub fn setCursorShape(_: *Darwin, _: CursorShape) void {
-    return;
-}
+//     //         const delegate = objc.mach.WindowDelegate.allocInit();
+//     //         defer window.setDelegate(@ptrCast(delegate));
+//     //         { // Set WindowDelegate blocks
+//     //             var windowWillResize_toSize = objc.foundation.stackBlockLiteral(WindowDelegateCallbacks.windowWillResize_toSize, darwin, null, null);
+//     //             delegate.setBlock_windowWillResize_toSize(windowWillResize_toSize.asBlock().copy());
+
+//     //             var windowShouldClose = objc.foundation.stackBlockLiteral(WindowDelegateCallbacks.windowShouldClose, darwin, null, null);
+//     //             delegate.setBlock_windowShouldClose(windowShouldClose.asBlock().copy());
+//     //         }
+//     //     } else std.debug.panic("mach: window failed to initialize", .{});
+//     // }
+
+//     darwin.* = .{
+//         .allocator = core.allocator,
+//         .core = core,
+//         // .title = options.title,
+//         // .display_mode = options.display_mode,
+//         // .vsync_mode = .none,
+//         // .cursor_mode = .normal,
+//         // .cursor_shape = .arrow,
+//         // .border = options.border,
+//         // .headless = options.headless,
+//         // .refresh_rate = 60, // TODO: set to something meaningful
+//         // .size = options.size,
+//         // .surface_descriptor = surface_descriptor,
+//         .window = window_opt,
+//     };
+// }
+
+// pub fn deinit(darwin: *Darwin) void {
+//     if (darwin.window) |w| @as(*objc.foundation.ObjectProtocol, @ptrCast(w)).release();
+//     return;
+// }
+
+// pub fn update(darwin: *Darwin) !void {
+//     if (darwin.window) |window| window.update();
+// }
+
+// pub fn setTitle(darwin: *Darwin, title: [:0]const u8) void {
+//     if (darwin.window) |window| {
+//         var string = objc.app_kit.String.allocInit();
+//         defer string.release();
+//         string = string.initWithUTF8String(title.ptr);
+//         window.setTitle(string);
+//     }
+// }
+
+// pub fn setDisplayMode(_: *Darwin, _: DisplayMode) void {
+//     return;
+// }
+
+// pub fn setBorder(_: *Darwin, _: bool) void {
+//     return;
+// }
+
+// pub fn setHeadless(_: *Darwin, _: bool) void {
+//     return;
+// }
+
+// pub fn setVSync(_: *Darwin, _: VSyncMode) void {
+//     return;
+// }
+
+// pub fn setSize(darwin: *Darwin, window_id: mach.ObjectID, size: Size) void {
+//     _ = darwin; // autofix
+//     _ = window_id; // autofix
+//     _ = size; // autofix
+//     // if (darwin.core.windows.getAll(window_id)) |window| {
+
+//     // }
+// }
+
+// pub fn setCursorMode(_: *Darwin, _: CursorMode) void {
+//     return;
+// }
+
+// pub fn setCursorShape(_: *Darwin, _: CursorShape) void {
+//     return;
+// }
 
 const WindowDelegateCallbacks = struct {
-    pub fn windowWillResize_toSize(block: *objc.foundation.BlockLiteral(*Darwin), size: objc.app_kit.Size) callconv(.C) void {
-        const darwin: *Darwin = block.context;
+    pub fn windowWillResize_toSize(block: *objc.foundation.BlockLiteral(*Core), size: objc.app_kit.Size) callconv(.C) void {
+        const core: *Core = block.context;
+        _ = core; // autofix
         const s: Size = .{ .width = @intFromFloat(size.width), .height = @intFromFloat(size.height) };
+        _ = s; // autofix
 
-        // TODO: Eventually we need to be able to tie a window here with the window Objects in core, and treat the windows
-        // as a list, rather than a single main window
-        darwin.size = .{
-            .height = s.width,
-            .width = s.height,
-        };
-        darwin.core.swap_chain_update.set();
+        // // TODO: Eventually we need to be able to tie a window here with the window Objects in core, and treat the windows
+        // // as a list, rather than a single main window
+        // core.size = .{
+        //     .height = s.width,
+        //     .width = s.height,
+        // };
+        // core.swap_chain_update.set();
 
-        darwin.core.windows.setRaw(darwin.core.main_window, .width, s.width);
-        darwin.core.windows.setRaw(darwin.core.main_window, .height, s.height);
+        // darwin.core.windows.setRaw(darwin.core.main_window, .width, s.width);
+        // darwin.core.windows.setRaw(darwin.core.main_window, .height, s.height);
 
-        darwin.core.pushEvent(.{ .framebuffer_resize = .{ .width = s.width, .height = s.height } });
+        // darwin.core.pushEvent(.{ .framebuffer_resize = .{ .width = s.width, .height = s.height } });
     }
 
-    pub fn windowShouldClose(block: *objc.foundation.BlockLiteral(*Darwin)) callconv(.C) bool {
-        const darwin: *Darwin = block.context;
-        darwin.core.pushEvent(.close);
+    pub fn windowShouldClose(block: *objc.foundation.BlockLiteral(*Core)) callconv(.C) bool {
+        const core: *Core = block.context;
+        core.pushEvent(.close);
         return false;
     }
 };
 
 const ViewCallbacks = struct {
-    pub fn keyDown(block: *objc.foundation.BlockLiteral(*Darwin), event: *objc.app_kit.Event) callconv(.C) void {
-        const darwin: *Darwin = block.context;
+    pub fn keyDown(block: *objc.foundation.BlockLiteral(*Core), event: *objc.app_kit.Event) callconv(.C) void {
+        const core: *Core = block.context;
         if (event.isARepeat()) {
-            darwin.core.pushEvent(.{ .key_repeat = .{
+            core.pushEvent(.{ .key_repeat = .{
                 .key = machKeyFromKeycode(event.keyCode()),
                 .mods = machModifierFromModifierFlag(event.modifierFlags()),
             } });
         } else {
-            darwin.core.pushEvent(.{ .key_press = .{
+            core.pushEvent(.{ .key_press = .{
                 .key = machKeyFromKeycode(event.keyCode()),
                 .mods = machModifierFromModifierFlag(event.modifierFlags()),
             } });
         }
     }
 
-    pub fn keyUp(block: *objc.foundation.BlockLiteral(*Darwin), event: *objc.app_kit.Event) callconv(.C) void {
-        const darwin: *Darwin = block.context;
+    pub fn keyUp(block: *objc.foundation.BlockLiteral(*Core), event: *objc.app_kit.Event) callconv(.C) void {
+        const core: *Core = block.context;
 
-        darwin.core.pushEvent(.{ .key_release = .{
+        core.pushEvent(.{ .key_release = .{
             .key = machKeyFromKeycode(event.keyCode()),
             .mods = machModifierFromModifierFlag(event.modifierFlags()),
         } });

--- a/src/core/Null.zig
+++ b/src/core/Null.zig
@@ -5,7 +5,7 @@ const std = @import("std");
 const mach = @import("../main.zig");
 const Core = @import("../Core.zig");
 const gpu = mach.gpu;
-const InitOptions = Core.InitOptions;
+//const InitOptions = Core.InitOptions;
 const Event = Core.Event;
 const KeyEvent = Core.KeyEvent;
 const MouseButtonEvent = Core.MouseButtonEvent;
@@ -40,10 +40,10 @@ surface_descriptor: gpu.Surface.Descriptor,
 pub fn init(
     nul: *Null,
     core: *Core,
-    options: InitOptions,
+    //options: InitOptions,
 ) !void {
     _ = nul;
-    _ = options;
+    //_ = options;
     _ = core;
     return;
 }

--- a/src/core/Windows.zig
+++ b/src/core/Windows.zig
@@ -21,6 +21,14 @@ const KeyMods = Core.KeyMods;
 const EventQueue = std.fifo.LinearFifo(Event, .Dynamic);
 const Win32 = @This();
 
+pub const Native = struct {
+    window: w.HWND,
+    surrogate: u16 = 0,
+    dinput: *w.IDirectInput8W,
+    saved_window_rect: w.RECT,
+    surface_descriptor_from_hwnd: gpu.Surface.DescriptorFromWindowsHWND,
+};
+
 // --------------------------
 // Module state
 // --------------------------
@@ -28,22 +36,22 @@ allocator: std.mem.Allocator,
 core: *Core,
 
 // Core platform interface
-surface_descriptor: gpu.Surface.Descriptor,
-display_mode: DisplayMode,
-vsync_mode: VSyncMode,
-cursor_mode: CursorMode,
-cursor_shape: CursorShape,
-border: bool,
-headless: bool,
-size: Size,
+// surface_descriptor: gpu.Surface.Descriptor,
+// display_mode: DisplayMode,
+// vsync_mode: VSyncMode,
+// cursor_mode: CursorMode,
+// cursor_shape: CursorShape,
+// border: bool,
+// headless: bool,
+// size: Size,
 
-// Internals
-window: w.HWND,
-refresh_rate: u32,
-surrogate: u16 = 0,
-dinput: *w.IDirectInput8W,
-saved_window_rect: w.RECT,
-surface_descriptor_from_hwnd: gpu.Surface.DescriptorFromWindowsHWND,
+// // Internals
+// window: w.HWND,
+// refresh_rate: u32,
+// surrogate: u16 = 0,
+// dinput: *w.IDirectInput8W,
+// saved_window_rect: w.RECT,
+// surface_descriptor_from_hwnd: gpu.Surface.DescriptorFromWindowsHWND,
 
 // ------------------------------
 // Platform interface

--- a/src/module.zig
+++ b/src/module.zig
@@ -68,7 +68,7 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
             /// Global pointer to object relations graph
             graph: *Graph,
 
-            /// A bitset per-field used to track field changes. Only used if options.track_fields == true.
+            /// A bitset used to track per-field changes. Only used if options.track_fields == true.
             updated: ?std.bit_set.DynamicBitSetUnmanaged = if (options.track_fields) .{} else null,
         },
 

--- a/src/module.zig
+++ b/src/module.zig
@@ -209,10 +209,10 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
         ///
         /// Unlike setAll(), this method does not respect any mach.Objects tracking
         /// options, so changes made to an object through this method will not be tracked.
-        pub fn setAllRaw(objs: *@This(), id: ObjectID, value: T) void {
+        pub fn setValueRaw(objs: *@This(), id: ObjectID, value: T) void {
             const data = &objs.internal.data;
 
-            const unpacked = objs.validateAndUnpack(id, "setAllRaw");
+            const unpacked = objs.validateAndUnpack(id, "setValueRaw");
             data.set(unpacked.index, value);
         }
 
@@ -220,10 +220,10 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
         ///
         /// Unlike setAllRaw, this method respects mach.Objects tracking
         /// and changes made to an object through this method will be tracked.
-        pub fn setAll(objs: *@This(), id: ObjectID, value: T) void {
+        pub fn setValue(objs: *@This(), id: ObjectID, value: T) void {
             const data = &objs.internal.data;
 
-            const unpacked = objs.validateAndUnpack(id, "setAll");
+            const unpacked = objs.validateAndUnpack(id, "setValue");
             data.set(unpacked.index, value);
 
             if (objs.internal.updated) |*updated_fields| {
@@ -267,7 +267,7 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
         }
 
         /// Get a single field.
-        pub fn get(objs: *@This(), id: ObjectID, comptime field_name: std.meta.FieldEnum(T)) ?std.meta.FieldType(T, field_name) {
+        pub fn get(objs: *@This(), id: ObjectID, comptime field_name: std.meta.FieldEnum(T)) std.meta.FieldType(T, field_name) {
             const data = &objs.internal.data;
 
             const unpacked = objs.validateAndUnpack(id, "get");
@@ -276,10 +276,10 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
         }
 
         /// Get all fields.
-        pub fn getAll(objs: *@This(), id: ObjectID) ?T {
+        pub fn getValue(objs: *@This(), id: ObjectID) T {
             const data = &objs.internal.data;
 
-            const unpacked = objs.validateAndUnpack(id, "getAll");
+            const unpacked = objs.validateAndUnpack(id, "getValue");
             return data.get(unpacked.index);
         }
 

--- a/src/module.zig
+++ b/src/module.zig
@@ -85,7 +85,7 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
 
         pub const Slice = struct {
             index: Index,
-            objs: *Objects(T),
+            objs: *Objects(options, T),
 
             /// Same as Objects(T).set but doesn't employ safety checks
             pub fn set(objs: *@This(), id: ObjectID, value: T) void {
@@ -127,6 +127,7 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
                     defer iter.index += 1;
 
                     if (!dead.isSet(iter.index)) return @bitCast(PackedID{
+                        .type_id = iter.objs.internal.type_id,
                         .generation = generation.items[iter.index],
                         .index = iter.index,
                     });


### PR DESCRIPTION
This PR is stacked on top of #1308, so review that one first.

At the moment, this PR breaks a lot and only triangle example on macOS is building. The effort here is to move more of Core to use the object system, first of these efforts is to treat windows as a list of objects so all window-dependent fields have been moved to `core.windows` and `Platform.tick` just checks for field changes and responds accordingly.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.