### PR TITLE
linux: setup with new object system

### DIFF
--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -56,7 +56,7 @@ backend: Backend,
 // these arrays are used as info messages to the user that some features are missing
 // please keep these up to date until we can remove them
 const MISSING_FEATURES_X11 = [_][]const u8{ "Resizing window", "Changing display mode", "VSync", "Setting window border/cursor" };
-const MISSING_FEATURES_WAYLAND = [_][]const u8{ "Changing display mode", "VSync", "Setting window border/cursor" };
+const MISSING_FEATURES_WAYLAND = [_][]const u8{ "Resizing window", "Changing display mode", "VSync", "Setting window border/cursor" };
 
 pub fn tick(core: *Core) !void {
     var windows = core.windows.slice();

--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -97,7 +97,8 @@ pub fn initWindow(
     // Try to initialize the desired backend, falling back to the other if that one is not supported
     switch (desired_backend) {
         .x11 => {
-            return;
+            log.err("\nX11 needs to be setup to work with the new object system, so it is not working at the moment. Using Wayland.\n", .{});
+            try Wayland.initWindow(core, window_id);
             // X11.initWindow(core, window_id) catch |err| {
             //     const err_msg = switch (err) {
             //         error.LibraryNotFound => "Missing X11 library",
@@ -116,7 +117,9 @@ pub fn initWindow(
                     error.FailedToConnectToDisplay => "Failed to connect to Wayland display",
                     else => "An unknown error occured while trying to connect to Wayland",
                 };
-                log.err("{s}\n\nFalling back to X11\n", .{err_msg});
+                log.err("{s}\n\nCannot connect to Wayland. X11 is unavailable as a fallback while it is being reconfigured to work with the new object system. Failing...\n", .{err_msg});
+                return error.X11NotImplemented;
+                // log.err("{s}\n\nFalling back to X11\n", .{err_msg});
                 // try X11.initWindow(core, window_id);
             };
         },

--- a/src/core/linux/Wayland.zig
+++ b/src/core/linux/Wayland.zig
@@ -243,7 +243,7 @@ pub fn tick(window_id: mach.ObjectID) !void {
     _ = libwaylandclient.wl_display_roundtrip(wl.display);
 }
 
-pub fn setTitle(wl: *Wayland, title: [:0]const u8) void {
+pub fn setTitle(wl: *const Native, title: [:0]const u8) void {
     c.xdg_toplevel_set_title(wl.toplevel, title);
 }
 

--- a/src/core/linux/Wayland.zig
+++ b/src/core/linux/Wayland.zig
@@ -140,6 +140,9 @@ pub fn initWindow(
     // Setup surface
     wl.surface = c.wl_compositor_create_surface(wl.interfaces.wl_compositor) orelse return error.UnableToCreateSurface;
     wl.surface_descriptor = .{ .display = wl.display, .surface = wl.surface };
+    core_window.surface_descriptor = .{ .next_in_chain = .{
+        .from_wayland_surface = &wl.surface_descriptor,
+    } };
 
     // Setup opaque region
     {
@@ -203,6 +206,7 @@ pub fn initWindow(
     _ = libwaylandclient.wl_display_roundtrip(wl.display);
 
     core.windows.setValue(window_id, core_window);
+    try core.initWindow(window_id);
 }
 
 // pub fn deinit(


### PR DESCRIPTION
* Setup Wayland to use new mach object system

    * In listeners, such as `wl_registry_add_listener`, rather than sharing a pointer to an instance of `Linux` with the Wayland server, pass the mach object system window id.
    * Store a pointer to `Core` in the global scope of `Wayland` so that listeners can use the provided window id and pointer to `Core` to lookup the data for that window, modify it, and save it directly in the handler function. See `registryHandleGlobal()` [definition](https://github.com/hexops/mach/pull/1319/files#diff-1275ab21c249f178087e859f98791a64c2b4aedc3c0c4ac7686da18b258b529dL329) for an example.
    * Handle some errors that were previously unhandled
    * Handle getting and setting the state of windows when needed. Previously a step that wasn't done because we only had 1 state to manage, now we have 2: state in the local scope, and state in the mach object system (`core.windows`)
* Setup X11 to use new mach object system
    * Store native state in new `Native` struct
    * Store a pointer to `Core` in the global scope. I think this can be avoided. Not sure if it's a good idea for X11
* Setup logs to appropriately explain the current status of the X11 implementation, which is not functional

Both X11 and Wayland work at runtime

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.