### PR TITLE
use multiarraylist more optimally in mach.Objects

### DIFF
--- a/src/module.zig
+++ b/src/module.zig
@@ -226,10 +226,7 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
             const data = &objs.internal.data;
             const unpacked = objs.validateAndUnpack(id, "setRaw");
 
-            var current = data.get(unpacked.index);
-            @field(current, @tagName(field_name)) = value;
-
-            data.set(unpacked.index, current);
+            data.items(field_name)[unpacked.index] = value;
         }
 
         /// Sets a single field of the given object to the given value.
@@ -240,10 +237,7 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
             const data = &objs.internal.data;
             const unpacked = objs.validateAndUnpack(id, "set");
 
-            var current = data.get(unpacked.index);
-            @field(current, @tagName(field_name)) = value;
-
-            data.set(unpacked.index, current);
+            data.items(field_name)[unpacked.index] = value;
 
             if (options.track_fields)
                 if (std.meta.fieldIndex(T, @tagName(field_name))) |field_index|
@@ -256,8 +250,7 @@ pub fn Objects(options: ObjectsOptions, comptime T: type) type {
             const data = &objs.internal.data;
 
             const unpacked = objs.validateAndUnpack(id, "get");
-            const d = data.get(unpacked.index);
-            return @field(d, @tagName(field_name));
+            return data.items(field_name)[unpacked.index];
         }
 
         /// Get all fields.


### PR DESCRIPTION
found a ~10% speedup in the sprites example. the `get` and `set` methods on `MultiArrayList` should probably be avoided more often than not as it requires accessing each field which somewhat defeats the purpose
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.