### PR TITLE
Fix for vulkan sysgpu backend when only some attachments are cleared

### DIFF
--- a/src/sysgpu/vulkan.zig
+++ b/src/sysgpu/vulkan.zig
@@ -3181,18 +3181,16 @@ pub const RenderPassEncoder = struct {
                     } else null,
                 });
 
-                if (attach.load_op == .clear) {
-                    try clear_values.append(.{
-                        .color = .{
-                            .float_32 = [4]f32{
-                                @floatCast(attach.clear_value.r),
-                                @floatCast(attach.clear_value.g),
-                                @floatCast(attach.clear_value.b),
-                                @floatCast(attach.clear_value.a),
-                            },
+                try clear_values.append(.{
+                    .color = .{
+                        .float_32 = [4]f32{
+                            @floatCast(attach.clear_value.r),
+                            @floatCast(attach.clear_value.g),
+                            @floatCast(attach.clear_value.b),
+                            @floatCast(attach.clear_value.a),
                         },
-                    });
-                }
+                    },
+                });
 
                 extent = view.extent;
             }
@@ -3216,14 +3214,12 @@ pub const RenderPassEncoder = struct {
                 .read_only = attach.depth_read_only == .true or attach.stencil_read_only == .true,
             };
 
-            if (attach.depth_load_op == .clear or attach.stencil_load_op == .clear) {
-                try clear_values.append(.{
-                    .depth_stencil = .{
-                        .depth = attach.depth_clear_value,
-                        .stencil = attach.stencil_clear_value,
-                    },
-                });
-            }
+            try clear_values.append(.{
+                .depth_stencil = .{
+                    .depth = attach.depth_clear_value,
+                    .stencil = attach.stencil_clear_value,
+                },
+            });
 
             extent = view.extent;
         }


### PR DESCRIPTION
Fix for issue I ran into when I tried to "load" a color attachment, but "clear" the depth attachment. I got a validation error saying that all buffers must be represented in p_clear_values/clear_value_count so the driver can just jump to find the matching attachment.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.