### PR TITLE
Various fixes for hexadecimal numbers in shaders

### DIFF
--- a/src/sysgpu/shader/AstGen.zig
+++ b/src/sysgpu/shader/AstGen.zig
@@ -1393,9 +1393,9 @@ fn genNumber(astgen: *AstGen, node: NodeIndex) !InstIndex {
 
     var i: usize = 0;
     var suffix: u8 = 0;
-    var base: u8 = 10;
-    var exponent = false;
-    var dot = false;
+    var is_hex: bool = false;
+    var has_exponent = false;
+    var has_dot = false;
 
     if (bytes.len >= 2 and bytes[0] == '0') switch (bytes[1]) {
         '0'...'9' => {
@@ -1404,39 +1404,60 @@ fn genNumber(astgen: *AstGen, node: NodeIndex) !InstIndex {
         },
         'x', 'X' => {
             i = 2;
-            base = 16;
+            is_hex = true;
         },
         else => {},
     };
 
-    while (i < bytes.len) : (i += 1) {
+    while (i < (bytes.len - 1)) : (i += 1) {
         const c = bytes[i];
         switch (c) {
-            'f', 'h' => suffix = c,
-            'i', 'u' => {
-                if (dot or suffix == 'f' or suffix == 'h' or exponent) {
-                    try astgen.errors.add(node_loc, "suffix '{c}' on float literal", .{c}, null);
-                    return error.AnalysisFail;
+            'e', 'E' => {
+                if (is_hex) {
+                    continue;
                 }
-
-                suffix = c;
-            },
-            'e', 'E', 'p', 'P' => {
-                if (exponent) {
+                if (has_exponent) {
                     try astgen.errors.add(node_loc, "duplicate exponent '{c}'", .{c}, null);
                     return error.AnalysisFail;
                 }
-
-                exponent = true;
+                has_exponent = true;
             },
-            '.' => dot = true,
+            'p', 'P' => {
+                if (!is_hex) {
+                    try astgen.errors.add(node_loc, "hexadecimal exponent '{c}' in decimal float", .{c}, null);
+                    return error.AnalysisFail;
+                }
+                // TODO
+                try astgen.errors.add(node_loc, "hexadecimal float literals not implemented", .{}, null);
+                return error.AnalysisFail;
+            },
+            '.' => has_dot = true,
             else => {},
         }
     }
 
+    switch (bytes[bytes.len - 1]) {
+        'i', 'u' => |c| {
+            if (has_dot or has_exponent) {
+                try astgen.errors.add(node_loc, "int suffix '{c}' on float literal", .{c}, null);
+                return error.AnalysisFail;
+            } else {
+                suffix = c;
+            }
+        },
+        'h' => |c| suffix = c,
+        'f' => |c| {
+            if (!is_hex or has_dot or has_exponent) {
+                suffix = c;
+            }
+            // else is part of a hex literal
+        },
+        else => {},
+    }
+
     var inst: Inst = undefined;
-    if (dot or exponent or suffix == 'f' or suffix == 'h') {
-        if (base == 16) {
+    if (has_dot or has_exponent or suffix == 'f' or suffix == 'h') {
+        if (is_hex) {
             // TODO
             try astgen.errors.add(node_loc, "hexadecimal float literals not implemented", .{}, null);
             return error.AnalysisFail;

--- a/src/sysgpu/shader/Tokenizer.zig
+++ b/src/sysgpu/shader/Tokenizer.zig
@@ -165,7 +165,7 @@ pub fn peek(tokenizer: *Tokenizer) Token {
                 result.tag = .number;
                 switch (c) {
                     '0'...'9' => {},
-                    'a'...'d', 'A'...'D' => if (!number.is_hex) break,
+                    'a'...'d', 'A'...'D', 'F' => if (!number.is_hex) break,
                     'x', 'X' => number.is_hex = true,
                     '.' => {
                         if (number.has_dot) break;


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

Fixes the issues described in #1340:
* `F` inside a hexadecimal number classified as identifier
* `f` inside a hexadecimal number causes "float literals not implemented" error
* `e/E` inside a hexadecimal number cause either "float literals not implemented" or "duplicate exponent" error

Also adds/changes some error messages:
* Adds "hexadecimal exponent in decimal float" when finding `p/P` outside a number starting with `0x`
* Clarifies "suffix '{c}' on float literal" --> "int suffix '{c}' on float literal"

The implementation seems a bit heavy-handed and I'm not 100% sure to have caught all edge cases despite testing, so I'm open for any feedback and changes.