### PR TITLE
start work on implementing libdecor for csd

### DIFF
--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -136,7 +136,7 @@ pub fn initWindow(
         .wayland => {
             Wayland.initWindow(core, window_id) catch |err| {
                 const err_msg = switch (err) {
-                    error.NoServerSideDecorationSupport => "Server Side Decorations aren't supported",
+                    error.NoDecorationSupport => "No window decoration support available",
                     error.LibraryNotFound => "Missing Wayland library",
                     error.FailedToConnectToDisplay => "Failed to connect to Wayland display",
                     else => "An unknown error occured while trying to connect to Wayland",


### PR DESCRIPTION
- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

This PR introduces libdecor to the wayland backend to help render client side decorations. See this issue for more context: https://github.com/hexops/mach/issues/1298

This is a screenshot of the core-triangle example running with client side decorations,
![image](https://github.com/user-attachments/assets/197f9c73-519c-47e6-b59d-3f4548ab6e00)

I'm testing on nixos with gnome mutter which does not support server side decorations, from the logs, the error: 

```
error(mach): Server Side Decorations aren't supported

Falling back to X11
```
No longer shows!

This PR is a bit incomplete however, things like resizing are still wonky:
[Screencast From 2025-02-18 11-45-01.webm](https://github.com/user-attachments/assets/d16cf78a-e0d5-45df-b0b2-e37bc521aa43)


**Other things I'm not sure about**
- libdecor has a couple of plugins implemented for rendering decorations for different backends, it appears these are packaged with the library but I'm not sure if I need to dynamically load them for cross compilation or if there should be a way to select which plugin is used.
- Need to test server side rendering to make sure I didn't break that functionality 
- Introduced an issue where a keyboard press causes a crash in `libxkbcommon`'s interface


This is also my first PR to mach so additional feedback / guidance is appreciated :)
Feel free to push changes to the fork as well!
