### PR TITLE
Core: Add ability to have separate render thread accessed through `window.on_tick`, which is called each display refresh.

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -24,9 +24,8 @@
         },
         .mach_objc = .{
             //.path = "../mach-objc-dev",
-            .url = "https://github.com/foxnne/mach-objc/archive/4a704d093d4215ba72e34dd2fcba91025bdcd797.tar.gz",
-            .hash = "1220e2edade45c87f896ab2dc5ef3ddcbe60a4b50a2e143b5f98bf4371fd7315d138",
-            //.hash = "12203675829014e69be2ea7c126ecf25d403009d336b7ca5f6e7c4ccede826c8e597",
+            .url = "https://github.com/foxnne/mach-objc/archive/60022b32ae8d1f90bf425f84242d7c7c2f93ed6d.tar.gz",
+            .hash = "1220326e869daa634901c57442c01254b8c84039ebeb0ffc053382e76436bb177619",
             .lazy = true,
         },
         .xcode_frameworks = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = "mach",
     .version = "0.4.0",
+    .mach_zig_version = "2024.11.0-mach",
     .paths = .{
         "src",
         "build.zig",
@@ -22,8 +23,10 @@
             .lazy = true,
         },
         .mach_objc = .{
-            .url = "https://pkg.machengine.org/mach-objc/79b6f80c32b14948554958afe72dace261b14afc.tar.gz",
-            .hash = "12203675829014e69be2ea7c126ecf25d403009d336b7ca5f6e7c4ccede826c8e597",
+            //.path = "../mach-objc-dev",
+            .url = "https://github.com/foxnne/mach-objc/archive/4a704d093d4215ba72e34dd2fcba91025bdcd797.tar.gz",
+            .hash = "1220e2edade45c87f896ab2dc5ef3ddcbe60a4b50a2e143b5f98bf4371fd7315d138",
+            //.hash = "12203675829014e69be2ea7c126ecf25d403009d336b7ca5f6e7c4ccede826c8e597",
             .lazy = true,
         },
         .xcode_frameworks = .{

--- a/src/core/Darwin.zig
+++ b/src/core/Darwin.zig
@@ -220,7 +220,7 @@ fn initWindow(
         // for rendering based on whether or not we have an on_tick function ID.
         // Then set the layer to our metal layer.
         var view = objc.mach.View.allocInit();
-        view = view.initWithFrame_withThread(rect, core_window.on_tick != null);
+        view = view.initWithFrame_withRenderLoop(rect, core_window.on_tick != null);
         view.setLayer(@ptrCast(layer));
         defer native_window.setContentView(@ptrCast(view));
 

--- a/src/core/Darwin.zig
+++ b/src/core/Darwin.zig
@@ -429,9 +429,11 @@ const ViewCallbacks = struct {
         const core_mod = block.context.core_mod;
         const window_id = block.context.window_id;
 
-        const window = core.windows.getValue(window_id);
+        var window = core.windows.getValue(window_id);
+        defer core.windows.setValueRaw(window_id, window);
 
         if (window.on_tick) |function_id| {
+            window.frame.tick();
             core_mod.run(function_id);
         }
     }

--- a/src/core/Linux.zig
+++ b/src/core/Linux.zig
@@ -62,7 +62,7 @@ pub fn run(comptime on_each_update_fn: anytype, args_tuple: std.meta.ArgsTuple(@
     while (@call(.auto, on_each_update_fn, args_tuple) catch false) {}
 }
 
-pub fn tick(core: *Core) !void {
+pub fn tick(core: *Core, _: mach.Mod(Core)) !void {
     var windows = core.windows.slice();
     while (windows.next()) |window_id| {
         const native_opt: ?Native = core.windows.get(window_id, .native);

--- a/src/core/Windows.zig
+++ b/src/core/Windows.zig
@@ -38,7 +38,7 @@ pub fn run(comptime on_each_update_fn: anytype, args_tuple: std.meta.ArgsTuple(@
     while (@call(.auto, on_each_update_fn, args_tuple) catch false) {}
 }
 
-pub fn tick(core: *Core) !void {
+pub fn tick(core: *Core, _: mach.Mod(Core)) !void {
     {
         var windows = core.windows.slice();
         while (windows.next()) |window_id| {

--- a/src/graph.zig
+++ b/src/graph.zig
@@ -210,7 +210,7 @@ pub const Graph = struct {
         while (!graph.should_stop.load(.acquire)) {
             // Process the entire queue
             while (graph.queue.pop()) |op| graph.processOp(allocator, op);
-            std.Thread.yield() catch {};
+            std.Thread.sleep(std.time.ns_per_s);
         }
     }
 

--- a/src/sysgpu/metal.zig
+++ b/src/sysgpu/metal.zig
@@ -443,8 +443,9 @@ pub const SwapChain = struct {
         layer.setPixelFormat(conv.metalPixelFormat(desc.format));
         layer.setFramebufferOnly(!(desc.usage.storage_binding or desc.usage.render_attachment));
         layer.setDrawableSize(size);
-        layer.setMaximumDrawableCount(if (desc.present_mode == .mailbox) 3 else 2);
-        layer.setDisplaySyncEnabled(desc.present_mode != .immediate);
+        layer.setMaximumDrawableCount(2);
+        //layer.setDisplaySyncEnabled(desc.present_mode != .immediate);
+        layer.setDisplaySyncEnabled(true);
 
         const swapchain = try allocator.create(SwapChain);
         swapchain.* = .{ .device = device, .surface = surface };
@@ -483,14 +484,8 @@ pub const SwapChain = struct {
             const command_buffer: *mtl.CommandBuffer = queue.command_queue.commandBuffer() orelse {
                 return error.NewCommandBufferFailed;
             };
-
-            if (swapchain.surface.layer.displaySyncEnabled()) {
-                command_buffer.commit();
-                drawable.present();
-            } else {
-                command_buffer.presentDrawable(@ptrCast(drawable));
-                command_buffer.commit();
-            }
+            command_buffer.presentDrawable(@ptrCast(drawable));
+            command_buffer.commit();
         }
     }
 };


### PR DESCRIPTION
This PR depends on [this PR](https://github.com/hexops/mach-objc/pull/36) which will need to be merged before we can update the zon here. 

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.