### PR TITLE
Fix Shared VecN comparison operators

### DIFF
--- a/src/math/vec.zig
+++ b/src/math/vec.zig
@@ -322,23 +322,23 @@ pub fn VecShared(comptime Scalar: type, comptime VecN: type) type {
         }
 
         /// Element-wise a < b
-        pub inline fn less(a: *const VecN, b: Scalar) bool {
-            return a.v < b.v;
+        pub inline fn less(a: *const VecN, b: *const VecN) bool {
+            return @reduce(.And, a.v < b.v);
         }
 
         /// Element-wise a <= b
-        pub inline fn lessEq(a: *const VecN, b: Scalar) bool {
-            return a.v <= b.v;
+        pub inline fn lessEq(a: *const VecN, b: *const VecN) bool {
+            return @reduce(.And, a.v <= b.v);
         }
 
         /// Element-wise a > b
-        pub inline fn greater(a: *const VecN, b: Scalar) bool {
-            return a.v > b.v;
+        pub inline fn greater(a: *const VecN, b: *const VecN) bool {
+            return @reduce(.And, a.v > b.v);
         }
 
         /// Element-wise a >= b
-        pub inline fn greaterEq(a: *const VecN, b: Scalar) bool {
-            return a.v >= b.v;
+        pub inline fn greaterEq(a: *const VecN, b: *const VecN) bool {
+            return @reduce(.And, a.v >= b.v);
         }
 
         /// Returns a vector with all components set to the `scalar` value:


### PR DESCRIPTION
These seem like useful functions that I could use. Imagine my surprise when they didn't work! This PR should fix that.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.