### PR TITLE
Implement wgsl atomic functions

### DIFF
--- a/src/sysgpu/shader/Air.zig
+++ b/src/sysgpu/shader/Air.zig
@@ -430,6 +430,10 @@ pub const Inst = union(enum) {
     binary_intrinsic: BinaryIntrinsic,
     triple_intrinsic: TripleIntrinsic,
 
+    atomic_load: AtomicLoad,
+    atomic_store: AtomicStore,
+    atomic_binary_intrinsic: AtomicBinaryIntrinsic,
+
     block: RefIndex,
     loop: InstIndex,
     continuing: InstIndex,
@@ -756,9 +760,9 @@ pub const Inst = union(enum) {
     };
 
     pub const Unary = struct {
+        op: Op,
         result_type: InstIndex,
         expr: InstIndex,
-        op: Op,
 
         pub const Op = enum {
             not,
@@ -770,13 +774,14 @@ pub const Inst = union(enum) {
 
     pub const NilIntrinsic = enum {
         storage_barrier,
+        texture_barrier,
         workgroup_barrier,
     };
 
     pub const UnaryIntrinsic = struct {
+        op: Op,
         result_type: InstIndex,
         expr: InstIndex,
-        op: Op,
 
         pub const Op = enum {
             all,
@@ -894,6 +899,53 @@ pub const Inst = union(enum) {
             smoothstep,
             clamp,
             mix,
+        };
+    };
+
+    pub const AtomicLoad = struct {
+        result_type: InstIndex,
+        scope: Scope,
+        expr: InstIndex,
+
+        pub const Scope = enum {
+            device,
+            workgroup,
+        };
+    };
+
+    pub const AtomicStore = struct {
+        result_type: InstIndex,
+        scope: Scope,
+        lhs: InstIndex,
+        rhs: InstIndex,
+
+        pub const Scope = enum {
+            device,
+            workgroup,
+        };
+    };
+
+    pub const AtomicBinaryIntrinsic = struct {
+        op: Op,
+        result_type: InstIndex,
+        scope: Scope,
+        lhs: InstIndex,
+        rhs: InstIndex,
+
+        pub const Op = enum {
+            add,
+            sub,
+            max,
+            min,
+            @"and",
+            @"or",
+            xor,
+            exchange,
+        };
+
+        pub const Scope = enum {
+            device,
+            workgroup,
         };
     };
 

--- a/src/sysgpu/shader/codegen/hlsl.zig
+++ b/src/sysgpu/shader/codegen/hlsl.zig
@@ -817,6 +817,7 @@ fn emitNilIntrinsic(hlsl: *Hlsl, op: Inst.NilIntrinsic) !void {
     try hlsl.writeAll(switch (op) {
         .storage_barrier => "DeviceMemoryBarrierWithGroupSync()",
         .workgroup_barrier => "GroupMemoryBarrierWithGroupSync()",
+        else => std.debug.panic("TODO: implement Nil Intrinsic {s}", .{@tagName(op)}),
     });
 }
 

--- a/src/sysgpu/shader/codegen/msl.zig
+++ b/src/sysgpu/shader/codegen/msl.zig
@@ -775,6 +775,7 @@ fn emitNilIntrinsic(msl: *Msl, op: Inst.NilIntrinsic) !void {
     try msl.writeAll(switch (op) {
         .storage_barrier => "threadgroup_barrier(mem_flags::mem_device)",
         .workgroup_barrier => "threadgroup_barrier(mem_flags::mem_threadgroup)",
+        else => std.debug.panic("TODO: implement Nil Intrinsic {s}", .{@tagName(op)}),
     });
 }
 


### PR DESCRIPTION
Atomic functions now work in spirv

TODO: implement atomic functions in msl, hsl, and glsl backends.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.