### PR TITLE
Providing a shell.nix file for more conveniently fetching the compatible Zig version

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,45 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  zigVersion = builtins.replaceStrings ["\n"] [""] (builtins.readFile ./.zigversion);
+
+  # Determine platform-specific details
+  platform = if pkgs.stdenv.isDarwin then "macos" else "linux";
+  arch = if pkgs.stdenv.isAarch64 then "aarch64" else "x86_64";
+
+  # URL for the Zig binary
+  zigUrl = "https://pkg.machengine.org/zig/zig-${platform}-${arch}-${zigVersion}.tar.xz";
+
+  zigSrc = pkgs.fetchurl {
+    url = zigUrl;
+    hash = "sha256-/vTDPMiyya8cr0ffmHhsa8BJ3XDsbAXHlKMnOyk3gBs=";
+  };
+
+  zigVersionCompatibleWithMach = pkgs.stdenv.mkDerivation {
+    pname = "zig";
+    version = zigVersion;
+
+    src = zigSrc;
+
+    dontBuild = true;
+    dontConfigure = true;
+
+    installPhase = ''
+        mkdir -p $out/bin
+        cp -r ./* $out/
+        chmod +x $out/zig
+        ln -s $out/zig $out/bin/zig
+    '';
+  };
+
+in pkgs.mkShell {
+  buildInputs = [
+    pkgs.git
+    zigVersionCompatibleWithMach
+  ];
+
+  shellHook = ''
+    echo "Zig ${zigVersion} loaded"
+    zig version
+  '';
+}


### PR DESCRIPTION
When trying out the examples for this repo, I was unable to run them on my machine due to a version mismatch with the most up-to-date version of Zig (v0.15.1). 

In my opinion, it would be convenient to have a nice way to pull the correct version of Zig compatible with the repo for new users to have a more seamless experience when trying out the repo.

This is a ["shell.nix"](https://nix.dev/tutorials/first-steps/declarative-shell.html) file for the 0.4 tagged branch. It looks for the `.zigversion` file in the repo root and fetches the appropriate version of Zig and makes it available on the command line. You can enter the Nix shell by running `nix-shell` from the repo root as long as you have Nix installed. I like to install Nix using the convenient installer that you can find here from [Determinate Systems](https://docs.determinate.systems/determinate-nix/).

<img width="1496" height="929" alt="Screenshot 2025-10-05 at 5 32 47 PM" src="https://github.com/user-attachments/assets/1cbf3bf0-e021-4d06-96e4-bab36ff27dc3" />


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.